### PR TITLE
Create import failure concept

### DIFF
--- a/app/Models/ImportFailure.php
+++ b/app/Models/ImportFailure.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ImportFailure extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'line',
+        'message'
+    ];
+
+    public function importMeta()
+    {
+        return $this->belongsTo(ImportMeta::class, 'import_id')->withDefault();
+    }
+}

--- a/database/factories/ImportFailureFactory.php
+++ b/database/factories/ImportFailureFactory.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ImportFailure;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ImportFailureFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = ImportFailure::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        $randomLine = $this->faker->optional(0.8)->numberBetween(0, 10000);
+        $randomWordAmount = $this->faker->numberBetween(1, 15);
+        $randomSentence = $this->faker->sentence($randomWordAmount);
+        $message = $randomLine ? $this->faker->randomElement([
+            __('validation.import.error', [
+                'line' => $randomLine,
+                'message' => $randomSentence
+            ]),
+            __('parsing.import.error', [
+                'line' => $randomLine,
+                'message' => $randomSentence
+            ])
+        ]) : $randomSentence;
+
+        return [
+            // Some errors might not include a line number (80% chance that they do).
+            // Assuming a file might contain up to 10,000 lines.
+            'line' => $randomLine,
+            'message' => $message
+        ];
+    }
+}

--- a/database/migrations/2021_08_05_073148_create_import_failures_table.php
+++ b/database/migrations/2021_08_05_073148_create_import_failures_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateImportFailuresTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('import_failures', function (Blueprint $table) {
+            $table->id();
+            $table->integer('line')->nullable();
+            $table->string('message');
+            $table->foreignId('import_id')->constrained('import_meta');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('import_failures');
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -17,7 +17,8 @@ class DatabaseSeeder extends Seeder
             UserSeeder::class,
             UploadUserSeeder::class,
             ImportMetaSeeder::class,
-            MismatchSeeder::class
+            MismatchSeeder::class,
+            ImportFailureSeeder::class
         ]);
     }
 }

--- a/database/seeders/ImportFailureSeeder.php
+++ b/database/seeders/ImportFailureSeeder.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\ImportMeta;
+use App\Models\User;
+use App\Models\ImportFailure;
+
+class ImportFailureSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $import = ImportMeta::factory()
+            ->for(User::factory()->uploader())
+            ->create([
+                'status' => 'failed'
+            ]);
+
+        ImportFailure::factory(3)
+            ->for($import)
+            ->create();
+    }
+}


### PR DESCRIPTION
This change attempts to model the concept of an import failure, which will belong to each failed import. This is done to easily associate import failure messages with their correct import, without having to query the failed jobs table and parsing the serialized exceptions saved there.

To validate, you can attempt to run the migration (`sail artisan migrate`) and the seeder (`sail artisan db:seed ImportFailureSeeder`).

Bug: [T288042](https://phabricator.wikimedia.org/T288042)