### PR TITLE
Get active mismatches

### DIFF
--- a/app/Http/Controllers/MismatchController.php
+++ b/app/Http/Controllers/MismatchController.php
@@ -3,10 +3,9 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\MismatchesRequest;
-use App\Http\Resources\MismatchCollection;
 use App\Http\Resources\MismatchResource;
 use App\Models\Mismatch;
-use Illuminate\Http\Request;
+use Carbon\Carbon;
 
 class MismatchController extends Controller
 {
@@ -20,8 +19,22 @@ class MismatchController extends Controller
      */
     public function index(MismatchesRequest $request)
     {
-        $mismatches = Mismatch::whereIn('item_id', $request->ids)->get();
+        $query = Mismatch::whereIn('item_id', $request->ids);
 
-        return MismatchResource::collection($mismatches);
+        // limit to 'pending',
+        // unless include_reviewed parameter is provided
+        if (!$request->include_reviewed) {
+            $query->where('status', 'pending');
+        }
+
+        // limit to non-expired,
+        // unless include_expired parameter is provided
+        if (!$request->include_expired) {
+            $query->whereHas('importMeta', function ($import) {
+                $import->where('expires', '>=', Carbon::now());
+            });
+        }
+
+        return MismatchResource::collection($query->get());
     }
 }

--- a/app/Http/Controllers/MismatchController.php
+++ b/app/Http/Controllers/MismatchController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers;
 use App\Http\Requests\MismatchesRequest;
 use App\Http\Resources\MismatchResource;
 use App\Models\Mismatch;
-use Carbon\Carbon;
 
 class MismatchController extends Controller
 {
@@ -31,7 +30,7 @@ class MismatchController extends Controller
         // unless include_expired parameter is provided
         if (!$request->include_expired) {
             $query->whereHas('importMeta', function ($import) {
-                $import->where('expires', '>=', Carbon::now());
+                $import->where('expires', '>=', now());
             });
         }
 

--- a/app/Http/Requests/MismatchesRequest.php
+++ b/app/Http/Requests/MismatchesRequest.php
@@ -10,7 +10,7 @@ class MismatchesRequest extends FormRequest
     protected function prepareForValidation()
     {
         $separator = config('mismatches.id_separator');
-        $this->replace(['ids' => explode($separator, $this->ids)]);
+        $this->merge(['ids' => explode($separator, $this->ids)]);
     }
 
     /**

--- a/app/Http/Resources/MismatchResource.php
+++ b/app/Http/Resources/MismatchResource.php
@@ -22,6 +22,7 @@ class MismatchResource extends JsonResource
             'wikidata_value' => $this->wikidata_value,
             'external_value' => $this->external_value,
             'external_url' => $this->external_url,
+            'status' => $this->status,
             'import' => new ImportMetaResource($this->importMeta)
         ];
     }

--- a/database/factories/ImportMetaFactory.php
+++ b/database/factories/ImportMetaFactory.php
@@ -48,4 +48,18 @@ class ImportMetaFactory extends Factory
             ];
         });
     }
+
+    /**
+     * Indicate that the import is expired.
+     *
+     * @return \Illuminate\Database\Eloquent\Factories\Factory
+     */
+    public function expired(string $username = null)
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'expires' => $this->faker->dateTimeBetween('-6 months', '-1 day')->format('Y-m-d'),
+            ];
+        });
+    }
 }

--- a/database/factories/MismatchFactory.php
+++ b/database/factories/MismatchFactory.php
@@ -31,7 +31,7 @@ class MismatchFactory extends Factory
     }
 
     /**
-     * Indicate that a mismatch has been edited
+     * Indicate that a mismatch has been reviewed
      *
      * @return \Illuminate\Database\Eloquent\Factories\Factory
      */

--- a/database/factories/MismatchFactory.php
+++ b/database/factories/MismatchFactory.php
@@ -65,8 +65,11 @@ class MismatchFactory extends Factory
 
     private function getRandomReviewStatus()
     {
-        $reviewStatuses = [ 'wikidata', 'external', 'both', 'none' ];
-        $randomStatusIndex = $this->faker->numberBetween(0, 3);
-        return $reviewStatuses[ $randomStatusIndex ];
+        return $this->faker->randomElement([
+            'wikidata',
+            'external',
+            'both',
+            'none'
+        ]);
     }
 }

