### PR TITLE
[Imports 4/7] Create WikidataValue validation Rule

### DIFF
--- a/app/Rules/WikidataValue.php
+++ b/app/Rules/WikidataValue.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+use App\Services\WikibaseAPIClient;
+use App\Exceptions\WikibaseValueParserException;
+
+class WikidataValue implements Rule
+{
+    /**
+     * @var WikibaseAPIClient Wikidata API Client
+     */
+    private $wikidata;
+
+    /**
+     * Create a new rule instance.
+     *
+     * @return void
+     */
+    public function __construct(WikibaseAPIClient $wikidata)
+    {
+        $this->wikidata = $wikidata;
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        [
+            'property' => $property,
+            'value' => $wikidataValue
+        ] = $value;
+
+        try {
+            $this->wikidata->parseValue($property, $wikidataValue);
+        } catch (WikibaseValueParserException $e) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return __('validation.wikidata_value');
+    }
+}

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -140,6 +140,7 @@ return [
         ],
     ],
 
+    'wikidata_value' => 'The :attribute could not be parsed for the given property id',
     /*
     |--------------------------------------------------------------------------
     | Custom Validation Attributes

--- a/tests/Unit/WikidataValueTest.php
+++ b/tests/Unit/WikidataValueTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Mockery;
+use App\Services\WikibaseAPIClient;
+use App\Rules\WikidataValue;
+use App\Exceptions\WikibaseValueParserException;
+
+class WikidataValueTest extends TestCase
+{
+    public function test_passes_validation_when_client_returns(): void
+    {
+        $mockApiClient = Mockery::mock(WikibaseAPIClient::class);
+        $mockApiClient->shouldReceive('parseValue')->once();
+
+        $rule = new WikidataValue($mockApiClient);
+
+        $this->assertTrue($rule->passes('some-attribute', [
+            'property' => 'P1234',
+            'value' => 'some-value'
+        ]));
+    }
+
+    public function test_fails_validation_when_client_throws(): void
+    {
+        $mockApiClient = Mockery::mock(WikibaseAPIClient::class);
+        $mockApiClient->shouldReceive('parseValue')->andThrow(
+            new WikibaseValueParserException()
+        );
+
+        $rule = new WikidataValue($mockApiClient);
+
+        $this->assertFalse($rule->passes('some-attribute', [
+            'property' => 'P1234',
+            'value' => 'some-value'
+        ]));
+    }
+}


### PR DESCRIPTION
**4**/7 in the `feature/import-mismatches` chain. This depends on #38.

This change introduces a new custom validation rule for validating wikidata values. The rule utilizes the API client in order to check a Wikibase value against a parser derived from the provided property ID. In case the parse fails, the validation rule will not pass.

Relevant Documentation:
- [Laravel Custom Validation Rules](https://laravel.com/docs/8.x/validation#custom-validation-rules)

Bug: [T285299](https://phabricator.wikimedia.org/T285299)