### PR TITLE
[Imports 6/7] Create CSV import job

### DIFF
--- a/app/Jobs/ImportCSV.php
+++ b/app/Jobs/ImportCSV.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use App\Models\ImportMeta;
+use Illuminate\Support\LazyCollection;
+use App\Models\Mismatch;
+use Illuminate\Support\Facades\Storage;
+use App\Services\CSVImportReader;
+use Illuminate\Support\Facades\DB;
+use App\Exceptions\ImportParserException;
+use Exception;
+use Throwable;
+
+class ImportCSV implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Information about the current import.
+     *
+     * @var ImportMeta
+     */
+    protected $meta;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct(ImportMeta $meta)
+    {
+        $this->meta = $meta;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle(CSVImportReader $reader)
+    {
+        try {
+            $filepath = Storage::disk('local')
+                ->path('mismatch-files/' . $this->meta->filename);
+
+            DB::transaction(function () use ($reader, $filepath) {
+                $reader->lines($filepath)->each(function ($mismatchLine) {
+                    $mismatch = Mismatch::make($mismatchLine);
+                    $mismatch->importMeta()->associate($this->meta);
+                    $mismatch->save();
+                });
+
+                $this->meta->status = 'completed';
+                $this->meta->save();
+            });
+        } catch (Throwable $error) {
+            $this->meta->status = 'failed';
+            $this->meta->save();
+            throw $error;
+        }
+    }
+}

--- a/tests/Feature/ImportCSVTest.php
+++ b/tests/Feature/ImportCSVTest.php
@@ -77,7 +77,7 @@ class ImportCSVTest extends TestCase
         $lines = [
             ["Q184746$7814880A-A6EF-40EC-885E-F46DD58C8DC5","P569","3 April 1934"
             ,"1934-04-03","https://d-nb.info/gnd/119004453"],
-            ["Q184746$7200D1AD-E4E8-401B-8D57-8C823810F11F","P21","Q6581072","nonbinary"] // Ensure invalid second row
+            ["Q184746$7200D1AD-E4E8-401B-8D57-8C823810F11F","P21","Q6581072","nonbinary"] // Ensure short second row
         ];
 
         $content = join("\n", array_map(function (array $line) {

--- a/tests/Feature/ImportCSVTest.php
+++ b/tests/Feature/ImportCSVTest.php
@@ -63,7 +63,7 @@ class ImportCSVTest extends TestCase
     }
 
     /**
-     * Ensure import persists mismatches to database
+     * Ensure no change is commited to Database in case of error
      */
     public function test_rolls_back_on_failure(): void
     {

--- a/tests/Feature/ImportCSVTest.php
+++ b/tests/Feature/ImportCSVTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Http\File;
+use App\Models\ImportMeta;
+use App\Jobs\ImportCSV;
+use Illuminate\Support\Str;
+use App\Models\User;
+use App\Exceptions\ImportParserException;
+use Throwable;
+
+class ImportCSVTest extends TestCase
+{
+    use RefreshDatabase;
+    /**
+     * Ensure import persists mismatches to database
+     */
+    public function test_creates_mismatches(): void
+    {
+        $filename = 'creates-mismatches.csv';
+        $user = User::factory()->uploader()->create();
+        $import = ImportMeta::factory()->for($user)->create([
+            'filename' => $filename
+        ]);
+
+        $header = config('imports.upload.column_keys');
+        $lines = [
+            ["Q184746$7814880A-A6EF-40EC-885E-F46DD58C8DC5","P569","3 April 1934"
+            ,"1934-04-03","https://d-nb.info/gnd/119004453"],
+            ["Q184746$7200D1AD-E4E8-401B-8D57-8C823810F11F","P21","Q6581072"
+            ,"nonbinary","https://www.imdb.com/name/nm0328762/"]
+        ];
+
+        $content = join("\n", array_map(function (array $line) {
+            return join(',', $line);
+        }, array_merge([$header], $lines)));
+
+        Storage::fake('local');
+        Storage::put(
+            'mismatch-files/' . $filename,
+            $content
+        );
+
+        $expected = array_map(function ($row) use ($header) {
+            return array_combine($header, $row);
+        }, $lines);
+
+        ImportCSV::dispatch($import);
+
+        $this->assertDatabaseCount('mismatches', count($lines));
+        $this->assertDatabaseHas('mismatches', [
+            'import_id' => $import->id
+        ]);
+
+        foreach ($expected as $mismatch) {
+            $this->assertDatabaseHas('mismatches', $mismatch);
+        }
+    }
+
+    /**
+     * Ensure import persists mismatches to database
+     */
+    public function test_rolls_back_on_failure(): void
+    {
+        $filename = 'fails-gracefully.csv';
+        $user = User::factory()->uploader()->create();
+        $import = ImportMeta::factory()->for($user)->create([
+            'filename' => $filename
+        ]);
+
+        $header = config('imports.upload.column_keys');
+        $lines = [
+            ["Q184746$7814880A-A6EF-40EC-885E-F46DD58C8DC5","P569","3 April 1934"
+            ,"1934-04-03","https://d-nb.info/gnd/119004453"],
+            ["Q184746$7200D1AD-E4E8-401B-8D57-8C823810F11F","P21","Q6581072","nonbinary"] // Ensure invalid second row
+        ];
+
+        $content = join("\n", array_map(function (array $line) {
+            return join(',', $line);
+        }, array_merge([$header], $lines)));
+
+        Storage::fake('local');
+        Storage::put(
+            'mismatch-files/' . $filename,
+            $content
+        );
+
+        try {
+            ImportCSV::dispatch($import);
+        } catch (Throwable $ignored) {
+            $this->assertDatabaseHas('import_meta', [
+                'id' => $import->id,
+                'status' => 'failed'
+            ]);
+            $this->assertDatabaseCount('mismatches', 0);
+            $this->assertDatabaseMissing('mismatches', [
+                'import_id' => $import->id
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
**Important!** This PR has been re-chained to enable easier review.
**6**/7 in the `feature/import-mismatches` chain. This depends on #24.

In this change, we introduce the CSV import job. The job iterates over a mismatch CSV file and attempts to store each mismatch line into the database. This process is done within a database transaction, to ensure that if an error has occurred while attempting to save, the database will simply roll back to its previous state.

Relevant Documentation:
- [Laravel Database Transactions](https://laravel.com/docs/8.x/database#database-transactions)

Bug: [T285299](https://phabricator.wikimedia.org/T285299)