### PR TITLE
[Imports 5/7] Create mismatch CSV validation job

### DIFF
--- a/app/Exceptions/ImportValidationException.php
+++ b/app/Exceptions/ImportValidationException.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+use App\Models\ImportMeta;
+use Throwable;
+
+class ImportValidationException extends Exception
+{
+
+    /**
+     * @var ImportMeta
+     */
+    private $import;
+
+    /**
+     * @var int
+     */
+    private $csvLine;
+
+    public function __construct(
+        ImportMeta $import,
+        int $line,
+        string $message = '',
+        int $code = 0,
+        Throwable $previous = null
+    ) {
+        parent::__construct(__('validation.import.error', [
+            'line' => $line,
+            'message' => $message
+        ]), $code, $previous);
+
+        $this->import = $import;
+        $this->csvLine = $line;
+    }
+
+    /**
+     * Get the exception's context information.
+     */
+    public function context(): array
+    {
+        return [
+            'csv_line' => $this->csvLine,
+            'import_id' => $this->import->id,
+            'user_id' => $this->import->user->id
+        ];
+    }
+}

--- a/app/Jobs/ValidateCSV.php
+++ b/app/Jobs/ValidateCSV.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use App\Models\ImportMeta;
+use Illuminate\Support\LazyCollection;
+use App\Exceptions\ImportValidationException;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\Validator;
+use App\Rules\WikidataValue;
+use App\Services\CSVImportReader;
+use App\Exceptions\ImportParserException;
+use Throwable;
+
+class ValidateCSV implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Information about the current import.
+     *
+     * @var ImportMeta
+     */
+    protected $meta;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct(ImportMeta $meta)
+    {
+        $this->meta = $meta;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle(WikidataValue $valueValidator, CSVImportReader $reader)
+    {
+        try {
+            $filepath = Storage::disk('local')
+            ->path('mismatch-files/' . $this->meta->filename);
+
+            $reader->lines($filepath)
+                ->each(function ($mismatch, $i) use ($valueValidator) {
+                    $error = $this->checkFieldErrors($mismatch)
+                        ?? $this->checkValueErrors($mismatch, $valueValidator);
+
+                    if ($error) {
+                        throw new ImportValidationException($this->meta, $i, $error);
+                    }
+                });
+        } catch (Throwable $error) {
+            $this->meta->status = 'failed';
+            $this->meta->save();
+
+            throw $error;
+        }
+    }
+
+    private function checkFieldErrors($mismatch): ?string
+    {
+        $rules = config('mismatches.validation');
+
+        $validator = Validator::make($mismatch, [
+            'statement_guid' => [
+                'required',
+                'max:' . $rules['guid']['max_length'],
+                'regex:' . $rules['guid']['format']
+            ],
+            'property_id' => [
+                'required',
+                'max:' . $rules['pid']['max_length'],
+                'regex:' . $rules['pid']['format']
+            ],
+            'wikidata_value' => [
+                'required',
+                'max:' . $rules['wikidata_value']['max_length']
+            ],
+            'external_value' => [
+                'required',
+                'max:' . $rules['external_value']['max_length']
+            ],
+            'external_url' => [
+                'url',
+                'max:' . $rules['external_url']['max_length']
+            ]
+        ]);
+
+        if ($validator->stopOnFirstFailure()->fails()) {
+            return $validator->errors()->first();
+        }
+
+        return null;
+    }
+
+    private function checkValueErrors($mismatch, WikidataValue $valueRule): ?string
+    {
+        // We require a separate validator for wikidata value formatting,
+        // as it must be validated alongside the wikidata property id.
+        $validator = Validator::make([
+            'wikidata_value' => [
+                'property' => $mismatch['property_id'],
+                'value' => $mismatch['wikidata_value']
+            ]
+        ], [
+            'wikidata_value' => [$valueRule]
+        ]);
+
+        if ($validator->fails()) {
+            return $validator->errors()->first();
+        }
+
+        return null;
+    }
+}

