### PR TITLE
[Imports 3/7] Create Wikidata API Client

### DIFF
--- a/app/Exceptions/WikibaseValueParserException.php
+++ b/app/Exceptions/WikibaseValueParserException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+class WikibaseValueParserException extends Exception
+{
+    //
+}

--- a/app/Providers/WikidataAPIProvider.php
+++ b/app/Providers/WikidataAPIProvider.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use App\Services\WikibaseAPIClient;
+use Kevinrob\GuzzleCache\CacheMiddleware;
+use Kevinrob\GuzzleCache\Strategy\PrivateCacheStrategy;
+use Kevinrob\GuzzleCache\Storage\LaravelCacheStorage;
+use Illuminate\Support\Facades\Cache;
+
+class WikidataAPIProvider extends ServiceProvider
+{
+    /**
+     * Register services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->app->singleton(WikibaseAPIClient::class, function ($app) {
+            $store = new LaravelCacheStorage(Cache::store('file'));
+            $strategy = new PrivateCacheStrategy($store);
+
+            return new WikibaseAPIClient(config('wikidata.api.url'), new CacheMiddleware($strategy));
+        });
+    }
+
+    /**
+     * Bootstrap services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        //
+    }
+}

--- a/app/Services/WikibaseAPIClient.php
+++ b/app/Services/WikibaseAPIClient.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Http\Client\Response;
+use App\Exceptions\WikibaseValueParserException;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Arr;
+use Kevinrob\GuzzleCache\CacheMiddleware;
+
+class WikibaseAPIClient
+{
+
+    /**
+     * @var string wikibase api url
+     */
+    private $baseUrl;
+
+    /**
+     * @var CacheMiddleware Guzzlehttp response caching middleware
+     */
+    private $cache;
+
+    public function __construct(string $baseUrl, CacheMiddleware $cache)
+    {
+        $this->baseUrl = $baseUrl;
+        $this->cache = $cache;
+    }
+
+    private function get(string $action, array $params): Response
+    {
+        return Http::withMiddleware($this->cache)
+            ->get($this->baseUrl, array_merge([
+                'action' => $action,
+                'format' => 'json',
+                'maxage' => config('wikidata.response_cache.ttl')
+            ], $params));
+    }
+
+    public function parseValue(string $property, $value): Response
+    {
+        $response = $this->get('wbparsevalue', [
+            'values' => $value,
+            'property' => $property,
+            'validate' => true
+        ]);
+
+        // Checking for an errors field in the response, since Wikibase api
+        // responds with 200 even for erroneous requests
+        if (isset($response['error'])) {
+            throw new WikibaseValueParserException($response['error']['info']);
+        }
+
+        return $response;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         "fideloper/proxy": "^4.4",
         "fruitcake/laravel-cors": "^2.0",
         "guzzlehttp/guzzle": "^7.0.1",
+        "kevinrob/guzzle-cache-middleware": "^3.4",
         "laravel/framework": "^8.40",
         "laravel/sanctum": "^2.11",
         "laravel/socialite": "^5.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "aeaf66202c68d0c1964613dd58963763",
+    "content-hash": "dc4754c9ea59a5734262975d77d07cf3",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -860,6 +860,88 @@
                 "source": "https://github.com/guzzle/psr7/tree/2.0.0"
             },
             "time": "2021-06-30T20:03:07+00:00"
+        },
+        {
+            "name": "kevinrob/guzzle-cache-middleware",
+            "version": "v3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Kevinrob/guzzle-cache-middleware.git",
+                "reference": "d40eb54f08362d01da598da1b0e7421e8c3a52f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Kevinrob/guzzle-cache-middleware/zipball/d40eb54f08362d01da598da1b0e7421e8c3a52f6",
+                "reference": "d40eb54f08362d01da598da1b0e7421e8c3a52f6",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "^6.0 || ^7.0",
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "cache/array-adapter": "^0.4 || ^0.5 || ^1.0",
+                "cache/simple-cache-bridge": "^0.1 || ^1.0",
+                "doctrine/cache": "^1.0",
+                "illuminate/cache": "^5.0",
+                "league/flysystem": "^1.0",
+                "phpunit/phpunit": "^4.8.36 || ^5.0",
+                "psr/cache": "^1.0",
+                "symfony/phpunit-bridge": "^4.4 || ^5.0"
+            },
+            "suggest": {
+                "doctrine/cache": "This library has a lot of ready-to-use cache storage (to be used with Kevinrob\\GuzzleCache\\Storage\\DoctrineCacheStorage).",
+                "guzzlehttp/guzzle": "For using this library. It was created for Guzzle6 (but you can use it with any PSR-7 HTTP client).",
+                "laravel/framework": "To be used with Kevinrob\\GuzzleCache\\Storage\\LaravelCacheStorage",
+                "league/flysystem": "To be used with Kevinrob\\GuzzleCache\\Storage\\FlysystemStorage",
+                "psr/cache": "To be used with Kevinrob\\GuzzleCache\\Storage\\Psr6CacheStorage",
+                "psr/simple-cache": "To be used with Kevinrob\\GuzzleCache\\Storage\\Psr16CacheStorage"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Kevinrob\\GuzzleCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kevin Robatel",
+                    "email": "kevinrob2@gmail.com",
+                    "homepage": "https://github.com/Kevinrob"
+                }
+            ],
+            "description": "A HTTP/1.1 Cache for Guzzle 6. It's a simple Middleware to be added in the HandlerStack. (RFC 7234)",
+            "homepage": "https://github.com/Kevinrob/guzzle-cache-middleware",
+            "keywords": [
+                "Etag",
+                "Flysystem",
+                "Guzzle",
+                "cache",
+                "cache-control",
+                "doctrine",
+                "expiration",
+                "guzzle6",
+                "handler",
+                "http",
+                "http 1.1",
+                "middleware",
+                "performance",
+                "php",
+                "promise",
+                "psr6",
+                "psr7",
+                "rfc7234",
+                "validation"
+            ],
+            "support": {
+                "issues": "https://github.com/Kevinrob/guzzle-cache-middleware/issues",
+                "source": "https://github.com/Kevinrob/guzzle-cache-middleware/tree/v3.4.0"
+            },
+            "time": "2021-07-02T15:53:35+00:00"
         },
         {
             "name": "laravel/framework",

--- a/config/app.php
+++ b/config/app.php
@@ -175,6 +175,10 @@ return [
         App\Providers\EventServiceProvider::class,
         App\Providers\RouteServiceProvider::class,
 
+        /*
+         * Custom Service Providers
+         */
+        App\Providers\WikidataAPIProvider::class,
     ],
 
     /*

--- a/config/wikidata.php
+++ b/config/wikidata.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * Various configurations relating to wikidata
+ */
+return [
+    'api' => [
+        'url' => env('WIKIDATA_API_URL', 'https://www.wikidata.org/w/api.php'),
+        'response_cache' => [
+            'ttl' => env('WIKIDATA_API_CACHE_TTL', 60 * 60 * 60 * 24) // 1 day arbitrarily chosen as default
+        ]
+    ]
+];

--- a/tests/Feature/WikibaseAPIClientTest.php
+++ b/tests/Feature/WikibaseAPIClientTest.php
@@ -74,6 +74,8 @@ class WikibaseAPIClientTest extends TestCase
         $fakeResponseBody = ['test' => 'okay'];
 
         $mockCache = Mockery::mock(CacheMiddleware::class);
+        // The `__invoke()` magic method is utilized by guzzle middleware: 
+        // https://www.phptutorial.net/php-oop/php-__invoke/
         $mockCache->shouldReceive('__invoke')->andReturn(function () use ($fakeResponseBody) {
             return Http::response($fakeResponseBody, 200);
         });

--- a/tests/Feature/WikibaseAPIClientTest.php
+++ b/tests/Feature/WikibaseAPIClientTest.php
@@ -74,7 +74,7 @@ class WikibaseAPIClientTest extends TestCase
         $fakeResponseBody = ['test' => 'okay'];
 
         $mockCache = Mockery::mock(CacheMiddleware::class);
-        // The `__invoke()` magic method is utilized by guzzle middleware: 
+        // The `__invoke()` magic method is utilized by guzzle middleware:
         // https://www.phptutorial.net/php-oop/php-__invoke/
         $mockCache->shouldReceive('__invoke')->andReturn(function () use ($fakeResponseBody) {
             return Http::response($fakeResponseBody, 200);

--- a/tests/Feature/WikibaseAPIClientTest.php
+++ b/tests/Feature/WikibaseAPIClientTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Support\Facades\Http;
+use App\Services\WikibaseAPIClient;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Str;
+use App\Exceptions\WikibaseValueParserException;
+use Illuminate\Http\Client\Response;
+use Mockery;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Arr;
+use Kevinrob\GuzzleCache\CacheMiddleware;
+use Kevinrob\GuzzleCache\Strategy\NullCacheStrategy;
+
+class WikibaseAPIClientTest extends TestCase
+{
+    const FAKE_API_URL = "http://fake.wikibase.api";
+
+    /**
+     * A basic unit test example.
+     *
+     * @return void
+     */
+    public function test_parse_value_returns_api_response(): void
+    {
+        $fakePayload = [
+            'property' => 'P1234',
+            'values' => 'fake-value'
+        ];
+        $fakeResponseBody = ['test' => 'okay'];
+
+        Http::fake(function (Request $req) use ($fakeResponseBody) {
+            return Http::response($fakeResponseBody, 200);
+        });
+
+        $mockCache = Mockery::mock(CacheMiddleware::class)->shouldIgnoreMissing();
+
+        $client = new WikibaseAPIClient(self::FAKE_API_URL, $mockCache);
+        $response = $client->parseValue($fakePayload['property'], $fakePayload['values']);
+
+        $this->assertActionRequest(self::FAKE_API_URL, 'wbparsevalue', $fakePayload);
+        $this->assertSame($fakeResponseBody, $response->json());
+    }
+
+    public function test_parse_value_throws_on_error_response()
+    {
+        $fakePayload = [
+            'property' => 'P1234',
+            'values' => 'fake-value'
+        ];
+        $fakeErrorResponse = ['error' => [
+            'info' => 'not okay'
+        ]];
+
+        Http::fake(function (Request $req) use ($fakeErrorResponse) {
+            return Http::response($fakeErrorResponse, 200);
+        });
+        $mockCache = Mockery::mock(CacheMiddleware::class)->shouldIgnoreMissing();
+
+        $this->expectException(WikibaseValueParserException::class);
+        $this->expectExceptionMessage($fakeErrorResponse['error']['info']);
+
+        $client = new WikibaseAPIClient(self::FAKE_API_URL, $mockCache);
+        $client->parseValue($fakePayload['property'], $fakePayload['values']);
+
+        $this->assertActionRequest(self::FAKE_API_URL, 'wbparsevalue', $fakePayload);
+    }
+
+    public function test_parse_value_retrieves_cached_responses()
+    {
+        $fakeResponseBody = ['test' => 'okay'];
+
+        $mockCache = Mockery::mock(CacheMiddleware::class);
+        $mockCache->shouldReceive('__invoke')->andReturn(function () use ($fakeResponseBody) {
+            return Http::response($fakeResponseBody, 200);
+        });
+
+        $client = new WikibaseAPIClient(self::FAKE_API_URL, $mockCache);
+        $response = $client->parseValue('P1234', 'fake-value');
+
+        $this->assertSame($fakeResponseBody, $response->json());
+    }
+
+    private function assertActionRequest(string $url, string $action, array $payload)
+    {
+        Http::assertSent(function (Request $req) use ($url, $action, $payload) {
+            foreach ($payload as $key => $value) {
+                if ($req[$key] != $value) {
+                    return false;
+                }
+            }
+
+            return Str::startsWith($req->url(), $url)
+                && $req['action'] == $action;
+        });
+    }
+}


### PR DESCRIPTION
**3**/7 in the `feature/import-mismatches` chain. This depends on #37.

This change introduces a Wikibase API Client Service, so that we can call Wikidata API endpoints and cache our responses. The service already includes a method to call `wbparsevalue` which throws a `WikibaseValueParserException` on errors. Additionally, we wire up this service to the service container in `WikidataAPIProvider`, as it has external dependencies, and thus cannot be injected with Laravel's Zero-configuration resolution mechanism.

This change also installs some caching middleware, in order to enable us to cache responses for our API calls to try to keep our call rate to a minimum.

Relevant Documentation:
- [Laravel Service Container](https://laravel.com/docs/8.x/container)
- [Laravel Service Providers](https://laravel.com/docs/8.x/providers)
- [Laravel HTTP Client](https://laravel.com/docs/8.x/http-client)
- [Guzzle HTTP Middleware](https://docs.guzzlephp.org/en/stable/handlers-and-middleware.html)
- [Kevinrob's Guzzle Cache Middleware](https://github.com/Kevinrob/guzzle-cache-middleware)

Blogs and Co:
- [When to use DI in Laravel](https://blog.quickadminpanel.com/laravel-when-to-use-dependency-injection-services-and-static-methods/)

Bug: [T285299](https://phabricator.wikimedia.org/T285299)