--- a/database/factories/MismatchFactory.php
+++ b/database/factories/MismatchFactory.php
@@ -35,11 +35,11 @@ class MismatchFactory extends Factory
      *
      * @return \Illuminate\Database\Eloquent\Factories\Factory
      */
-    public function edited()
+    public function reviewed()
     {
         return $this->state(function (array $attributes) {
             return [
-                'status' => $this->getRandomEditStatus()
+                'status' => $this->getRandomReviewStatus()
             ];
         });
     }
@@ -63,10 +63,10 @@ class MismatchFactory extends Factory
         ]);
     }
 
-    private function getRandomEditStatus()
+    private function getRandomReviewStatus()
     {
-        $editStatuses = [ 'wikidata', 'external', 'both', 'none' ];
+        $reviewStatuses = [ 'wikidata', 'external', 'both', 'none' ];
         $randomStatusIndex = $this->faker->numberBetween(0, 3);
-        return $editStatuses[ $randomStatusIndex ];
+        return $reviewStatuses[ $randomStatusIndex ];
     }
 }

--- a/database/factories/MismatchFactory.php
+++ b/database/factories/MismatchFactory.php
@@ -30,6 +30,20 @@ class MismatchFactory extends Factory
         ];
     }
 
+    /**
+     * Indicate that a mismatch has been edited
+     *
+     * @return \Illuminate\Database\Eloquent\Factories\Factory
+     */
+    public function edited()
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'status' => $this->getRandomEditStatus()
+            ];
+        });
+    }
+
     private function getRandomValue()
     {
         $randomWordAmount = $this->faker->numberBetween(1, 5);
@@ -47,5 +61,12 @@ class MismatchFactory extends Factory
             // A random lorem text with up to 5 words
             $this->faker->words($randomWordAmount, true)
         ]);
+    }
+
+    private function getRandomEditStatus()
+    {
+        $editStatuses = [ 'wikidata', 'external', 'both', 'none' ];
+        $randomStatusIndex = $this->faker->numberBetween(0, 3);
+        return $editStatuses[ $randomStatusIndex ];
     }
 }

--- a/database/seeders/MismatchSeeder.php
+++ b/database/seeders/MismatchSeeder.php
@@ -33,9 +33,14 @@ class MismatchSeeder extends Seeder
             ->for($expiredImport)
             ->create();
 
-        Mismatch::factory(21)
+        Mismatch::factory(10)
             ->for($import)
-            ->edited()
+            ->reviewed()
+            ->create();
+
+        Mismatch::factory(11)
+            ->for($expiredImport)
+            ->reviewed()
             ->create();
     }
 }

--- a/database/seeders/MismatchSeeder.php
+++ b/database/seeders/MismatchSeeder.php
@@ -21,9 +21,9 @@ class MismatchSeeder extends Seeder
             ->create();
 
         $expiredImport = ImportMeta::factory()
-        ->for(User::factory()->uploader())
-        ->expired()
-        ->create();
+            ->for(User::factory()->uploader())
+            ->expired()
+            ->create();
 
         Mismatch::factory(10)
             ->for($import)

--- a/database/seeders/MismatchSeeder.php
+++ b/database/seeders/MismatchSeeder.php
@@ -20,8 +20,17 @@ class MismatchSeeder extends Seeder
             ->for(User::factory()->uploader())
             ->create();
 
-        Mismatch::factory(21)
+        $expiredImport = ImportMeta::factory()
+        ->for(User::factory()->uploader())
+        ->expired()
+        ->create();
+
+        Mismatch::factory(10)
             ->for($import)
+            ->create();
+
+        Mismatch::factory(11)
+            ->for($expiredImport)
             ->create();
 
         Mismatch::factory(21)

--- a/database/seeders/MismatchSeeder.php
+++ b/database/seeders/MismatchSeeder.php
@@ -20,8 +20,13 @@ class MismatchSeeder extends Seeder
             ->for(User::factory()->uploader())
             ->create();
 
-        Mismatch::factory(42)
+        Mismatch::factory(21)
             ->for($import)
+            ->create();
+
+        Mismatch::factory(21)
+            ->for($import)
+            ->edited()
             ->create();
     }
 }

