### PR TITLE
Fix UUID Regex from v4 to generic format

### DIFF
--- a/config/mismatches.php
+++ b/config/mismatches.php
@@ -7,7 +7,8 @@ return [
     'validation' => [
         'guid' => [
             'max_length' => 100,
-            'format' => '/^Q\d+\$[0-9A-F]{8}\-[0-9A-F]{4}\-4[0-9A-F]{3}\-[89AB][0-9A-F]{3}\-[0-9A-F]{12}$/i'
+            // Q<INTEGER>$<UUID>: The uuid format is general and not restricted to any spec version
+            'format' => '/^Q\d+\$[0-9A-F]{8}\-[0-9A-F]{4}\-[0-9A-F]{4}\-[0-9A-F]{4}\-[0-9A-F]{12}$/i'
         ],
         'pid' => [
             'max_length' => 100,


### PR DESCRIPTION
As it turns out, Wikidata can have non v4 UUIDs as the statement GUID. Therefore, we must relax the UUID format rules a bit.