### PR TITLE
Add failure information to import status

### DIFF
--- a/app/Http/Resources/ImportMetaResource.php
+++ b/app/Http/Resources/ImportMetaResource.php
@@ -14,7 +14,7 @@ class ImportMetaResource extends JsonResource
      */
     public function toArray($request)
     {
-        return [
+        $meta = [
             'id' => $this->id,
             'status' => $this->status,
             'description' => $this->description,
@@ -25,5 +25,11 @@ class ImportMetaResource extends JsonResource
                 'self' => route('imports.show', $this)
             ]
         ];
+
+        if( $this->error ) {
+            $meta['error'] = $this->error->message;
+        }
+
+        return $meta;
     }
 }

--- a/app/Http/Resources/ImportMetaResource.php
+++ b/app/Http/Resources/ImportMetaResource.php
@@ -26,7 +26,7 @@ class ImportMetaResource extends JsonResource
             ]
         ];
 
-        if( $this->error ) {
+        if ($this->error) {
             $meta['error'] = $this->error->message;
         }
 

--- a/app/Models/ImportMeta.php
+++ b/app/Models/ImportMeta.php
@@ -50,4 +50,9 @@ class ImportMeta extends Model
     {
         return $this->belongsTo(User::class)->withDefault();
     }
+
+    public function error()
+    {
+        return $this->hasOne(ImportFailure::class, 'import_id');
+    }
 }

--- a/database/factories/ImportMetaFactory.php
+++ b/database/factories/ImportMetaFactory.php
@@ -25,13 +25,27 @@ class ImportMetaFactory extends Factory
     {
         return [
             'description' => $this->faker->optional(0.8)->realText(350),
+            // Exclude failed, so that we could associate it with an Import Failure
             'status' => $this->faker->randomElement([
                 'pending',
-                'failed',
                 'completed'
             ]),
             'expires' => $this->faker->dateTimeBetween('+1 day', '+6 months')->format('Y-m-d'),
             'filename' => 'test_file.csv'
         ];
+    }
+
+    /**
+     * Indicate that the import is failed.
+     *
+     * @return \Illuminate\Database\Eloquent\Factories\Factory
+     */
+    public function failed(string $username = null)
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'status' => 'failed',
+            ];
+        });
     }
 }

--- a/database/seeders/ImportFailureSeeder.php
+++ b/database/seeders/ImportFailureSeeder.php
@@ -16,14 +16,18 @@ class ImportFailureSeeder extends Seeder
      */
     public function run()
     {
-        $import = ImportMeta::factory()
-            ->for(User::factory()->uploader())
-            ->create([
-                'status' => 'failed'
-            ]);
+        $user = User::factory()->uploader()->create();
 
-        ImportFailure::factory()
-            ->for($import)
-            ->create();
+        // Create 3 failed imports
+        for ($i = 0; $i < 3; $i++) {
+            $import = ImportMeta::factory()
+                ->failed()
+                ->for($user);
+
+            ImportFailure::factory()
+                ->for($import)
+                ->create();
+        }
+
     }
 }

--- a/database/seeders/ImportFailureSeeder.php
+++ b/database/seeders/ImportFailureSeeder.php
@@ -22,7 +22,7 @@ class ImportFailureSeeder extends Seeder
                 'status' => 'failed'
             ]);
 
-        ImportFailure::factory(3)
+        ImportFailure::factory()
             ->for($import)
             ->create();
     }

--- a/database/seeders/ImportFailureSeeder.php
+++ b/database/seeders/ImportFailureSeeder.php
@@ -28,6 +28,5 @@ class ImportFailureSeeder extends Seeder
                 ->for($import)
                 ->create();
         }
-
     }
 }

--- a/docs/mismatchfinder-api-spec.yml
+++ b/docs/mismatchfinder-api-spec.yml
@@ -237,4 +237,6 @@ components:
     ListOfImportMeta:
       type: array
       items:
-        $ref: '#/components/schemas/ImportMeta'
+        anyOf:
+          - $ref: '#/components/schemas/ImportMeta'
+          - $ref: '#/components/schemas/FailedImportMeta'

--- a/docs/mismatchfinder-api-spec.yml
+++ b/docs/mismatchfinder-api-spec.yml
@@ -80,6 +80,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ImportMeta'
+
         '400':
           $ref: '#/components/responses/ClientError'
         '422':
@@ -101,7 +102,15 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ImportMeta'
+                oneOf:
+                 - $ref: '#/components/schemas/ImportMeta'
+                 - $ref: '#/components/schemas/FailedImportMeta'
+                discriminator:
+                  propertyName: status
+                  mapping:
+                    pending: '#/components/schemas/ImportMeta'
+                    completed: '#/components/schemas/ImportMeta'
+                    failed: '#/components/schemas/FailedImportMeta'
         '404':
           $ref: '#/components/responses/NotFound'
 
@@ -215,8 +224,15 @@ components:
           type: string
           format: date
         uploader:
-          type: object
           $ref: '#/components/schemas/User'
+
+    FailedImportMeta:
+      allOf:
+      - $ref: '#/components/schemas/ImportMeta'
+      - type: object
+        properties:
+          error:
+            type: string
 
     ListOfImportMeta:
       type: array

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -16,6 +16,10 @@ $color-red-30: #B32424;
 $color-red-50: #D33;
 $color-red-hover: #FF4242;
 
+body, body * {
+    box-sizing: border-box;
+}
+
 body {
     padding: 24px;
     max-width: 1090px;

--- a/resources/views/importStatus.blade.php
+++ b/resources/views/importStatus.blade.php
@@ -4,6 +4,11 @@
             <dt>{{ __('import-status.item:status') }}</dt>
             <dd>{{ __('import-status.item:status.' . $import->status) }}</dd>
 
+            @if($import->error)
+                <dt>{{ __('import-status.item:error') }}</dt>
+                <dd>{{ $import->error->message }}</dd>
+            @endif
+
             <dt>{{__('import-status.item:uploader')}}</dt>
             <dd>{{ $import->user->username }}</dd>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,6 +19,5 @@ Route::get('/', function () {
 });
 
 Route::get('/imports', function () {
-    // return ImportMeta::orderByDesc('id')->take(10)->get()->first()->error->message;
     return view('importStatus', [ 'imports' => ImportMeta::with('error')->orderByDesc('id')->take(10)->get() ]);
 })->name('import.status');

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,5 +19,6 @@ Route::get('/', function () {
 });
 
 Route::get('/imports', function () {
-    return view('importStatus', [ 'imports' => ImportMeta::orderByDesc('id')->take(10)->get() ]);
+    // return ImportMeta::orderByDesc('id')->take(10)->get()->first()->error->message;
+    return view('importStatus', [ 'imports' => ImportMeta::with('error')->orderByDesc('id')->take(10)->get() ]);
 })->name('import.status');


### PR DESCRIPTION
This change adds failure information to both the import status page, and the `GET /api/imports`, `GET /api/imports/{id}` API responses.

Bug: [T288045](https://phabricator.wikimedia.org/T288045) 