--- a/database/seeders/MismatchSeeder.php
+++ b/database/seeders/MismatchSeeder.php
@@ -23,7 +23,9 @@ class MismatchSeeder extends Seeder
         $expiredImport = ImportMeta::factory()
             ->for(User::factory()->uploader())
             ->expired()
-            ->create();
+            ->create([
+                'status' => 'completed'
+            ]);
 
         Mismatch::factory(10)
             ->for($import)

--- a/docs/mismatchfinder-api-spec.yml
+++ b/docs/mismatchfinder-api-spec.yml
@@ -16,18 +16,18 @@ paths:
             type: string
           required: true
           description: List of |-separated item IDs to get mismatches for
-        - name: status
+        - name: include_reviewed
           in: query
           schema:
-            type: string
-            enum:
-              - pending
-              - wikidata
-              - external
-              - both
-              - none
+            type: boolean
           required: false
-          description: Status(es) to filter mismatches by
+          description: "Include reviewed mismatches? (default: false)"
+        - name: include_expired
+          in: query
+          schema:
+            type: boolean
+          required: false
+          description: "Include expired mismatches? (default: false)"
       responses:
         '200':
           description: A list of mismatches, potentially empty if none are found.
@@ -195,6 +195,14 @@ components:
           type: string
         external_url:
           type: string
+        status:
+          type: string
+          enum:
+            - pending
+            - wikidata
+            - external
+            - both
+            - none
         import:
           type: object
           $ref: '#/components/schemas/ImportMeta'

--- a/tests/Feature/ApiMismatchRouteTest.php
+++ b/tests/Feature/ApiMismatchRouteTest.php
@@ -8,7 +8,6 @@ use App\Models\Mismatch;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
-use Laravel\Sanctum\Sanctum;
 use Illuminate\Foundation\Testing\WithFaker;
 
 class ApiMismatchRouteTest extends TestCase
@@ -77,13 +76,15 @@ class ApiMismatchRouteTest extends TestCase
         $pendingMismatches = Mismatch::factory(3)->for($import)->create();
         $reviewedMismatches = Mismatch::factory(3)->for($import)->reviewed()->create();
         $expiredMismatches = Mismatch::factory(3)->for($expiredImport)->create();
+        $expiredReviewedMismatches = Mismatch::factory(3)->for($expiredImport)->reviewed()->create();
         $response = $this->json(
             'GET',
             self::MISMATCH_ROUTE,
-            ['ids' =>
-                $pendingMismatches->implode('item_id', '|') . '|' .
-                $reviewedMismatches->implode('item_id', '|') . '|' .
-                $expiredMismatches->implode('item_id', '|')
+            [
+                'ids' => $pendingMismatches->implode('item_id', '|') . '|' .
+                         $reviewedMismatches->implode('item_id', '|') . '|' .
+                         $expiredMismatches->implode('item_id', '|') . '|' .
+                         $expiredReviewedMismatches->implode('item_id', '|')
             ]
         );
 
@@ -91,7 +92,7 @@ class ApiMismatchRouteTest extends TestCase
             ->assertJsonCount($pendingMismatches->count());
     }
 
-    public function test_query_including_reviewed()
+    public function test_query_including_reviewed_returns_reviewed_mismatches()
     {
         $import = ImportMeta::factory()
         ->for(User::factory()->uploader())
@@ -105,13 +106,15 @@ class ApiMismatchRouteTest extends TestCase
         $pendingMismatches = Mismatch::factory(3)->for($import)->create();
         $reviewedMismatches = Mismatch::factory(3)->for($import)->reviewed()->create();
         $expiredMismatches = Mismatch::factory(3)->for($expiredImport)->create();
+        $expiredReviewedMismatches = Mismatch::factory(3)->for($expiredImport)->reviewed()->create();
         $response = $this->json(
             'GET',
             self::MISMATCH_ROUTE,
             [
                 'ids' => $pendingMismatches->implode('item_id', '|') . '|' .
                          $reviewedMismatches->implode('item_id', '|') . '|' .
-                         $expiredMismatches->implode('item_id', '|'),
+                         $expiredMismatches->implode('item_id', '|') . '|' .
+                         $expiredReviewedMismatches->implode('item_id', '|'),
                 'include_reviewed' => true
             ]
         );
@@ -120,7 +123,7 @@ class ApiMismatchRouteTest extends TestCase
             ->assertJsonCount($pendingMismatches->count() + $reviewedMismatches->count());
     }
 
