### PR TITLE
Audit packages for security issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3464,6 +3464,7 @@
         },
         "node_modules/boolbase": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
             "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
             "dev": true
         },
@@ -4560,14 +4561,15 @@
             }
         },
         "node_modules/css-select": {
-            "version": "3.1.2",
-            "integrity": "sha512-qmss1EihSuBNWNNhHjxzxSfJoFBM/lERB/Q4EnsJQQC62R2evJDW481091oAdOr9uh46/0n4nrg0It5cAnj1RA==",
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.3.tgz",
+            "integrity": "sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==",
             "dev": true,
             "dependencies": {
                 "boolbase": "^1.0.0",
-                "css-what": "^4.0.0",
-                "domhandler": "^4.0.0",
-                "domutils": "^2.4.3",
+                "css-what": "^5.0.0",
+                "domhandler": "^4.2.0",
+                "domutils": "^2.6.0",
                 "nth-check": "^2.0.0"
             },
             "funding": {
@@ -4595,8 +4597,9 @@
             }
         },
         "node_modules/css-what": {
-            "version": "4.0.0",
-            "integrity": "sha512-teijzG7kwYfNVsUh2H/YN62xW3KK9YhXEgSlbxMlcyjPNvdKJqFx5lrwlJgoFP1ZHlB89iGDlo/JyshKeRhv5A==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
+            "integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==",
             "dev": true,
             "engines": {
                 "node": ">= 6"
@@ -5131,9 +5134,6 @@
                 "lru-cache": "^4.1.5",
                 "semver": "^5.6.0",
                 "sigmund": "^1.0.1"
-            },
-            "bin": {
-                "editorconfig": "bin/editorconfig"
             }
         },
         "node_modules/editorconfig/node_modules/commander": {
@@ -9313,6 +9313,7 @@
         },
         "node_modules/nth-check": {
             "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.0.tgz",
             "integrity": "sha512-i4sc/Kj8htBrAiH1viZ0TgU8Y5XqCaV/FziYK6TBczxmeKm3AEFWqqF3195yKudrarqy7Zu80Ra5dobFjn9X/Q==",
             "dev": true,
             "dependencies": {
@@ -12599,14 +12600,15 @@
             }
         },
         "node_modules/svgo": {
-            "version": "2.3.0",
-            "integrity": "sha512-fz4IKjNO6HDPgIQxu4IxwtubtbSfGEAJUq/IXyTPIkGhWck/faiiwfkvsB8LnBkKLvSoyNNIY6d13lZprJMc9Q==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.3.1.tgz",
+            "integrity": "sha512-riDDIQgXpEnn0BEl9Gvhh1LNLIyiusSpt64IR8upJu7MwxnzetmF/Y57pXQD2NMX2lVyMRzXt5f2M5rO4wG7Dw==",
             "dev": true,
             "dependencies": {
                 "@trysound/sax": "0.1.1",
                 "chalk": "^4.1.0",
                 "commander": "^7.1.0",
-                "css-select": "^3.1.2",
+                "css-select": "^4.1.3",
                 "css-tree": "^1.1.2",
                 "csso": "^4.2.0",
                 "stable": "^0.1.8"
@@ -16631,6 +16633,7 @@
         },
         "boolbase": {
             "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
             "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
             "dev": true
         },
@@ -17523,14 +17526,15 @@
             }
         },
         "css-select": {
-            "version": "3.1.2",
-            "integrity": "sha512-qmss1EihSuBNWNNhHjxzxSfJoFBM/lERB/Q4EnsJQQC62R2evJDW481091oAdOr9uh46/0n4nrg0It5cAnj1RA==",
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.3.tgz",
+            "integrity": "sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==",
             "dev": true,
             "requires": {
                 "boolbase": "^1.0.0",
-                "css-what": "^4.0.0",
-                "domhandler": "^4.0.0",
-                "domutils": "^2.4.3",
+                "css-what": "^5.0.0",
+                "domhandler": "^4.2.0",
+                "domutils": "^2.6.0",
                 "nth-check": "^2.0.0"
             }
         },
@@ -17551,8 +17555,9 @@
             }
         },
         "css-what": {
-            "version": "4.0.0",
-            "integrity": "sha512-teijzG7kwYfNVsUh2H/YN62xW3KK9YhXEgSlbxMlcyjPNvdKJqFx5lrwlJgoFP1ZHlB89iGDlo/JyshKeRhv5A==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
+            "integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==",
             "dev": true
         },
         "cssesc": {
@@ -21192,6 +21197,7 @@
         },
         "nth-check": {
             "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.0.tgz",
             "integrity": "sha512-i4sc/Kj8htBrAiH1viZ0TgU8Y5XqCaV/FziYK6TBczxmeKm3AEFWqqF3195yKudrarqy7Zu80Ra5dobFjn9X/Q==",
             "dev": true,
             "requires": {
@@ -23639,14 +23645,15 @@
             }
         },
         "svgo": {
-            "version": "2.3.0",
-            "integrity": "sha512-fz4IKjNO6HDPgIQxu4IxwtubtbSfGEAJUq/IXyTPIkGhWck/faiiwfkvsB8LnBkKLvSoyNNIY6d13lZprJMc9Q==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.3.1.tgz",
+            "integrity": "sha512-riDDIQgXpEnn0BEl9Gvhh1LNLIyiusSpt64IR8upJu7MwxnzetmF/Y57pXQD2NMX2lVyMRzXt5f2M5rO4wG7Dw==",
             "dev": true,
             "requires": {
                 "@trysound/sax": "0.1.1",
                 "chalk": "^4.1.0",
                 "commander": "^7.1.0",
-                "css-select": "^3.1.2",
+                "css-select": "^4.1.3",
                 "css-tree": "^1.1.2",
                 "csso": "^4.2.0",
                 "stable": "^0.1.8"


### PR DESCRIPTION
This change runs `npm audit` in order to upgrade some packages that were triggering vulnerability warnings by npm.

To validate:
1) run `sail npm audit` before pulling this branch, you should see a mesage saying
    ```
    3 high severity vulnerabilities
    ```
2) Pull this branch and run `sail npm audit` again, this time it should say:
    ```
    found 0 vulnerabilities
    ```
    