### PR TITLE
Add API route to list ImportMeta

### DIFF
--- a/app/Http/Controllers/ImportController.php
+++ b/app/Http/Controllers/ImportController.php
@@ -82,4 +82,12 @@ class ImportController extends Controller
     {
         return new ImportMetaResource($import);
     }
+
+    /**
+     * Display the list of imports (latest 10)
+     */
+    public function index()
+    {
+        return ImportMetaResource::collection(ImportMeta::orderByDesc('id')->take(10)->get());
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,4 +20,4 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 });
 
 Route::apiResource(ImportController::RESOURCE_NAME, ImportController::class)
-    ->only(['store', 'show']);
+    ->only(['store', 'show', 'index']);

--- a/tests/Feature/ApiRouteTest.php
+++ b/tests/Feature/ApiRouteTest.php
@@ -59,17 +59,6 @@ class ApiRouteTest extends TestCase
     }
 
     /**
-     * Test the /api/imports route's GET method
-     *
-     *  @return void
-     */
-    public function test_get_import_wrong_method()
-    {
-        $response = $this->getJson(self::IMPORTS_ROUTE);
-        $response->assertStatus(405);
-    }
-
-    /**
      * Test the /api/imports route' POST method
      *
      *  @return void
@@ -244,7 +233,7 @@ class ApiRouteTest extends TestCase
     }
 
     /**
-     * Test expired best before field in /api/imports
+     * Test single import
      *
      *  @return void
      */
@@ -264,6 +253,34 @@ class ApiRouteTest extends TestCase
                 'created' => $import->created_at->toJSON(),
                 'uploader' => [
                     'username' => $import->user->username
+                ]
+            ]);
+    }
+
+    /**
+     * Test import list
+     *
+     *  @return void
+     */
+    public function test_get_import_list()
+    {
+        $user = User::factory()->uploader()->create();
+        $import = ImportMeta::factory()->for($user)->create();
+
+        $response = $this->getJson(self::IMPORTS_ROUTE);
+
+        // response should contain a list with $import as element
+        $response
+            ->assertSuccessful()
+            ->assertJson([
+                [
+                    'id' => $import->id,
+                    'status' => $import->status,
+                    'expires' => $import->expires,
+                    'created' => $import->created_at->toJSON(),
+                    'uploader' => [
+                        'username' => $import->user->username
+                    ]
                 ]
             ]);
     }


### PR DESCRIPTION
This adds an index() method to ImportController.php to list the latest
10 Imports in the DB.

Bug: [T287010](https://phabricator.wikimedia.org/T287010)