-    public function test_query_including_expired()
+    public function test_query_including_expired_returns_expired_mismatches()
     {
         $import = ImportMeta::factory()
         ->for(User::factory()->uploader())
@@ -134,13 +137,15 @@ class ApiMismatchRouteTest extends TestCase
         $pendingMismatches = Mismatch::factory(3)->for($import)->create();
         $reviewedMismatches = Mismatch::factory(3)->for($import)->reviewed()->create();
         $expiredMismatches = Mismatch::factory(3)->for($expiredImport)->create();
+        $expiredReviewedMismatches = Mismatch::factory(3)->for($expiredImport)->reviewed()->create();
         $response = $this->json(
             'GET',
             self::MISMATCH_ROUTE,
             [
                 'ids' => $pendingMismatches->implode('item_id', '|') . '|' .
                          $reviewedMismatches->implode('item_id', '|') . '|' .
-                         $expiredMismatches->implode('item_id', '|'),
+                         $expiredMismatches->implode('item_id', '|') . '|' .
+                         $expiredReviewedMismatches->implode('item_id', '|'),
                 'include_expired' => true
             ]
         );
@@ -149,7 +154,7 @@ class ApiMismatchRouteTest extends TestCase
             ->assertJsonCount($pendingMismatches->count() + $expiredMismatches->count());
     }
 
