### PR TITLE
Add php zip extension

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -22,6 +22,7 @@ jobs:
         dev: no
         version: 2
         php_version: 7.3
+        php_extensions: zip
     - name: Installing node dependencies
       run: npm ci
     - name: Minify and Build CSS and JS


### PR DESCRIPTION
This hotfix enables the php zip extension in the composer (php-actions) Github Action used by our deployment script. To better fit our system requirements during the build step.