### PR TITLE
Add first version of a User Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A tool to review mismatches between Wikidata and External Databases
 
+## User Guide
+
+ * See the [User Guide](docs/UserGuide.md) for instructions on how to use Wikidata Mismatch Finder.
+
 ## Local Development
 
 * Follow [these instructions](docs/README.md#quickstart) to setup your local environment.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -4,8 +4,8 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Logging in](#login)
-- [Obtaining an API token](#apiToken)
 - [Accessing the API](#apiAccess)
+- [Obtaining an API token](#apiToken)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -13,10 +13,27 @@
 
 You can log in to the Mismatch Finder website using your MediaWiki account on `www.wikidata.org`. Simply click the Login button on the Welcome page and get redirected to Wikidata, to allow Mismatch Finder access to your account as a "Connected Application". If you are not logged in already, Wikidata will ask you for the username and passwort of your MediaWiki account.
 
-## Obtaining an API token <a id="apiToken"></a>
-
-Once you have logged in and have started to use the Mismatch Finder web interface, you may want to get access to the REST API, as well. You will need a personalised token for that, which you must provide in the `Authorization:` header of your API requests. Open the "API Token" tab to create a token. Mismatch finder will generate the secret token for you and display it only once after creation, so make sure to write it down in a safe place or copy-paste it into your password management tool.
-
 ## Accessing the API <a id="apiAccess"></a>
 
-To access the API, include your personalised API token as `Bearer <token>` string in the `Authorization:` header field.
+Once you have logged in and have started to use the Mismatch Finder web interface, you may want to access the REST API as well. In order to perform some actions with the REST api, such as uploading files, you will need a [personal access token](#apiToken). 
+
+For each request that involves authorization, your personal token must be provided in the `Authorization` header of your request as such:
+
+```
+Authorization: Bearer <your-access-token>
+```
+
+**Note:** Don't forget to replace `<your-access-token>` in the example above with your actual personal access token.
+
+## Obtaining an API access token <a id="apiToken"></a>
+
+To obtain a personal access token, follow these steps:
+
+1. At the [application homepage](https://mismatch-finder.toolforge.org/), click the API token link, or go to: https://mismatch-finder.toolforge.org/auth/token
+2. If you do no have an access token already, you will be prompted to create a new token.
+3. **Important!** Write the created token down in a safe place, as it will not be displayed again.
+4. Once you have noted down the token you will be redirected back to the token management page.
+
+In any case you want to revoke an existing token, simply click the revoke link in the token management page. After the token is revoked, you will be able to create a fresh token by repeating the steps above.
+
+

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -1,5 +1,14 @@
 # Mismatch Finder User Guide
 
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Logging in <a id="login"></a>](#logging-in-a-idlogina)
+- [Obtaining an API token <a id="apiToken"></a>](#obtaining-an-api-token-a-idapitokena)
+- [Accessing the API <a id="apiAccess"></a>](#accessing-the-api-a-idapiaccessa)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 ## Logging in <a id="login"></a>
 
 You can log in to the Mismatch Finder website using your MediaWiki account on `www.wikidata.org`. Simply click the Login button on the Welcome page and get redirected to Wikidata, to allow Mismatch Finder access to your account as a "Connected Application". If you are not logged in already, Wikidata will ask you for the username and passwort of your MediaWiki account.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -1,0 +1,14 @@
+# Mismatch Finder User Guide
+
+## Logging in <a id="login"></a>
+
+You can log in to the Mismatch Finder website using your MediaWiki account on `www.wikidata.org`. Simply click the Login button on the Welcome page and get redirected to Wikidata, to allow Mismatch Finder access to your account as a "Connected Application". If you are not logged in already, Wikidata will ask you for the username and passwort of your MediaWiki account.
+
+## Obtaining an API token <a id="apiToken"></a>
+
+Once you have logged in and have started to use the Mismatch Finder web interface, you may want to get access to the REST API, as well. You will need a personalised token for that, which you must provide in the `Authorization:` header of your API requests. Open the "API Token" tab to create a token. Mismatch finder will generate the secret token for you and display it only once after creation, so make sure to write it down in a safe place or copy-paste it into your password management tool.
+
+## Accessing the API <a id="apiAccess"></a>
+
+To access the API, include your personalised API token as `Bearer <token>` string in the `Authorization:` header field.
+

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -3,9 +3,9 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-- [Logging in <a id="login"></a>](#logging-in-a-idlogina)
-- [Obtaining an API token <a id="apiToken"></a>](#obtaining-an-api-token-a-idapitokena)
-- [Accessing the API <a id="apiAccess"></a>](#accessing-the-api-a-idapiaccessa)
+- [Logging in](#login)
+- [Obtaining an API token](#apiToken)
+- [Accessing the API](#apiAccess)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -20,4 +20,3 @@ Once you have logged in and have started to use the Mismatch Finder web interfac
 ## Accessing the API <a id="apiAccess"></a>
 
 To access the API, include your personalised API token as `Bearer <token>` string in the `Authorization:` header field.
-


### PR DESCRIPTION
For now, this includes three sections about authentication and authorization. To be expanded.

Bug: [T286340](https://phabricator.wikimedia.org/T286340)