### PR TITLE
Add ImportMeta

### DIFF
--- a/app/Http/Controllers/ImportController.php
+++ b/app/Http/Controllers/ImportController.php
@@ -56,10 +56,10 @@ class ImportController extends Controller
                 'string',
                 'max:' . config('imports.description.max_length')
             ],
-            'bestBefore' => [
+            'expires' => [
                 'nullable',
                 'date',
-                'after:' . config('imports.best_before.after')
+                'after:' . config('imports.expires.after')
             ]
         ]);
 
@@ -67,9 +67,11 @@ class ImportController extends Controller
         $filename = now()->format('Ymd_His') . '-mismatch-upload.' . $request->user()->mw_userid . '.csv';
         $request->file('mismatchFile')->storeAs('mismatch-files', $filename);
 
+        $expires = $request->expires ?? now()->add(6, 'months')->toDateString();
+
         $meta = ImportMeta::make([
             'description' => $request->description,
-            'best_before' => $request->bestBefore
+            'expires' => $expires
         ])->user()->associate($request->user());
 
         $meta->save();

--- a/app/Http/Controllers/ImportController.php
+++ b/app/Http/Controllers/ImportController.php
@@ -25,16 +25,6 @@ class ImportController extends Controller
     }
 
     /**
-     * Display a listing of the resource.
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function index()
-    {
-        //
-    }
-
-    /**
      * Store a newly created resource in storage.
      *
      * @param  \Illuminate\Http\Request  $request

--- a/app/Http/Controllers/ImportController.php
+++ b/app/Http/Controllers/ImportController.php
@@ -2,14 +2,30 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\UploadUser;
+use App\Models\ImportMeta;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Gate;
 
 class ImportController extends Controller
 {
-    public function upload(Request $request)
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
     {
         // TODO: Consider using a FormRequest class for auth and validation
         Gate::authorize('upload-import');
@@ -34,5 +50,16 @@ class ImportController extends Controller
             'filename' => $filename,
             'success' => 'true'
         ], 201);
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  \App\Models\ImportMeta  $importMeta
+     * @return \Illuminate\Http\Response
+     */
+    public function show(ImportMeta $importMeta)
+    {
+        //
     }
 }

--- a/app/Http/Controllers/ImportController.php
+++ b/app/Http/Controllers/ImportController.php
@@ -53,8 +53,11 @@ class ImportController extends Controller
             ]
         ]);
 
-        // TODO: Replace with strtr()
-        $filename = now()->format('Ymd_His') . '-mismatch-upload.' . $request->user()->mw_userid . '.csv';
+        $filename = strtr(config('imports.upload.filename_template'), [
+            ':datetime' => now()->format('Ymd_His'),
+            ':userid' => $request->user()->mw_userid
+        ]);
+
         $request->file('mismatchFile')->storeAs('mismatch-files', $filename);
 
         $expires = $request->expires ?? now()->add(6, 'months')->toDateString();

--- a/app/Http/Controllers/ImportController.php
+++ b/app/Http/Controllers/ImportController.php
@@ -63,6 +63,7 @@ class ImportController extends Controller
         $expires = $request->expires ?? now()->add(6, 'months')->toDateString();
 
         $meta = ImportMeta::make([
+            'filename' => $filename,
             'description' => $request->description,
             'expires' => $expires
         ])->user()->associate($request->user());

--- a/app/Http/Controllers/ImportController.php
+++ b/app/Http/Controllers/ImportController.php
@@ -9,6 +9,19 @@ use Illuminate\Support\Facades\Gate;
 
 class ImportController extends Controller
 {
+    /** @var string */
+    public const RESOURCE_NAME = 'imports';
+
+     /**
+     * Instantiate a new controller instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->middleware('auth:sanctum')->only('store');
+    }
+
     /**
      * Display a listing of the resource.
      *

--- a/app/Http/Controllers/ImportController.php
+++ b/app/Http/Controllers/ImportController.php
@@ -80,11 +80,10 @@ class ImportController extends Controller
     /**
      * Display the specified resource.
      *
-     * @param  \App\Models\ImportMeta  $importMeta
-     * @return \Illuminate\Http\Response
+     * @param  \App\Models\ImportMeta  $import
      */
-    public function show(ImportMeta $importMeta)
+    public function show(ImportMeta $import): JsonResource
     {
-        //
+        return new ImportMetaResource($import);
     }
 }

