### PR TITLE
Fix defintion data spacing

### DIFF
--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -174,8 +174,12 @@ dl.import-meta dt {
 
 dl.import-meta dd {
     margin: 0;
+}
+
+dl.import-meta dd:not(:last-child) {
     padding-bottom: 16px;
 }
+
 p {
     margin: 0 0 16px 0;
 }

--- a/resources/views/importStatus.blade.php
+++ b/resources/views/importStatus.blade.php
@@ -12,8 +12,10 @@
             <dt>{{__('import-status.item:uploader')}}</dt>
             <dd>{{ $import->user->username }}</dd>
 
-            <dt>{{__('import-status.item:description')}}</dt>
-            <dd>{{ $import->description }}</dd>
+            @if($import->description)
+                <dt>{{__('import-status.item:description')}}</dt>
+                <dd>{{ $import->description }}</dd>
+            @endif
 
             <dt>{{__('import-status.item:upload_date')}}</dt>
             <dd>{{ $import->created_at->format(__('import-status.date_format')) }}</dd>


### PR DESCRIPTION
This change fixes some spacing issues with the definition data in the Import status card. Additionally, we hide the "Short Description" title for non-existent import descriptions.