--- a/config/mismatches.php
+++ b/config/mismatches.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Various configurations relating to mismatches
+ */
+return [
+    'validation' => [
+        'guid' => [
+            'max_length' => 100,
+            'format' => '/^Q\d+\$[0-9A-F]{8}\-[0-9A-F]{4}\-4[0-9A-F]{3}\-[89AB][0-9A-F]{3}\-[0-9A-F]{12}$/i'
+        ],
+        'pid' => [
+            'max_length' => 100,
+            'format' => '/^P\d+$/i'
+        ],
+        'wikidata_value' => [
+            'max_length' => 1500 // Longest allowed value on wikidata
+        ],
+        'external_value' => [
+            'max_length' => 1500 // Longest allowed value on wikidata
+        ],
+        'external_url' => [
+            'max_length' => 1500 // Longest allowed value on wikidata
+        ]
+    ]
+];

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -140,6 +140,10 @@ return [
         ],
     ],
 
+    'import' => [
+        'error' => 'CSV import validation error at line :line: :message',
+    ],
+
     'wikidata_value' => 'The :attribute could not be parsed for the given property id',
     /*
     |--------------------------------------------------------------------------

--- a/tests/Feature/ValidateCSVTest.php
+++ b/tests/Feature/ValidateCSVTest.php
@@ -24,6 +24,10 @@ class ValidateCSVTest extends TestCase
 {
     use RefreshDatabase, WithFaker;
 
+    // Since PHPUnit data providers are evaluated earlier than Laravel we
+    // cannot use Laravel specific helpers such as __() or config().
+    // Therefore, we provide a closure, to be called at the appropriate time.
+    // See: https://technicallyfletch.com/how-to-use-laravel-factories-inside-a-data-provider/
     public function invalidLineProvider(): iterable
     {
         yield 'missing statement guid' => [
@@ -199,7 +203,7 @@ class ValidateCSVTest extends TestCase
 
         [$line, $message] = $data($config, $this->faker);
 
-        // Emulate passed validation rule
+        // Emulate passed validation rule, as this is not the system under test
         $this->partialMock(WikidataValue::class, function (MockInterface $mock) {
             $mock->shouldReceive('passes')->andReturn(true);
         });

--- a/tests/Feature/ValidateCSVTest.php
+++ b/tests/Feature/ValidateCSVTest.php
@@ -1,0 +1,292 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\ImportMeta;
+use Illuminate\Support\Facades\Storage;
+use App\Jobs\ValidateCSV;
+use App\Exceptions\ImportValidationException;
+use Closure;
+use Faker\Generator;
+use Mockery\MockInterface;
+use App\Rules\WikidataValue;
+use Exception;
+use Throwable;
+use Illuminate\Support\Facades\Validator;
+use App\Services\CSVImportReader;
+use App\Exceptions\ImportParserException;
+
+class ValidateCSVTest extends TestCase
+{
+    use RefreshDatabase, WithFaker;
+
+    public function invalidLineProvider(): iterable
+    {
+        yield 'missing statement guid' => [
+            function (array $config): array {
+                return [
+                    ',P569,3 April 1934,1934-04-03,http://www.example.com', // Emulate missing guid
+                    __('validation.required', [
+                        'attribute' => 'statement guid'
+                    ])
+                ];
+            }
+        ];
+
+        yield 'long statement guid' => [
+            function (array $config, Generator $faker): array {
+                $longQID= $faker->numerify('Q' . str_repeat('#', $config['guid']['max_length']));
+
+                return [
+                    $longQID . '$' . $faker->uuid() . ',' // Emulate long guid
+                    . 'P569,3 April 1934,1934-04-03,http://www.example.com', // Ensure correct columns
+                    __('validation.max.string', [
+                        'attribute' => 'statement guid',
+                        'max' => $config['guid']['max_length']
+                    ])
+                ];
+            }
+        ];
+
+        yield 'malformed statement guid' => [
+            function (array $config): array {
+                return [
+                    'some-malformed-guid,' // Emulate malformed guid
+                    . 'P569,3 April 1934,1934-04-03,http://www.example.com', // Ensure correct columns
+                    __('validation.regex', [
+                        'attribute' => 'statement guid'
+                    ])
+                ];
+            }
+        ];
+
+        yield 'missing property id' => [
+            function (array $config): array {
+                return [
+                    'Q184746$7814880A-A6EF-40EC-885E-F46DD58C8DC5,,' // Emulate missing property id
+                    . '3 April 1934,1934-04-03,http://www.example.com', // Ensure correct columns
+                    __('validation.required', [
+                        'attribute' => 'property id'
+                    ])
+                ];
+            }
+        ];
+
+        yield 'long property id' => [
+            function (array $config, Generator $faker): array {
+                $longPID= $faker->numerify('P' . str_repeat('#', $config['pid']['max_length']));
+
+                return [
+                     'Q184746$7814880A-A6EF-40EC-885E-F46DD58C8DC5,' // Ensure correct columns
+                    . $longPID . ',' // Emulate long pid
+                    . '3 April 1934,1934-04-03,http://www.example.com', // Ensure correct columns
+                    __('validation.max.string', [
+                        'attribute' => 'property id',
+                        'max' => $config['pid']['max_length']
+                     ])
+                ];
+            }
+        ];
+
+        yield 'malformed property id' => [
+            function (array $config): array {
+                return [
+                    'Q184746$7814880A-A6EF-40EC-885E-F46DD58C8DC5,' // Ensure correct columns
+                    . 'some-malformed-pid,' // Emulate malformed pid
+                    . '3 April 1934,1934-04-03,http://www.example.com', // Ensure correct columns
+                    __('validation.regex', [
+                        'attribute' => 'property id'
+                    ])
+                ];
+            }
+        ];
+
+        yield 'missing wikidata value' => [
+            function (array $config): array {
+                return [
+                    'Q184746$7814880A-A6EF-40EC-885E-F46DD58C8DC5,P569' // Ensure correct columns
+                    . ',,1934-04-03,http://www.example.com', // Emulate missing wikidata value
+                    __('validation.required', [
+                        'attribute' => 'wikidata value'
+                    ])
+                ];
+            }
+        ];
+
+        yield 'long wikidata value' => [
+            function (array $config): array {
+                $longValue = str_repeat('a', $config['wikidata_value']['max_length'] + 10);
+
+                return [
+                    'Q184746$7814880A-A6EF-40EC-885E-F46DD58C8DC5,P569,' // Ensure correct columns
+                    . $longValue . ',1934-04-03,http://www.example.com', // Emulate long wikidata value
+                    __('validation.max.string', [
+                        'attribute' => 'wikidata value',
+                        'max' => $config['wikidata_value']['max_length']
+                     ])
+                ];
+            }
+        ];
+
+        yield 'missing external value' => [
+            function (array $config): array {
+                return [
+                    'Q184746$7814880A-A6EF-40EC-885E-F46DD58C8DC5,P569,3 April 1934' // Ensure correct columns
+                    . ',,http://www.example.com', // Emulate missing external data
+                    __('validation.required', [
+                        'attribute' => 'external value'
+                    ])
+                ];
+            }
+        ];
+
+        yield 'long external value' => [
+            function (array $config, Generator $faker): array {
+                $longValue= str_repeat('-', $config['external_value']['max_length'] + 10);
+
+                return [
+                    'Q184746$7814880A-A6EF-40EC-885E-F46DD58C8DC5,P569,3 April 1934,' // Ensure correct cols
+                    . $longValue . ',http://www.example.com', // Emulate long value
+                    __('validation.max.string', [
+                        'attribute' => 'external value',
+                        'max' => $config['external_value']['max_length']
+                    ])
+                ];
+            }
+        ];
+
+        yield 'long external url' => [
+            function (array $config, Generator $faker): array {
+                $longURL= $faker->url() . '/' . str_repeat('a', $config['external_url']['max_length']);
+
+                return [
+                    'Q184746$7814880A-A6EF-40EC-885E-F46DD58C8DC5,P569,3 April 1934,1934-04-03,' // Ensure correct cols
+                    . $longURL, // Emulate long url
+                    __('validation.max.string', [
+                        'attribute' => 'external url',
+                        'max' => $config['external_url']['max_length']
+                    ])
+                ];
+            }
+        ];
+
+        yield 'malformed external url' => [
+            function (array $config): array {
+                return [
+                    'Q184746$7814880A-A6EF-40EC-885E-F46DD58C8DC5,P569,3 April 1934,1934-04-03,' // Ensure correct cols
+                    . 'i-am-not-your-gurl',
+                    __('validation.url', [
+                        'attribute' => 'external url'
+                    ])
+                ];
+            }
+        ];
+    }
+
+    /**
+     * @dataProvider invalidLineProvider
+     */
+    public function test_throws_on_invalid_line(Closure $data): void
+    {
+        $config = array_merge(
+            config('imports.upload'),
+            config('mismatches.validation')
+        );
+
+        [$line, $message] = $data($config, $this->faker);
+
+        // Emulate passed validation rule
+        $this->partialMock(WikidataValue::class, function (MockInterface $mock) {
+            $mock->shouldReceive('passes')->andReturn(true);
+        });
+
+        $import = $this->createMockImport($line);
+
+        $this->expectValidationException($message);
+
+        ValidateCSV::dispatch($import);
+    }
+
+    public function test_throws_on_malformed_wikidata_value(): void
+    {
+        // Ensure correct columns
+        $line = 'Q184746$7814880A-A6EF-40EC-885E-F46DD58C8DC5,P569,invalid-wikidata-value,'
+                . '1934-04-03,http://www.example.com';
+        $message = __('validation.wikidata_value', [
+            'attribute' => 'wikidata value'
+        ]);
+
+        // Emulate failed validation rule
+        $this->partialMock(WikidataValue::class, function (MockInterface $mock) {
+            $mock->shouldReceive('passes')->andReturn(false);
+        });
+
+        $import = $this->createMockImport($line);
+
+        $this->expectValidationException($message);
+        ValidateCSV::dispatch($import);
+    }
+
+    public function failureProvider()
+    {
+        yield 'validator failure' => [
+            function () {
+                Validator::shouldReceive('make')->once()->andThrow(Exception::class);
+            }
+        ];
+
+        yield 'reader failure' => [
+            function ($instance) {
+                $instance->mock(CSVImportReader::class, function ($mock) {
+                    $mock->shouldReceive('lines')->once()->andThrow(new ImportParserException(0));
+                });
+            }
+        ];
+    }
+
+    /**
+     * @dataProvider failureProvider
+     */
+    public function test_fails_on_thrown_exceptions(Closure $failSetup): void
+    {
+        $failSetup($this);
+
+        // Ensure rows
+        $import = $this->createMockImport('some-guid,some-pid,some-value,another-value,a-url');
+
+        try {
+            ValidateCSV::dispatch($import);
+        } catch (Throwable $ignored) {
+            $this->assertDatabaseHas('import_meta', [
+                'id' => $import->id,
+                'status' => 'failed'
+            ]);
+        }
+    }
+
+    private function createMockImport(string $content): ImportMeta
+    {
+        $headers = join(',', config('imports.upload.column_keys'));
+
+        Storage::fake('local');
+        Storage::put(
+            'mismatch-files/invalid-import.csv',
+            $headers . "\n" . $content // Add header line
+        );
+
+        $user = User::factory()->uploader()->create();
+        return ImportMeta::factory()->for($user)->create([
+            'filename' => 'invalid-import.csv'
+        ]);
+    }
+
+    private function expectValidationException(string $message): void
+    {
+        $this->expectException(ImportValidationException::class);
+        $this->expectExceptionMessage($message);
+    }
+}


### PR DESCRIPTION
**Important!** This PR has been re-chained to enable easier review.
**5**/7 in the `feature/import-mismatches` chain. This depends on #39.

This PR introduces the first job class to our code: `ValidateCSV`. The job is aimed at validating mismatch data in a CSV file prior to opening up a DB transaction and committing any mismatches to storage. In case a validation (or parsing) error is encountered, the job will fail and stop immediately, by throwing an `ImportValidationException`.

Relevant Documentation:
- [Laravel Job Classes](https://laravel.com/docs/8.x/queues#creating-jobs) 

Bug: [T285299](https://phabricator.wikimedia.org/T285299)