### PR TITLE
[Imports 0/7] Update mismatch migration

### DIFF
--- a/database/factories/MismatchFactory.php
+++ b/database/factories/MismatchFactory.php
@@ -32,14 +32,14 @@ class MismatchFactory extends Factory
 
     private function getRandomValue()
     {
+        $randomWordAmount = $this->faker->numberBetween(1, 5);
+        $randomDecimalLength = $this->faker->numberBetween(1, 25);
+
         return $this->faker->randomElement([
             $this->faker->date(),
-            $this->faker->randomFloat(),
-            $this->faker->randomNumber(),
-            $this->faker->words(
-                $this->faker->numberBetween(1, 15),
-                true
-            )
+            $this->faker->randomFloat($randomDecimalLength, 0, 10000),
+            $this->faker->randomNumber(30),
+            $this->faker->words($randomWordAmount, true)
         ]);
     }
 }

--- a/database/factories/MismatchFactory.php
+++ b/database/factories/MismatchFactory.php
@@ -35,10 +35,16 @@ class MismatchFactory extends Factory
         $randomWordAmount = $this->faker->numberBetween(1, 5);
         $randomDecimalLength = $this->faker->numberBetween(1, 25);
 
+        // Return one random value of any of the random value types below,
+        // to mimic data that might be in wikidata or external databases
         return $this->faker->randomElement([
+            // A random date
             $this->faker->date(),
+            // A random floating point number with up to 30 digits
             $this->faker->randomFloat($randomDecimalLength, 0, 10000),
+            // A random integer with up to 30 digits
             $this->faker->randomNumber(30),
+            // A random lorem text with up to 5 words
             $this->faker->words($randomWordAmount, true)
         ]);
     }

--- a/database/migrations/2021_07_19_123858_create_mismatches_table.php
+++ b/database/migrations/2021_07_19_123858_create_mismatches_table.php
@@ -18,8 +18,8 @@ class CreateMismatchesTable extends Migration
             $table->id();
             $table->string('statement_guid');
             $table->string('property_id');
-            $table->binary('wikidata_value'); // Saving as BLOB to enable storing JSON seralizations
-            $table->text('external_value');
+            $table->string('wikidata_value', 2048);
+            $table->string('external_value', 2048);
             $table->string('external_url', 2048)->nullable();
             $table->enum('status', [
                 'pending',

--- a/database/migrations/2021_07_19_123858_create_mismatches_table.php
+++ b/database/migrations/2021_07_19_123858_create_mismatches_table.php
@@ -18,9 +18,9 @@ class CreateMismatchesTable extends Migration
             $table->id();
             $table->string('statement_guid');
             $table->string('property_id');
-            $table->string('wikidata_value', 2048);
-            $table->string('external_value', 2048);
-            $table->string('external_url', 2048)->nullable();
+            $table->string('wikidata_value', 2048); // Arbitrary length above 1500 chars, upper limit for wikidata value
+            $table->string('external_value', 2048); // Arbitrary length above 1500 chars, upper limit for external value
+            $table->string('external_url', 2048)->nullable(); // Arbitrary length above 1500 chars, upper limit for url
             $table->enum('status', [
                 'pending',
                 'wikidata',


### PR DESCRIPTION
This PR corrects the mismatch migration to fit the most minimal product requirements, keeping in mind length limitations. As it turns out, since we do not intend to do anything with the wikidata value besides showing it, there is no need to save it as a BLOB. In addition, since we limit the length of external values to `1500` then we do not need to store it as TEXT. In case any of these have to be updated in the future, we can create an additional migration to handle that.

Bug: [T285299](https://phabricator.wikimedia.org/T285299)