--- a/app/Http/Controllers/ImportController.php
+++ b/app/Http/Controllers/ImportController.php
@@ -49,11 +49,20 @@ class ImportController extends Controller
                 'file',
                 'max:' . config('filesystems.uploads.max_size'),
                 'mimes:csv,txt'
+            ],
+            'description' => [
+                'nullable',
+                'string',
+                'max:' . config('imports.description.max_length')
+            ],
+            'bestBefore' => [
+                'nullable',
+                'date',
+                'after:' . config('imports.best_before.after')
             ]
         ]);
 
-        $uploadName = $request->name;
-        $description = $request->description;
+        // TODO: Replace with strtr()
         $filename = now()->format('Ymd_His') . '-mismatch-upload.' . $request->user()->mw_userid . '.csv';
         $request->file('mismatchFile')->storeAs('mismatch-files', $filename);
 

--- a/app/Http/Resources/ImportMetaResource.php
+++ b/app/Http/Resources/ImportMetaResource.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ImportMetaResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'status' => $this->status,
+            'description' => $this->description,
+            'best_before' => $this->best_before,
+            'created' => $this->created_at,
+            'uploader' => new UserResource($this->user),
+    }
+}

--- a/app/Http/Resources/ImportMetaResource.php
+++ b/app/Http/Resources/ImportMetaResource.php
@@ -18,7 +18,7 @@ class ImportMetaResource extends JsonResource
             'id' => $this->id,
             'status' => $this->status,
             'description' => $this->description,
-            'best_before' => $this->best_before,
+            'expires' => $this->expires,
             'created' => $this->created_at,
             'uploader' => new UserResource($this->user),
             'links' => [

--- a/app/Http/Resources/ImportMetaResource.php
+++ b/app/Http/Resources/ImportMetaResource.php
@@ -21,5 +21,9 @@ class ImportMetaResource extends JsonResource
             'best_before' => $this->best_before,
             'created' => $this->created_at,
             'uploader' => new UserResource($this->user),
+            'links' => [
+                'self' => route('imports.show', $this)
+            ]
+        ];
     }
 }

--- a/app/Http/Resources/UserResource.php
+++ b/app/Http/Resources/UserResource.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class UserResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'username' => $this->username,
+            'mw_userid' => $this->mw_userid
+        ];
+    }
+}

--- a/app/Models/ImportMeta.php
+++ b/app/Models/ImportMeta.php
@@ -38,6 +38,6 @@ class ImportMeta extends Model
 
     public function user()
     {
-        return $this->belongsTo(User::class);
+        return $this->belongsTo(User::class)->withDefault();
     }
 }

--- a/app/Models/ImportMeta.php
+++ b/app/Models/ImportMeta.php
@@ -24,8 +24,16 @@ class ImportMeta extends Model
     protected $fillable = [
         'description',
         'status',
-        'expires'
+        'expires',
+        'filename'
     ];
+
+    /**
+     * The attributes that should be hidden for arrays.
+     *
+     * @var array
+     */
+    protected $hidden = ['filename'];
 
     /**
      * The model's default values for attributes.

--- a/app/Models/ImportMeta.php
+++ b/app/Models/ImportMeta.php
@@ -24,7 +24,7 @@ class ImportMeta extends Model
     protected $fillable = [
         'description',
         'status',
-        'best_before'
+        'expires'
     ];
 
     /**

--- a/app/Models/ImportMeta.php
+++ b/app/Models/ImportMeta.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ImportMeta extends Model
+{
+    use HasFactory;
+
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'import_meta';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'description',
+        'status',
+        'best_before'
+    ];
+
+    /**
+     * The model's default values for attributes.
+     *
+     * @var array
+     */
+    protected $attributes = [
+        'status' => 'pending'
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Http\Resources\Json\JsonResource;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -23,6 +24,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        JsonResource::withoutWrapping();
     }
 }