-    public function test_query_including_reviewed_and_expired()
+    public function test_query_including_reviewed_and_expired_returns_all_mismatches()
     {
         $import = ImportMeta::factory()
         ->for(User::factory()->uploader())

--- a/tests/Feature/ApiMismatchRouteTest.php
+++ b/tests/Feature/ApiMismatchRouteTest.php
@@ -71,7 +71,9 @@ class ApiMismatchRouteTest extends TestCase
         $expiredImport = ImportMeta::factory()
             ->for(User::factory()->uploader())
             ->expired()
-            ->create();
+            ->create([
+                'status' => 'completed'
+            ]);
 
         $pendingMismatches = Mismatch::factory(3)->for($import)->create();
         $reviewedMismatches = Mismatch::factory(3)->for($import)->reviewed()->create();
@@ -101,7 +103,9 @@ class ApiMismatchRouteTest extends TestCase
         $expiredImport = ImportMeta::factory()
             ->for(User::factory()->uploader())
             ->expired()
-            ->create();
+            ->create([
+                'status' => 'completed'
+            ]);
 
         $pendingMismatches = Mismatch::factory(3)->for($import)->create();
         $reviewedMismatches = Mismatch::factory(3)->for($import)->reviewed()->create();
@@ -132,7 +136,9 @@ class ApiMismatchRouteTest extends TestCase
         $expiredImport = ImportMeta::factory()
             ->for(User::factory()->uploader())
             ->expired()
-            ->create();
+            ->create([
+                'status' => 'completed'
+            ]);
 
         $pendingMismatches = Mismatch::factory(3)->for($import)->create();
         $reviewedMismatches = Mismatch::factory(3)->for($import)->reviewed()->create();
@@ -163,7 +169,9 @@ class ApiMismatchRouteTest extends TestCase
         $expiredImport = ImportMeta::factory()
             ->for(User::factory()->uploader())
             ->expired()
-            ->create();
+            ->create([
+                'status' => 'completed'
+            ]);
 
         $pendingMismatches = Mismatch::factory(3)->for($import)->create();
         $reviewedMismatches = Mismatch::factory(3)->for($import)->reviewed()->create();

--- a/tests/Feature/ApiMismatchRouteTest.php
+++ b/tests/Feature/ApiMismatchRouteTest.php
@@ -24,8 +24,8 @@ class ApiMismatchRouteTest extends TestCase
     public function test_single_mismatch_returns_correct_data()
     {
         $import = ImportMeta::factory()
-        ->for(User::factory()->uploader())
-        ->create();
+           ->for(User::factory()->uploader())
+           ->create();
 
         $mismatch = Mismatch::factory()->for($import)->create();
 
@@ -65,13 +65,13 @@ class ApiMismatchRouteTest extends TestCase
     public function test_multiple_mismatches_do_not_return_edited_or_expired()
     {
         $import = ImportMeta::factory()
-        ->for(User::factory()->uploader())
-        ->create();
+            ->for(User::factory()->uploader())
+            ->create();
 
         $expiredImport = ImportMeta::factory()
-        ->for(User::factory()->uploader())
-        ->expired()
-        ->create();
+            ->for(User::factory()->uploader())
+            ->expired()
+            ->create();
 
         $pendingMismatches = Mismatch::factory(3)->for($import)->create();
         $reviewedMismatches = Mismatch::factory(3)->for($import)->reviewed()->create();
@@ -95,13 +95,13 @@ class ApiMismatchRouteTest extends TestCase
     public function test_query_including_reviewed_returns_reviewed_mismatches()
     {
         $import = ImportMeta::factory()
-        ->for(User::factory()->uploader())
-        ->create();
+            ->for(User::factory()->uploader())
+            ->create();
 
         $expiredImport = ImportMeta::factory()
-        ->for(User::factory()->uploader())
-        ->expired()
-        ->create();
+            ->for(User::factory()->uploader())
+            ->expired()
+            ->create();
 
         $pendingMismatches = Mismatch::factory(3)->for($import)->create();
         $reviewedMismatches = Mismatch::factory(3)->for($import)->reviewed()->create();
@@ -126,13 +126,13 @@ class ApiMismatchRouteTest extends TestCase
     public function test_query_including_expired_returns_expired_mismatches()
     {
         $import = ImportMeta::factory()
-        ->for(User::factory()->uploader())
-        ->create();
+            ->for(User::factory()->uploader())
+            ->create();
 
         $expiredImport = ImportMeta::factory()
-        ->for(User::factory()->uploader())
-        ->expired()
-        ->create();
+            ->for(User::factory()->uploader())
+            ->expired()
+            ->create();
 
         $pendingMismatches = Mismatch::factory(3)->for($import)->create();
         $reviewedMismatches = Mismatch::factory(3)->for($import)->reviewed()->create();
@@ -157,13 +157,13 @@ class ApiMismatchRouteTest extends TestCase
     public function test_query_including_reviewed_and_expired_returns_all_mismatches()
     {
         $import = ImportMeta::factory()
-        ->for(User::factory()->uploader())
-        ->create();
+            ->for(User::factory()->uploader())
+            ->create();
 
         $expiredImport = ImportMeta::factory()
-        ->for(User::factory()->uploader())
-        ->expired()
-        ->create();
+            ->for(User::factory()->uploader())
+            ->expired()
+            ->create();
 
         $pendingMismatches = Mismatch::factory(3)->for($import)->create();
         $reviewedMismatches = Mismatch::factory(3)->for($import)->reviewed()->create();
@@ -195,10 +195,10 @@ class ApiMismatchRouteTest extends TestCase
     {
         $response = $this->json('GET', self::MISMATCH_ROUTE);  // ids missing
         $response->assertJsonValidationErrors([
-                'ids.0' => __('validation.required', [
-                    'attribute' => 'ids.0'
-                ])
-            ]);
+            'ids.0' => __('validation.required', [
+                'attribute' => 'ids.0'
+            ])
+        ]);
     }
 
     public function test_too_many_item_ids_returns_validation_error()
@@ -212,11 +212,11 @@ class ApiMismatchRouteTest extends TestCase
         );
 
         $response->assertJsonValidationErrors([
-                'ids' => __('validation.max.array', [
-                    'attribute' => 'ids',
-                    'max' => $maxItemIds
-                ])
-            ]);
+            'ids' => __('validation.max.array', [
+                'attribute' => 'ids',
+                'max' => $maxItemIds
+            ])
+        ]);
     }
 
     public function test_invalid_item_id_returns_validation_error()
@@ -228,9 +228,9 @@ class ApiMismatchRouteTest extends TestCase
         );
 
         $response->assertJsonValidationErrors([
-                'ids.0' => __('validation.regex', [
-                    'attribute' => 'ids.0'
-                ])
-            ]);
+            'ids.0' => __('validation.regex', [
+                'attribute' => 'ids.0'
+            ])
+        ]);
     }
 }


### PR DESCRIPTION
This modifies the /mismatches endpoint, so that it only returns mismatches that have not been edited yet and that do not belong to expired imports. Two optional request parameters are added, which allow including reviewed mismatches or expired ones.

Bug: [T285301](https://phabricator.wikimedia.org/T285301)