### PR TITLE
Create web view for list of Imports

### DIFF
--- a/app/Models/ImportMeta.php
+++ b/app/Models/ImportMeta.php
@@ -44,6 +44,8 @@ class ImportMeta extends Model
         'status' => 'pending'
     ];
 
+    protected $dates = ['expires'];
+
     public function user()
     {
         return $this->belongsTo(User::class)->withDefault();

--- a/resources/lang/en/import-status.php
+++ b/resources/lang/en/import-status.php
@@ -1,0 +1,23 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Import Status Lines
+    |--------------------------------------------------------------------------
+    |
+    |
+    */
+    'item:status' => 'Import Status',
+    'item:status.pending' => 'Pending',
+    'item:status.failed' => 'Failed',
+    'item:status.completed' => 'Confirmed',
+    'item:error' => 'Error',
+    'item:error-line' => 'Line number :line',
+    'item:uploader' => 'Uploader Name',
+    'item:description' => 'Short Description',
+    'item:upload_date' => 'Upload Date',
+    'item:expiring_date' => 'Expiring Date',
+    'date_format' => 'd-m-Y'
+];

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -121,3 +121,35 @@ nav.tabs {
         }
     }
 }
+
+dl.import-meta {
+    margin: 0 0 24px 0;
+    border-radius: 2px;
+    font-family: 'Lato', sans-serif;
+    padding: 16px;
+}
+
+dl.import-meta-pending {
+    border: 1px solid #c8ccd1;
+    background-color: #f8f9fa;
+}
+
+dl.import-meta-failed {
+    border: 1px solid #dd3333;
+    background-color: #fee7e6;
+}
+
+dl.import-meta-completed {
+    border: 1px solid #c8ccd1;
+    background-color: #ffffff;
+}
+
+dl.import-meta dt {
+    font-weight: bold;
+    padding-bottom: 8px;
+}
+
+dl.import-meta dd {
+    margin: 0;
+    padding-bottom: 16px;
+}

--- a/resources/views/components/layout.blade.php
+++ b/resources/views/components/layout.blade.php
@@ -21,7 +21,7 @@
     <nav class="tabs" aria-label="{{__('store-layout.aria-labels:tabs')}}">
         <ul>
             <li tabindex="0" {{ ( url()->current() == route('token') ) ? 'aria-current=page' : '' }} class="{{url()->current() == route('token') ? 'selected' : ''}}"><a tabindex="-1" href="{{ route('token') }}" >{{__('store-layout.tab:authentication-token')}}</a></li>
-            <li tabindex="0"><a tabindex="-1" href="#">{{__('store-layout.tab:import-status')}}</a></li>
+            <li tabindex="0" {{ ( url()->current() == route('import.status') ) ? 'aria-current=page' : '' }} class="{{url()->current() == route('import.status') ? 'selected' : ''}}"><a tabindex="-1"  href="{{ route('import.status') }}">{{__('store-layout.tab:import-status')}}</a></li>
         </ul>
     </nav>
     {{ $slot }}

--- a/resources/views/importStatus.blade.php
+++ b/resources/views/importStatus.blade.php
@@ -4,11 +4,6 @@
             <dt>{{ __('import-status.item:status') }}</dt>
             <dd>{{ __('import-status.item:status.' . $import->status) }}</dd>
 
-        @if($import->status == 'failed' )
-            <dt>{{ __('import-status.item:error') }}</dt>
-            <dd>{{ __('import-status.item:error-line', [ 'line' => $errorLine ] ) }}</dd>
-        @endif
-
             <dt>{{__('import-status.item:uploader')}}</dt>
             <dd>{{ $import->user->username }}</dd>
 

--- a/resources/views/importStatus.blade.php
+++ b/resources/views/importStatus.blade.php
@@ -1,0 +1,25 @@
+<x-layout>
+    @foreach ($imports as $import)
+        <dl class="import-meta import-meta-{{ $import->status }}">
+            <dt>{{ __('import-status.item:status') }}</dt>
+            <dd>{{ __('import-status.item:status.' . $import->status) }}</dd>
+
+        @if($import->status == 'failed' )
+            <dt>{{ __('import-status.item:error') }}</dt>
+            <dd>{{ __('import-status.item:error-line', [ 'line' => $errorLine ] ) }}</dd>
+        @endif
+
+            <dt>{{__('import-status.item:uploader')}}</dt>
+            <dd>{{ $import->user->username }}</dd>
+
+            <dt>{{__('import-status.item:description')}}</dt>
+            <dd>{{ $import->description }}</dd>
+
+            <dt>{{__('import-status.item:upload_date')}}</dt>
+            <dd>{{ $import->created_at->format(__('import-status.date_format')) }}</dd>
+
+            <dt>{{__('import-status.item:expiring_date')}}</dt>
+            <dd>{{ $import->expires->format(__('import-status.date_format')) }}</dd>
+        </dl>
+    @endforeach
+</x-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,5 +19,5 @@ Route::get('/', function () {
 });
 
 Route::get('/imports', function () {
-    return view('importStatus', [ 'imports' => ImportMeta::orderByDesc('id')->take(10)->get(), 'errorLine' => 42 ]);
+    return view('importStatus', [ 'imports' => ImportMeta::orderByDesc('id')->take(10)->get() ]);
 })->name('import.status');

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\ImportMeta;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -16,3 +17,7 @@ use Illuminate\Support\Facades\Route;
 Route::get('/', function () {
     return view('welcome');
 });
+
+Route::get('/imports', function () {
+    return view('importStatus', [ 'imports' => ImportMeta::orderByDesc('id')->take(10)->get(), 'errorLine' => 42 ]);
+})->name('import.status');

--- a/tests/Feature/ApiRouteTest.php
+++ b/tests/Feature/ApiRouteTest.php
@@ -260,7 +260,7 @@ class ApiRouteTest extends TestCase
             ->assertJson([
                 'id' => $import->id,
                 'status' => $import->status,
-                'expires' => $import->expires,
+                'expires' => $import->expires->toJSON(),
                 'created' => $import->created_at->toJSON(),
                 'uploader' => [
                     'username' => $import->user->username

--- a/tests/Feature/WebRouteTest.php
+++ b/tests/Feature/WebRouteTest.php
@@ -2,12 +2,14 @@
 
 namespace Tests\Feature;
 
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
 class WebRouteTest extends TestCase
 {
-    // phpcs:disable PSR1.Methods.CamelCapsMethodName.NotCamelCaps
-
+    use RefreshDatabase;
+    
     /**
      * Test the /auth/token route
      *
@@ -19,5 +21,18 @@ class WebRouteTest extends TestCase
 
         $response->assertStatus(200);
         $response->assertViewIs('welcome');
+    }
+
+    /**
+     * Test the /importStatus route
+     *
+     *  @return void
+     */
+    public function test_importStatus_route()
+    {
+        $response = $this->get('/imports');
+
+        $response->assertStatus(200);
+        $response->assertViewIs('importStatus');
     }
 }


### PR DESCRIPTION
This adds a web view for the 10 latest mismatch file imports. A Laravel
style cast of ImportMeta's 'expires' field is needed for proper date
formatting in the view. This also required a minor change to API route
testing. Web route testing is still very limited.

Bug: [T287008](https://phabricator.wikimedia.org/T287008)