--- a/config/imports.php
+++ b/config/imports.php
@@ -10,7 +10,7 @@ return [
         'max_length' => env('IMPORTS_DESCRIPTION_MAX', 350)
     ],
 
-    'best_before' => [
-        'after' => env('IMPORTS_BEST_BEFORE_MIN', '+1 week')
+    'expires' => [
+        'after' => env('IMPORTS_BEST_BEFORE_MIN', '+1 day')
     ]
 ];

--- a/config/imports.php
+++ b/config/imports.php
@@ -6,6 +6,10 @@
  * Various configurations relating to imports
  */
 return [
+    'upload' => [
+        'filename_template' => ':datetime-mismatch-upload.:userid.csv'
+    ],
+
     'description' => [
         'max_length' => env('IMPORTS_DESCRIPTION_MAX', 350)
     ],

--- a/config/imports.php
+++ b/config/imports.php
@@ -1,0 +1,16 @@
+<?php
+
+
+
+/**
+ * Various configurations relating to imports
+ */
+return [
+    'description' => [
+        'max_length' => env('IMPORTS_DESCRIPTION_MAX', 350)
+    ],
+
+    'best_before' => [
+        'after' => env('IMPORTS_BEST_BEFORE_MIN', '+1 week')
+    ]
+];

--- a/database/factories/ImportMetaFactory.php
+++ b/database/factories/ImportMetaFactory.php
@@ -30,7 +30,7 @@ class ImportMetaFactory extends Factory
                 'failed',
                 'completed'
             ]),
-            'best_before' => $this->faker->optional(0.7)->date()
+            'expires' => $this->faker->dateTimeBetween('+1 day', '+6 months')
         ];
     }
 }

--- a/database/factories/ImportMetaFactory.php
+++ b/database/factories/ImportMetaFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ImportMeta;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use App\Models\User;
+use App\Models\UploadUser;
+
+class ImportMetaFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = ImportMeta::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'description' => $this->faker->optional(0.8)->realText(350),
+            'status' => $this->faker->randomElement([
+                'pending',
+                'failed',
+                'completed'
+            ]),
+            'best_before' => $this->faker->optional(0.7)->date()
+        ];
+    }
+}

--- a/database/factories/ImportMetaFactory.php
+++ b/database/factories/ImportMetaFactory.php
@@ -30,7 +30,8 @@ class ImportMetaFactory extends Factory
                 'failed',
                 'completed'
             ]),
-            'expires' => $this->faker->dateTimeBetween('+1 day', '+6 months')->format('Y-m-d')
+            'expires' => $this->faker->dateTimeBetween('+1 day', '+6 months')->format('Y-m-d'),
+            'filename' => 'test_file.csv'
         ];
     }
 }

--- a/database/factories/ImportMetaFactory.php
+++ b/database/factories/ImportMetaFactory.php
@@ -30,7 +30,7 @@ class ImportMetaFactory extends Factory
                 'failed',
                 'completed'
             ]),
-            'expires' => $this->faker->dateTimeBetween('+1 day', '+6 months')
+            'expires' => $this->faker->dateTimeBetween('+1 day', '+6 months')->format('Y-m-d')
         ];
     }
 }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -5,6 +5,7 @@ namespace Database\Factories;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
+use App\Models\UploadUser;
 
 class UserFactory extends Factory
 {
@@ -26,5 +27,26 @@ class UserFactory extends Factory
             'username' => $this->faker->userName(),
             'mw_userid' => $this->faker->randomNumber(8, true)
         ];
