### PR TITLE
[Imports 2/7] Create job queue table

### DIFF
--- a/database/migrations/2021_07_19_154807_create_jobs_table.php
+++ b/database/migrations/2021_07_19_154807_create_jobs_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateJobsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('jobs', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('queue')->index();
+            $table->longText('payload');
+            $table->unsignedTinyInteger('attempts');
+            $table->unsignedInteger('reserved_at')->nullable();
+            $table->unsignedInteger('available_at');
+            $table->unsignedInteger('created_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('jobs');
+    }
+}


### PR DESCRIPTION
**2**/7 in the `feature/import-mismatches` chain. This depends on #36.

This change introduces a database migration in order to create a `jobs` table so that we could utilize Laravel's database job queue driver.

Relevant documentation:
- [Laravel Job Queue Driver Notes](https://laravel.com/docs/8.x/queues#driver-prerequisites)

Bug: [T285299](https://phabricator.wikimedia.org/T285299)
