### PR TITLE
Copy uploaderlist to storage

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -43,3 +43,5 @@ jobs:
           cp -rv mismatch-finder-repo/ ~tools.mismatch-finder/
           become mismatch-finder take mismatch-finder-repo
           become mismatch-finder cp .env mismatch-finder-repo/
+          become mismatch-finder mkdir -p mismatch-finder-repo/storage/app/allowlist
+          become mismatch-finder cp uploaders.txt mismatch-finder-repo/storage/app/allowlist/


### PR DESCRIPTION
Add a step in the deploy workflow to avoid losing the uploaderslist everytime. 

Bug: T286024