+    }
+
+
+    /**
+     * Indicate that the user is suspended.
+     *
+     * @return \Illuminate\Database\Eloquent\Factories\Factory
+     */
+    public function uploader(string $username = null)
+    {
+        $username = $username ?? $this->faker->userName() . ' (uploader)';
+
+        $uploader = UploadUser::factory()->create([
+            'username' => $username
+        ]);
+
+        return $this->state(function (array $attributes) use ($uploader) {
+            return [
+                'username' => $uploader->getAttribute('username'),
+            ];
+        });
     }
 }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -31,7 +31,7 @@ class UserFactory extends Factory
 
 
     /**
-     * Indicate that the user is suspended.
+     * Indicate that the user is an uploader.
      *
      * @return \Illuminate\Database\Eloquent\Factories\Factory
      */

--- a/database/migrations/2021_07_15_075858_create_import_meta_table.php
+++ b/database/migrations/2021_07_15_075858_create_import_meta_table.php
@@ -17,7 +17,7 @@ class CreateImportMetaTable extends Migration
             $table->id();
             $table->string('description', 1024)->nullable();
             $table->enum('status', ['pending', 'failed', 'completed']);
-            $table->date('best_before')->nullable();
+            $table->date('expires')->nullable();
             $table->foreignId('user_id')->constrained();
             $table->timestamps();
         });

--- a/database/migrations/2021_07_15_075858_create_import_meta_table.php
+++ b/database/migrations/2021_07_15_075858_create_import_meta_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateImportMetaTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('import_meta', function (Blueprint $table) {
+            $table->id();
+            $table->string('description', 1024)->nullable();
+            $table->enum('status', ['pending', 'failed', 'completed']);
+            $table->date('best_before')->nullable();
+            $table->foreignId('user_id')->constrained();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('import_meta');
+    }
+}

