### PR TITLE
Add toolforge background job config

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -1,0 +1,31 @@
+---
+# Run the mismatch finder job queue on kubernetes
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mismatch-finder.queue
+  namespace: tool-mismatch-finder
+  labels:
+    name: mismatch-finder.queue
+    toolforge: tool
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: mismatch-finder.queue
+      toolforge: tool
+  template:
+    metadata:
+      labels:
+        name: mismatch-finder.queue
+        toolforge: tool
+    spec:
+      containers:
+        - name: artisan-queue
+          image: docker-registry.tools.wmflabs.org/toolforge-php73-sssd-base:latest
+          command: [ "php", "artisan", "queue:work" ]
+          workingDir: /data/project/mismatch-finder/mismatch-finder-repo
+          env:
+            - name: HOME
+              value: /data/project/mismatch-finder
+          imagePullPolicy: Always


### PR DESCRIPTION
This change adds a deployment.yaml file which is needed to create a
kubernetes continuous job on toolforge, that runs the artisan queue
worker to import mismatch files to the database.

Bug: [T285299](https://phabricator.wikimedia.org/T285299)