### PR TITLE
Fix out of bounds number generation

### DIFF
--- a/database/factories/MismatchFactory.php
+++ b/database/factories/MismatchFactory.php
@@ -33,17 +33,17 @@ class MismatchFactory extends Factory
     private function getRandomValue()
     {
         $randomWordAmount = $this->faker->numberBetween(1, 5);
-        $randomDecimalLength = $this->faker->numberBetween(1, 25);
+        $randomDecimalLength = $this->faker->numberBetween(1, 4);
 
         // Return one random value of any of the random value types below,
         // to mimic data that might be in wikidata or external databases
         return $this->faker->randomElement([
             // A random date
             $this->faker->date(),
-            // A random floating point number with up to 30 digits
-            $this->faker->randomFloat($randomDecimalLength, 0, 10000),
-            // A random integer with up to 30 digits
-            $this->faker->randomNumber(30),
+            // A random floating point number with up to 5 + 4 digits
+            $this->faker->randomFloat($randomDecimalLength, 0, 99999),
+            // A random integer with up to 9 digits
+            $this->faker->randomNumber(9),
             // A random lorem text with up to 5 words
             $this->faker->words($randomWordAmount, true)
         ]);


### PR DESCRIPTION
This change fixes the obscenely large numbers that were required to be generates in the `MismatchFactory`, changing them from 30-digit numbers to 9-digit numbers.