### PR TITLE
Create mismatch import job

### DIFF
--- a/app/Exceptions/ImportValidationException.php
+++ b/app/Exceptions/ImportValidationException.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+use App\Models\ImportMeta;
+use Throwable;
+
+class ImportValidationException extends Exception
+{
+
+    /**
+     * @var ImportMeta
+     */
+    private $import;
+
+    /**
+     * @var int
+     */
+    private $csvLine;
+
+    public function __construct(
+        ImportMeta $import,
+        int $line,
+        string $message = '',
+        int $code = 0,
+        Throwable $previous = null)
+    {
+        parent::__construct(__('validation.import.error', [
+            'line' => $line,
+            'message' => $message
+        ]), $code, $previous);
+
+        $this->import = $import;
+        $this->csvLine = $line;
+    }
+
+    /**
+     * Get the exception's context information.
+     */
+    public function context(): array
+    {
+        return [
+            'csv_line' => $this->csvLine,
+            'import_id' => $this->import->id,
+            'user_id' => $this->import->user->id
+        ];
+    }
+}

--- a/app/Http/Controllers/ImportController.php
+++ b/app/Http/Controllers/ImportController.php
@@ -9,6 +9,8 @@ use Illuminate\Support\Facades\Gate;
 use App\Http\Resources\ImportMetaResource;
 use Illuminate\Http\Resources\Json\JsonResource;
 use App\Jobs\ImportCSV;
+use Illuminate\Support\Facades\Bus;
+use App\Jobs\ValidateCSV;
 
 class ImportController extends Controller
 {
@@ -71,7 +73,10 @@ class ImportController extends Controller
 
         $meta->save();
 
-        ImportCSV::dispatch($meta);
+        Bus::chain([
+            new ValidateCSV($meta),
+            new ImportCSV($meta)
+        ])->dispatch();
 
         return new ImportMetaResource($meta);
     }

--- a/app/Http/Controllers/ImportController.php
+++ b/app/Http/Controllers/ImportController.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Gate;
 use App\Http\Resources\ImportMetaResource;
 use Illuminate\Http\Resources\Json\JsonResource;
+use App\Jobs\ImportCSV;
 
 class ImportController extends Controller
 {
@@ -69,6 +70,8 @@ class ImportController extends Controller
         ])->user()->associate($request->user());
 
         $meta->save();
+
+        ImportCSV::dispatch($meta);
 
         return new ImportMetaResource($meta);
     }

--- a/app/Jobs/ImportCSV.php
+++ b/app/Jobs/ImportCSV.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use App\Models\ImportMeta;
+use Illuminate\Support\LazyCollection;
+use Illuminate\Support\Facades\Storage;
+use App\Models\Mismatch;
+
+class ImportCSV implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Information about the current import.
+     *
+     * @var ImportMeta
+     */
+    protected $meta;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct(ImportMeta $meta)
+    {
+        $this->meta = $meta;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $filepath = storage_path('app/mismatch-files/' . $this->meta->filename);
+
+        LazyCollection::make(function () use ($filepath) {
+            $file = fopen($filepath, 'r');
+
+            while ($data = fgetcsv($file)){
+                yield $data;
+            }
+        })->skip(1)->map(function ($row){
+            if($row[1] == 'P21'){
+                return false;
+            }
+
+            $mismatch = Mismatch::make([
+                'statement_guid' => $row[0],
+                'property_id' => $row[1],
+                'wikidata_value' => $row[2],
+                'external_value' => $row[3],
+                'external_url'  => $row[4]
+            ]);
+
+            $mismatch->importMeta()->associate($this->meta);
+
+            $mismatch->save();
+        });
+
+        $this->meta->status = 'completed';
+
+        $this->meta->save();
+    }
+}

--- a/app/Jobs/ImportCSV.php
+++ b/app/Jobs/ImportCSV.php
@@ -11,6 +11,7 @@ use Illuminate\Queue\SerializesModels;
 use App\Models\ImportMeta;
 use Illuminate\Support\LazyCollection;
 use App\Models\Mismatch;