--- a/database/migrations/2021_07_15_075858_create_import_meta_table.php
+++ b/database/migrations/2021_07_15_075858_create_import_meta_table.php
@@ -15,6 +15,7 @@ class CreateImportMetaTable extends Migration
     {
         Schema::create('import_meta', function (Blueprint $table) {
             $table->id();
+            $table->string('filename');
             $table->string('description', 1024)->nullable();
             $table->enum('status', ['pending', 'failed', 'completed']);
             $table->date('expires')->nullable();

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,35 +13,10 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // Seed 5 users
-        $this->seedUsers(5);
-
-        // Seeds 1 uploader only once
-        $this->seedUploader();
-    }
-
-    private function seedUsers(int $amount): void
-    {
-        if ($amount < 1) {
-            return;
-        }
-
-        // Create random Users
-        User::factory($amount)->create();
-    }
-
-    private function seedUploader(): void
-    {
-        $test_username = 'test_user';
-
-        // Create 1 static user for testing with upload permissions
-        User::firstOrCreate([
-            'username' => $test_username,
-            'mw_userid' => 12345678
-        ]);
-
-        UploadUser::firstOrCreate([
-            'username' => $test_username
+        $this->call([
+            UserSeeder::class,
+            UploadUserSeeder::class,
+            ImportMetaSeeder::class
         ]);
     }
 }

--- a/database/seeders/ImportMetaSeeder.php
+++ b/database/seeders/ImportMetaSeeder.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\ImportMeta;
+use App\Models\User;
+
+class ImportMetaSeeder extends Seeder
+{
+    /**
+     * Create imports
+     *
+     * @return void
+     */
+    public function run()
+    {
+        // 10 Imports belong to current uploaders
+        ImportMeta::factory(10)
+            ->for(User::factory()->uploader())
+            ->create();
+
+        // 3 Imports belong to non uploaders
+        ImportMeta::factory(3)
+            ->forUser()
+            ->create();
+    }
+}

--- a/database/seeders/UploadUserSeeder.php
+++ b/database/seeders/UploadUserSeeder.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\User;
+use App\Models\UploadUser;
+
+class UploadUserSeeder extends Seeder
+{
+    public const TEST_USER = 'Test Uploader';
+
+    /**
+     * Creates an upload user ONCE
+     *
+     * @return void
+     */
+    public function run()
+    {
+        User::factory()
+            ->uploader(self::TEST_USER)
+            ->create();
+    }
+}

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\User;
+
+class UserSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        User::factory(5)->create();
+    }
+}

--- a/docs/mismatchfinder-api-spec.yml
+++ b/docs/mismatchfinder-api-spec.yml
@@ -204,7 +204,7 @@ components:
             - pending
             - failed
             - completed
-        best_before:
+        expires:
           type: string
           format: date
         created:

--- a/docs/mismatchfinder-api-spec.yml
+++ b/docs/mismatchfinder-api-spec.yml
@@ -167,6 +167,13 @@ components:
                   required: [ code, message ]
 
   schemas:
+    User:
+      properties:
+        username:
+          type: string
+        mw_userid:
+          type: string
+
     Mismatch:
       properties:
         statementGuid:
@@ -189,16 +196,23 @@ components:
 
     ImportMeta:
       properties:
-        name:
-          type: string
-        uploader:
-          type: string
-        date:
-          type: string
         description:
           type: string
         status:
           type: string
+          enum:
+            - pending
+            - failed
+            - completed
+        best_before:
+          type: string
+          format: date
+        created:
+          type: string
+          format: date
+        uploader:
+          type: object
+          $ref: '#/components/schemas/User'
 
     ListOfImportMeta:
       properties:

--- a/docs/mismatchfinder-api-spec.yml
+++ b/docs/mismatchfinder-api-spec.yml
@@ -68,24 +68,23 @@ paths:
             schema:
               type: object
               properties:
-                name:
-                  type: string
-                file:
+                mismatchFile:
                   type: string
                   format: binary
                 description:
                   type: string
-              required: [ name, file ]
+                  maxLength: 350
+                bestBefore:
+                  type: string
+                  format: date
+              required: [ mismatchFile ]
       responses:
         '201':
           description: Upload successful, import resource created.
           content:
             application/json:
               schema:
-                properties:
-                  importURI:
-                    type: string
-                    description: URI of the newly created import resource.
+                $ref: '#/components/schemas/ImportMeta'
         '400':
           $ref: '#/components/responses/ClientError'
         '422':
@@ -151,7 +150,7 @@ components:
                   items:
                     type: string
                 example:
-                    name: [ "string" ]
+                    attribute_name: [ "string" ]
 
     UnexpectedError:
         description: An unexpected error has occurred
@@ -198,6 +197,7 @@ components:
       properties:
         description:
           type: string
+          maxLength: 350
         status:
           type: string
           enum:

--- a/routes/api.php
+++ b/routes/api.php
@@ -19,5 +19,5 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
 
-Route::resource(ImportController::RESOURCE_NAME, ImportController::class)
+Route::apiResource(ImportController::RESOURCE_NAME, ImportController::class)
     ->only(['store']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,4 +20,4 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 });
 
 Route::apiResource(ImportController::RESOURCE_NAME, ImportController::class)
