### PR TITLE
[Imports 1/7] Create CSV reader service

### DIFF
--- a/app/Exceptions/ImportParserException.php
+++ b/app/Exceptions/ImportParserException.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+use Throwable;
+
+class ImportParserException extends Exception
+{
+    /**
+     * @var int
+     */
+    private $csvLine;
+
+    public function __construct(
+        int $line,
+        string $message = '',
+        int $code = 0,
+        Throwable $previous = null
+    ) {
+        parent::__construct(__('parsing.import.error', [
+            'line' => $line,
+            'message' => $message
+        ]), $code, $previous);
+
+        $this->csvLine = $line;
+        $this->parserMessage = $message;
+    }
+
+    /**
+     * Get the exception's context information.
+     */
+    public function context(): array
+    {
+        return [
+            'csv_line' => $this->csvLine,
+            'parser_message' => $this->parserMessage
+        ];
+    }
+}

--- a/app/Services/CSVImportReader.php
+++ b/app/Services/CSVImportReader.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\LazyCollection;
+use App\Exceptions\ImportParserException;
+
+class CSVImportReader
+{
+    public function lines(string $path): LazyCollection
+    {
+        $lines = LazyCollection::make(function () use ($path) {
+            $file = fopen($path, 'r');
+
+            while ($data = fgetcsv($file)) {
+                yield $data;
+            }
+        });
+
+        $allowedKeys = config('imports.upload.column_keys');
+        $columnKeys = $lines->get(0);
+
+        if (count(array_diff($allowedKeys, $columnKeys)) !== 0) {
+            throw new ImportParserException(0, __('parsing.import.headers', [
+                'header-list' => join(", ", $allowedKeys)
+            ]));
+        }
+
+        return $lines->except(0)
+            ->filter(function (array $row) {
+                return $row[0] !== null
+                && $row !== array_fill(0, 5, '');
+            })
+            ->map(function (array $row, int $i) use ($columnKeys) {
+                if (count($row) !== count($columnKeys)) {
+                    throw new ImportParserException($i, __('parsing.import.columns', [
+                        'amount' => count($columnKeys)
+                    ]));
+                }
+
+                return array_combine($columnKeys, $row);
+            });
+    }
+}

--- a/config/imports.php
+++ b/config/imports.php
@@ -7,7 +7,14 @@
  */
 return [
     'upload' => [
-        'filename_template' => ':datetime-mismatch-upload.:userid.csv'
+        'filename_template' => ':datetime-mismatch-upload.:userid.csv',
+        'column_keys' => [
+            'statement_guid',
+            'property_id',
+            'wikidata_value',
+            'external_value',
+            'external_url'
+        ]
     ],
 
     'description' => [

--- a/resources/lang/en/parsing.php
+++ b/resources/lang/en/parsing.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Parsing Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by various parsing messages.
+    |
+    */
+
+    'import' => [
+        'error' => 'CSV import parsing error at line :line: :message',
+        'columns' => 'A mismatch csv import must include exactly :amount columns for each line',
+        'headers' => 'Unrecognized column headers, please include the following column headers: :header-list'
+    ],
+
+];

--- a/tests/Feature/CSVImportReaderTest.php
+++ b/tests/Feature/CSVImportReaderTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Support\Facades\Storage;
+use App\Services\CSVImportReader;
+use Closure;
+use App\Exceptions\ImportParserException;
+
+class CSVImportReaderTest extends TestCase
+{
+    // Since PHPUnit data providers are evaluated earlier than Laravel we
+    // cannot use Laravel specific helpers such as __() or config().
+    // Therefore, we provide a closure, to be called at the appropriate time.
+    // See: https://technicallyfletch.com/how-to-use-laravel-factories-inside-a-data-provider/
+    public function skippedLinesProvider(): iterable
+    {
+        yield 'no skipped lines' => [function () {
+            return [];
+        }];
+
+        yield 'skips empty lines' => [function () {
+            return [''];
+        }];
+
+        yield 'skips lines with all empty values' => [function (array $cols) {
+            return array_fill(0, count($cols), '');
+        }];
+    }
+
+    /**
+     * @dataProvider skippedLinesProvider
+     */
+    public function test_parses_mismatch_lines($data)
+    {
+        $filename = 'import.csv';
+        $columns = config('imports.upload.column_keys');
+        $skip = $data($columns);
+
+        $fakeLines = [
+            ["some-statement-guid","some-pid","some-data","more-data","a-url"],
+            ["another-statement-guid","another-pid","another-data","different-data","no-url"]
+        ];
+
+        $fakeCSVContent = join("\n", array_map(function (array $line) {
+            return join(',', $line);
+        }, array_merge([$columns], [$skip], $fakeLines, [$skip]))); // Add extra lines
+
+        Storage::fake('local');
+        Storage::put($filename, $fakeCSVContent);
+
+        $reader = new CSVImportReader();
+        $actual = $reader->lines(Storage::path($filename))->values()->all();
+
+        $this->assertEquals(array_map(function ($row) use ($columns) {
+            return array_combine($columns, $row);
+        }, $fakeLines), $actual);
+    }
+
+    public function unparsableLineProvider(): iterable
+    {
+        yield 'too few columns' => [
+            function (array $config): array {
+                $colCount = count($config['column_keys']);
+
+                return [
+                    join(',', $config['column_keys']) . "\n"
+                    . str_repeat(',', $colCount - 2), // Emulate one column too few
+                    __('parsing.import.columns', [
+                        'amount' => $colCount
+                    ])
+                ];
+            }
+        ];
+
+        yield 'too many columns' => [
+            function (array $config): array {
+                $colCount = count($config['column_keys']);
+
+                return [
+                    join(',', $config['column_keys']) . "\n"
+                    . str_repeat(',', $colCount), // Emulate one column too many
+                    __('parsing.import.columns', [
+                        'amount' => $colCount
+                    ])
+                ];
+            }
+        ];
+
+        yield 'unrecognized header line' => [
+            function (array $config): array {
+                return [
+                    'some,form,of,non,headers', // Emulate unrecognized headers
+                    __('parsing.import.headers', [
+                        'header-list' => join(', ', $config['column_keys'])
+                    ])
+                ];
+            }
+        ];
+    }
+
+    /**
+     * @dataProvider unparsableLineProvider
+     */
+    public function test_throws_parsing_errors(Closure $data)
+    {
+        $filename = 'unparsable-import.csv';
+        $config = config('imports.upload');
+
+        [$content, $message] = $data($config);
+
+        Storage::fake('local');
+        Storage::put($filename, $content);
+
+        $this->expectException(ImportParserException::class);
+        $this->expectExceptionMessage($message);
+
+        $reader = new CSVImportReader();
+        $reader->lines(Storage::path($filename))->all();
+    }
+}


### PR DESCRIPTION
**Start HERE!** PR **1**/7 in the `feature/import-mismatches` chain.

This change introduces an import CSV reader service to be used in both the mismatch validation and mismatch import jobs. The service lazily reads CSV files from disk, while ensuring that:

1. Column headers match the allowed mismatch column headers
2. Empty rows are skipped
3. Column data is parsed into an associative array according to the specified column headers

In case of issues with column parsing, the service will throw a `ImportParserException`.

Relevant Documentation:
- [Laravel Lazy Collections](https://laravel.com/docs/8.x/collections#lazy-collections)
- [Laravel Exception Context](https://laravel.com/docs/8.x/errors#exception-log-context)

Blogs and Co:
- [Lazy collection CSV Import](https://www.magutti.com/blog/laravel-lazy-collections)

Bug: [T285299](https://phabricator.wikimedia.org/T285299)