+use Illuminate\Support\Facades\Storage;
 
 class ImportCSV implements ShouldQueue
 {
@@ -40,7 +41,8 @@ class ImportCSV implements ShouldQueue
      */
     public function handle()
     {
-        $filepath = storage_path('app/mismatch-files/' . $this->meta->filename);
+        $filepath = Storage::disk('local')
+            ->path('mismatch-files/' . $this->meta->filename);
 
         LazyCollection::make(function () use ($filepath) {
             $file = fopen($filepath, 'r');

--- a/app/Jobs/ValidateCSV.php
+++ b/app/Jobs/ValidateCSV.php
@@ -10,9 +10,8 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use App\Models\ImportMeta;
 use Illuminate\Support\LazyCollection;
-use App\Models\Mismatch;
 
-class ImportCSV implements ShouldQueue
+class ValidateCSV implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
@@ -49,20 +48,6 @@ class ImportCSV implements ShouldQueue
                 yield $data;
             }
         })->skip(1)->each(function ($row) {
-            $mismatch = Mismatch::make([
-                'statement_guid' => $row[0],
-                'property_id' => $row[1],
-                'wikidata_value' => $row[2],
-                'external_value' => $row[3],
-                'external_url'  => $row[4]
-            ]);
-
-            $mismatch->importMeta()->associate($this->meta);
-
-            $mismatch->save();
         });
-
-        $this->meta->status = 'completed';
-        $this->meta->save();
     }
 }

--- a/app/Models/Mismatch.php
+++ b/app/Models/Mismatch.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Mismatch extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'statement_guid',
+        'property_id',
+        'wikidata_value',
+        'external_value',
+        'external_url'
+    ];
+
+    /**
+     * The model's default values for attributes.
+     *
+     * @var array
+     */
+    protected $attributes = [
+        'status' => 'pending'
+    ];
+
+    public function importMeta()
+    {
+        return $this->belongsTo(ImportMeta::class, 'import_id')->withDefault();
+    }
+}

--- a/config/imports.php
+++ b/config/imports.php
@@ -7,7 +7,8 @@
  */
 return [
     'upload' => [
-        'filename_template' => ':datetime-mismatch-upload.:userid.csv'
+        'filename_template' => ':datetime-mismatch-upload.:userid.csv',
+        'col_count' => 5
     ],
 
     'description' => [

--- a/config/mismatches.php
+++ b/config/mismatches.php
@@ -13,5 +13,12 @@ return [
             'both',
             'none'
         ]
+    ],
+
+    'validation' => [
+        'guid' => [
+            'max_length' => 100,
+            'format' => '/^Q\d+\$[0-9A-F]{8}\-[0-9A-F]{4}\-4[0-9A-F]{3}\-[89AB][0-9A-F]{3}\-[0-9A-F]{12}$/i'
+        ]
     ]
 ];

--- a/config/mismatches.php
+++ b/config/mismatches.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * Various configurations relating to mismatches
+ */
+return [
+    'statuses' => [
+        'default' => 'pending',
+        'available' => [
+            'pending',
+            'wikidata',
+            'external',
+            'both',
+            'none'
+        ]
+    ]
+];

--- a/database/factories/MismatchFactory.php
+++ b/database/factories/MismatchFactory.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Mismatch;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class MismatchFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Mismatch::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'statement_guid' => 'Q' . $this->faker->randomNumber() . '$' . $this->faker->uuid(),
+            'property_id' => 'P' . $this->faker->randomNumber(),
+            'wikidata_value' => $this->getRandomValue(),
+            'external_value'=> $this->getRandomValue(),
+            'external_url' => $this->faker->optional(0.6)->url()
+        ];
+    }
+
+    private function getRandomValue()
+    {
+        return $this->faker->randomElement([
+            $this->faker->date(),
+            $this->faker->randomFloat(),
+            $this->faker->randomNumber(),
+            $this->faker->words(
+                $this->faker->numberBetween(1, 15),
+                true
+            )
+        ]);
+    }
+}

--- a/database/migrations/2021_07_19_123858_create_mismatches_table.php
+++ b/database/migrations/2021_07_19_123858_create_mismatches_table.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use App\Models\ImportMeta;
+
+class CreateMismatchesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('mismatches', function (Blueprint $table) {
+            $table->id();
+            $table->string('statement_guid');
+            $table->string('property_id');
+            $table->binary('wikidata_value'); // Saving as BLOB to enable storing JSON seralizations
+            $table->text('external_value');
+            $table->string('external_url', 1024)->nullable();
+            $table->enum('status', [
+                'pending',
+                'wikidata',
+                'external',
+                'both',
+                'none'
+            ]);
+            $table->foreignId('import_id')->constrained('import_meta');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('mismatches');
+    }
+}

