### PR TITLE
Validate column count of import file header

### DIFF
--- a/app/Services/CSVImportReader.php
+++ b/app/Services/CSVImportReader.php
@@ -20,7 +20,9 @@ class CSVImportReader
         $allowedKeys = config('imports.upload.column_keys');
         $columnKeys = $lines->get(0);
 
-        if (count(array_diff($allowedKeys, $columnKeys)) !== 0) {
+        if (count($allowedKeys) != count($columnKeys) ||
+            count(array_diff($allowedKeys, $columnKeys)) !== 0
+            ) {
             throw new ImportParserException(0, __('parsing.import.headers', [
                 'header-list' => join(", ", $allowedKeys)
             ]));

--- a/resources/lang/en/parsing.php
+++ b/resources/lang/en/parsing.php
@@ -14,7 +14,7 @@ return [
     'import' => [
         'error' => 'CSV import parsing error at line :line: :message',
         'columns' => 'A mismatch csv import must include exactly :amount columns for each line',
-        'headers' => 'Unrecognized column headers, please include the following column headers: :header-list'
+        'headers' => 'Unrecognized column headers, please include exactly the following column headers: :header-list'
     ],
 
 ];


### PR DESCRIPTION
The header line of imported mismatch files must contain exactly the
allowed columns and no additional ones.

Bug: [T288043](https://phabricator.wikimedia.org/T288043)