-    ->only(['store']);
+    ->only(['store', 'show']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -19,5 +19,5 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
 
-Route::middleware('auth:sanctum')->post('/import', [ImportController::class, 'upload'])
-    ->name('upload');
+Route::resource(ImportController::RESOURCE_NAME, ImportController::class)
+    ->only(['store']);

--- a/tests/Feature/ApiRouteTest.php
+++ b/tests/Feature/ApiRouteTest.php
@@ -88,7 +88,16 @@ class ApiRouteTest extends TestCase
         $filename = now()->format('Ymd_His') . '-mismatch-upload.' . $user->getAttribute('mw_userid') . '.csv';
 
         $response = $this->makePostImportApiRequest(['mismatchFile' => $file]);
-        $response->assertStatus(201);
+        $response->assertStatus(201)
+            ->assertJsonStructure([
+                'id',
+                'description',
+                'best_before',
+                'created',
+                'uploader' => [
+                    'username'
+                ]
+            ]);
 
         Storage::disk('local')->assertExists('mismatch-files/' . $filename);
 

--- a/tests/Feature/ApiRouteTest.php
+++ b/tests/Feature/ApiRouteTest.php
@@ -12,10 +12,14 @@ use Illuminate\Database\Eloquent\Model;
 use App\Models\UploadUser;
 use Illuminate\Http\Testing\File;
 use Illuminate\Testing\TestResponse;
+use App\Http\Controllers\ImportController;
 
 class ApiRouteTest extends TestCase
 {
     use RefreshDatabase;
+
+    private const USER_ROUTE = 'api/user';
+    private const IMPORTS_ROUTE = 'api/' . ImportController::RESOURCE_NAME;
 
     /**
      * @var Model|null
@@ -29,7 +33,7 @@ class ApiRouteTest extends TestCase
      */
     public function test_non_authenticated_api_user_will_redirect()
     {
-        $response = $this->get('/api/user');
+        $response = $this->get(self::USER_ROUTE);
         $response->assertStatus(302);
     }
 
@@ -44,7 +48,7 @@ class ApiRouteTest extends TestCase
 
         Sanctum::actingAs($user);
 
-        $response = $this->get('/api/user');
+        $response = $this->get(self::USER_ROUTE);
         $response->assertStatus(200)
             ->assertJsonStructure([
                 'username',
@@ -62,7 +66,7 @@ class ApiRouteTest extends TestCase
      */
     public function test_get_import_wrong_method()
     {
-        $response = $this->get('/api/import');
+        $response = $this->get(self::IMPORTS_ROUTE);
         $response->assertStatus(405);
     }
 
@@ -192,6 +196,6 @@ class ApiRouteTest extends TestCase
     {
         return $this->withHeaders([
             'Accept' => 'application/json'
-        ])->post('/api/import', $payload);
+        ])->post(self::IMPORTS_ROUTE, $payload);
     }
 }

--- a/tests/Feature/ApiRouteTest.php
+++ b/tests/Feature/ApiRouteTest.php
@@ -231,7 +231,7 @@ class ApiRouteTest extends TestCase
         $response
             ->assertJsonValidationErrors([
                 'expires' => __('validation.after', [
-                    'attribute' => 'best before',
+                    'attribute' => 'expires',
                     'date' => config('imports.expires.after')
                 ])
             ]);

--- a/tests/Feature/ApiRouteTest.php
+++ b/tests/Feature/ApiRouteTest.php
@@ -90,7 +90,7 @@ class ApiRouteTest extends TestCase
             ->assertJsonStructure([
                 'id',
                 'description',
-                'best_before',
+                'expires',
                 'created',
                 'uploader' => ['username']
             ]);
@@ -225,14 +225,14 @@ class ApiRouteTest extends TestCase
         Sanctum::actingAs($user);
 
         $response = $this->postJson(self::IMPORTS_ROUTE, [
-            'bestBefore' => '1986-05-04'
+            'expires' => '1986-05-04'
         ]);
 
         $response
             ->assertJsonValidationErrors([
-                'bestBefore' => __('validation.after', [
+                'expires' => __('validation.after', [
                     'attribute' => 'best before',
-                    'date' => config('imports.best_before.after')
+                    'date' => config('imports.expires.after')
                 ])
             ]);
     }
@@ -254,7 +254,7 @@ class ApiRouteTest extends TestCase
             ->assertJson([
                 'id' => $import->id,
                 'status' => $import->status,
-                'best_before' => $import->best_before,
+                'expires' => $import->expires,
                 'created' => $import->created_at->toJSON(),
                 'uploader' => [
                     'username' => $import->user->username

--- a/tests/Feature/ApiRouteTest.php
+++ b/tests/Feature/ApiRouteTest.php
@@ -83,7 +83,10 @@ class ApiRouteTest extends TestCase
         Sanctum::actingAs($user);
 
         $this->travelTo(now()); // freezes time to ensure correct filenames
-        $filename = now()->format('Ymd_His') . '-mismatch-upload.' . $user->getAttribute('mw_userid') . '.csv';
+        $filename = strtr(config('imports.upload.filename_template'), [
+            ':datetime' => now()->format('Ymd_His'),
+            ':userid' => $user->getAttribute('mw_userid')
+        ]);
 
         $response = $this->postJson(self::IMPORTS_ROUTE, ['mismatchFile' => $file]);
         $response->assertCreated()

--- a/tests/Feature/ApiRouteTest.php
+++ b/tests/Feature/ApiRouteTest.php
@@ -98,6 +98,9 @@ class ApiRouteTest extends TestCase
                 'uploader' => ['username']
             ]);
 
+        $this->assertDatabaseHas('import_meta', [
+            'filename' => $filename
+        ]);
         Storage::disk('local')->assertExists('mismatch-files/' . $filename);
 
         $this->travelBack(); // resumes the clock

--- a/tests/Feature/ApiRouteTest.php
+++ b/tests/Feature/ApiRouteTest.php
@@ -18,6 +18,11 @@ class ApiRouteTest extends TestCase
     use RefreshDatabase;
 
     /**
+     * @var Model|null
+     */
+    private $fakeUploader = null;
+
+    /**
      * Test non authenticated api/user route
      *
      *  @return void
@@ -68,9 +73,7 @@ class ApiRouteTest extends TestCase
      */
     public function test_post_import_upload_file()
     {
-
-
-        $user = $this->createFakeUploader();
+        $user = $this->getFakeUploader();
         $file = UploadedFile::fake()->create('mismatchFile.csv');
 
         Storage::fake('local');
@@ -113,7 +116,7 @@ class ApiRouteTest extends TestCase
     {
         $maxSize = config('filesystems.uploads.max_size');
         $sizeInKilobytes = $maxSize + 10;
-        $user = $this->createFakeUploader();
+        $user = $this->getFakeUploader();
         $file = UploadedFile::fake()->create('mismatchFile.csv', $sizeInKilobytes);
 
         Storage::fake('local');
@@ -138,7 +141,7 @@ class ApiRouteTest extends TestCase
      */
     public function test_import_wrong_file_format()
     {
-        $user = $this->createFakeUploader();
+        $user = $this->getFakeUploader();
         $file = UploadedFile::fake()->create('mismatchFile.xls');
 
         Storage::fake('local');
@@ -163,7 +166,7 @@ class ApiRouteTest extends TestCase
      */
     public function test_import_missing_file()
     {
-        $user = $this->createFakeUploader();
+        $user = $this->getFakeUploader();
 
         Sanctum::actingAs($user);
 
@@ -176,14 +179,13 @@ class ApiRouteTest extends TestCase
             ]);
     }
 
-    private function createFakeUploader(): Model
+    private function getFakeUploader(): Model
     {
-        $user = User::factory()->createOne();
-        UploadUser::factory()->createOne([
-            'username' => $user->getAttribute('username')
-        ]);
+        if (!$this->fakeUploader) {
+            $this->fakeUploader = User::factory()->uploader()->create();
+        }
 
-        return $user;
+        return $this->fakeUploader;
     }
 
     private function makePostImportApiRequest(array $payload = []): TestResponse


### PR DESCRIPTION
This PR adds the `ImportMeta` model and resource, to attach to upload responses. In addition, some changes were made to the database seeders, to ensure enough testing data is available for manual testing. Also, a route was added to be able to access information about a single `ImportMeta`. 

Bug: [T285299](https://phabricator.wikimedia.org/T285299) 