--- a/database/migrations/2021_07_19_154807_create_jobs_table.php
+++ b/database/migrations/2021_07_19_154807_create_jobs_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateJobsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('jobs', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('queue')->index();
+            $table->longText('payload');
+            $table->unsignedTinyInteger('attempts');
+            $table->unsignedInteger('reserved_at')->nullable();
+            $table->unsignedInteger('available_at');
+            $table->unsignedInteger('created_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('jobs');
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -16,7 +16,8 @@ class DatabaseSeeder extends Seeder
         $this->call([
             UserSeeder::class,
             UploadUserSeeder::class,
-            ImportMetaSeeder::class
+            ImportMetaSeeder::class,
+            MismatchSeeder::class
         ]);
     }
 }

--- a/database/seeders/MismatchSeeder.php
+++ b/database/seeders/MismatchSeeder.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\ImportMeta;
+use App\Models\Mismatch;
+use App\Models\User;
+
+class MismatchSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $import = ImportMeta::factory()
+            ->for(User::factory()->uploader())
+            ->create();
+
+        Mismatch::factory(42)
+            ->for($import)
+            ->create();
+    }
+}

--- a/docs/exampleMismatchFile.csv
+++ b/docs/exampleMismatchFile.csv
@@ -1,4 +1,3 @@
 statement guid,property id,wd value,ext value,ext link
 Q184746$7814880A-A6EF-40EC-885E-F46DD58C8DC5,P569,3 April 1934,some_date,from_some_URL
 Q184746$7200D1AD-E4E8-401B-8D57-8C823810F11F,P21,Q6581072,third_option,somewhere_on_the_internet
-

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -142,7 +142,7 @@ return [
 
     'import' => [
         'error' => 'CSV import validation error at line :line: :message',
-        'columns' => 'A mismatch csv import must include exactly :amount columns for each line'
+        'columns' => 'A mismatch csv import must include exactly :amount columns for each line',
     ],
     /*
     |--------------------------------------------------------------------------

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -140,6 +140,10 @@ return [
         ],
     ],
 
+    'import' => [
+        'error' => 'CSV import validation error at line :line: :message',
+        'columns' => 'A mismatch csv import must include exactly :amount columns for each line'
+    ],
     /*
     |--------------------------------------------------------------------------
     | Custom Validation Attributes

--- a/tests/Feature/ApiRouteTest.php
+++ b/tests/Feature/ApiRouteTest.php
@@ -112,7 +112,6 @@ class ApiRouteTest extends TestCase
             ImportCSV::class
         ]);
 
-
         $this->travelBack(); // resumes the clock
     }
 

--- a/tests/Feature/ApiRouteTest.php
+++ b/tests/Feature/ApiRouteTest.php
@@ -17,6 +17,9 @@ use Illuminate\Foundation\Testing\WithFaker;
 use App\Models\ImportMeta;
 use App\Http\Resources\ImportMetaResource;
 use Illuminate\Testing\Fluent\AssertableJson;
+use App\Jobs\ValidateCSV;
+use Illuminate\Support\Facades\Bus;
+use App\Jobs\ImportCSV;
 
 class ApiRouteTest extends TestCase
 {
@@ -79,6 +82,7 @@ class ApiRouteTest extends TestCase
         $user = User::factory()->uploader()->create();
         $file = UploadedFile::fake()->create('mismatchFile.csv');
 
+        Bus::fake();
         Storage::fake('local');
         Sanctum::actingAs($user);
 
@@ -101,7 +105,13 @@ class ApiRouteTest extends TestCase
         $this->assertDatabaseHas('import_meta', [
             'filename' => $filename
         ]);
+
         Storage::disk('local')->assertExists('mismatch-files/' . $filename);
+        Bus::assertChained([
+            ValidateCSV::class,
+            ImportCSV::class
+        ]);
+
 
         $this->travelBack(); // resumes the clock
     }

--- a/tests/Feature/ImportCSVTest.php
+++ b/tests/Feature/ImportCSVTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Http\File;
+use App\Models\ImportMeta;
+use App\Jobs\ImportCSV;
+use Illuminate\Support\Str;
+use App\Models\User;
+
+class ImportCSVTest extends TestCase
+{
+    use RefreshDatabase;
+    /**
+     * Ensure import persists mismatches to database
+     */
+    public function test_creates_mismatches(): void
+    {
+        $filename = 'creates-mismatches-test.csv';
+        $user = User::factory()->uploader()->create();
+        $import = ImportMeta::factory()->for($user)->create([
+            'filename' => $filename
+        ]);
+
+        Storage::fake('local');
+        $path = Storage::putFileAs(
+            'mismatch-files',
+            new File(__DIR__ . '/../file-fixtures/successful-import.csv'),
+            $filename
+        );
+
+        $lines = Str::of(Storage::get($path))->trim()->explode("\n");
+        $line = Str::of($lines->get(1))->explode(',')->all();
+        $keys = [
+            'statement_guid',
+            'property_id',
+            'wikidata_value',
+            'external_value',
+            'external_url'
+        ];
+
+        $expected = array_combine($keys, $line);
+
+        ImportCSV::dispatch($import);
+
+        $this->assertDatabaseCount('mismatches', $lines->count() - 1); // Except table headers
+        $this->assertDatabaseHas('mismatches', [
+            'import_id' => $import->id
+        ]);
+        $this->assertDatabaseHas('mismatches', $expected);
+    }
+}

--- a/tests/Feature/ValidateCSVTest.php
+++ b/tests/Feature/ValidateCSVTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\ImportMeta;
+use Illuminate\Support\Facades\Storage;
+use App\Jobs\ValidateCSV;
+use App\Exceptions\ImportValidationException;
+
+class ValidateCSVTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Ensure validation fails on lines with too few columns
+     */
+    public function test_fails_on_too_few_columns(): void
+    {
+        $colCount = config('imports.upload.col_count');
+
+        $import = $this->createMockImport(
+            'too-few-columns.csv',
+            str_repeat(',', $colCount - 2) // Emulate one column too few
+        );
+
+        $this->expectValidationException(__('validation.import.columns', [
+            'amount' => $colCount
+        ]));
+
+        ValidateCSV::dispatch($import);
+
+        $this->assertFailedImport($import);
+    }
+
+    /**
+     * Ensure validation fails on lines with too many columns
+     */
+    public function test_fails_on_too_many_columns(): void
+    {
+        $colCount = config('imports.upload.col_count');
+
+        $import = $this->createMockImport(
+            'too-many-columns.csv',
+            str_repeat(',', $colCount) // Emulate one column too many
+        );
+
+        $this->expectValidationException(__('validation.import.columns', [
+            'amount' => $colCount
+        ]));
+
+        ValidateCSV::dispatch($import);
+
+        $this->assertFailedImport($import);
+    }
+
+
+
+    private function createMockImport(string $filename, string $content): ImportMeta
+    {
+        Storage::fake('local');
+        Storage::put(
+            'mismatch-files/' . $filename,
+            "\n" . $content // Emulate empty header line
+        );
+
+        $user = User::factory()->uploader()->create();
+        return ImportMeta::factory()->for($user)->create([
+            'filename' => $filename
+        ]);
+    }
+
+    private function expectValidationException(string $message): void
+    {
+        $this->expectException(ImportValidationException::class);
+        $this->expectExceptionMessage($message);
+    }
+
+    private function assertFailedImport(ImportMeta $import): void
+    {
+        $this->assertDatabaseCount('failed_jobs', 1);
+        $this->assertDatabaseHas('import_meta',[
+            'id' => $import->id,
+            'status' => 'failed'
+        ]);
+    }
+}

--- a/tests/file-fixtures/successful-import.csv
+++ b/tests/file-fixtures/successful-import.csv
@@ -1,0 +1,3 @@
+statement guid,property id,wd value,ext value,ext link
+Q184746$7814880A-A6EF-40EC-885E-F46DD58C8DC5,P569,3 April 1934,1934-04-03,https://d-nb.info/gnd/119004453
+Q184746$7200D1AD-E4E8-401B-8D57-8C823810F11F,P21,Q6581072,nonbinary,https://www.imdb.com/name/nm0328762/


### PR DESCRIPTION
This PR introduces the `Mismatch` model, migration, factory and seeder. As well as [jobs](https://laravel.com/docs/8.x/queues) to validate a CSV file and import mismatches from a file and into our mismatches' database table.

Bug: [T285299](https://phabricator.wikimedia.org/T285299)