### PR TITLE
Set up localization

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,3 +27,6 @@ jobs:
 
         - name: Run ESLint
           run: npm run lint
+
+        - name: Run i18 Validation
+          run: npm run i18n:validate

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -21,6 +21,7 @@ class Kernel extends HttpKernel
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
         \App\Http\Middleware\TrimStrings::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
+        \App\Http\Middleware\SetLocale::class
     ];
 
     /**

--- a/app/Http/Middleware/SetLocale.php
+++ b/app/Http/Middleware/SetLocale.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\App;
+
+class SetLocale
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $locale = $request->query('uselang');
+        $translated = $locale && file_exists(public_path('i18n/' .$locale . '.json'));
+
+        if($translated){
+            App::setLocale($locale);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/SetLocale.php
+++ b/app/Http/Middleware/SetLocale.php
@@ -20,7 +20,7 @@ class SetLocale
         $locale = $request->query('uselang');
         $translated = $locale && file_exists(public_path('i18n/' .$locale . '.json'));
 
-        if($translated){
+        if ($translated) {
             App::setLocale($locale);
         }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -165,7 +165,13 @@ sail npm run dev
 
 ## Localization and Internationalization
 
-The Mismatch Finder application employs two separate localization systems: one for the server-side Laravel  app, and another for the vue based clinet-side application.
+The Mismatch Finder application employs two separate localization systems: one for the server-side Laravel  app, and another for the vue based client-side application.
+
+To switch to any other language than English, set the `uselang` parameter in the URL. For example, to set the language to German:
+
+```
+http://<your-localhost>/?uselang=de
+```
 
 On the server side, we fully employ the default [Laravel localization system](https://laravel.com/docs/8.x/localization) and syntax, and messages in the server side should be added as or to php files in the `resources/lang/en` directory.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -163,6 +163,20 @@ To manually compile assets for your local dev environment run:
 sail npm run dev
 ```
 
+## Localization and Internationalization
+
+The Mismatch Finder application employs two separate localization systems: one for the server-side Laravel  app, and another for the vue based clinet-side application.
+
+On the server side, we fully employ the default [Laravel localization system](https://laravel.com/docs/8.x/localization) and syntax, and messages in the server side should be added as or to php files in the `resources/lang/en` directory.
+
+The client side localization system utilizes the [banana-i18n](https://www.npmjs.com/package/banana-i18n) library and format. Messages for the client side application are kept in the `public/i18n/` directory, and are served in order to be consumed by the vue client. Each message that is added to the `en.json` file, should be documented in the `qqq.json` file as well, to provide more context for translators.
+
+To ensure that your client side localization files are valid, run:
+
+```
+sail npm run i18n:validate
+```
+
 ## Linting <a id="linting"></a>
 ### PHP Linting <a id="php-linting"></a>
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,9 +5,11 @@ module.exports = {
     ],
     // vue: transform vue with vue-jest to make jest understand Vue's syntax
     // js: transform js files with babel, we can now use import statements in tests
+    // ts: transform ts files with babel, to import ts files into js specs
     "transform": {
         ".*\\.(vue)$": "<rootDir>/node_modules/vue-jest",
-        "^.+\\.js$": "<rootDir>/node_modules/babel-jest"
+        "^.+\\.js$": "<rootDir>/node_modules/babel-jest",
+        "^.+\\.tsx?$": "<rootDir>/node_modules/ts-jest"
     },
     // (Optional) This file helps you later for global settings
     "setupFilesAfterEnv": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
                 "babel-core": "^7.0.0-bridge.0",
                 "eslint": "^7.32.0",
                 "eslint-plugin-vue": "^7.16.0",
+                "grunt-banana-checker": "^0.9.0",
                 "jest": "^26.6.3",
                 "laravel-mix": "^6.0.6",
                 "lodash": "^4.17.19",
@@ -7067,6 +7068,18 @@
             "version": "1.3.0",
             "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
             "dev": true
+        },
+        "node_modules/grunt-banana-checker": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/grunt-banana-checker/-/grunt-banana-checker-0.9.0.tgz",
+            "integrity": "sha512-SqPiB6OazWqR8USL0NymtuT5Br3mD9WBBsM1rHC/3wIi2SrZNM6/+j9CIeuEM5oCn+AtO2Y0+rzzFyOdC9afAg==",
+            "dev": true,
+            "bin": {
+                "banana-checker": "src/cli.js"
+            },
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/handle-thing": {
             "version": "2.0.1",
@@ -20511,6 +20524,12 @@
         "growly": {
             "version": "1.3.0",
             "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+            "dev": true
+        },
+        "grunt-banana-checker": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/grunt-banana-checker/-/grunt-banana-checker-0.9.0.tgz",
+            "integrity": "sha512-SqPiB6OazWqR8USL0NymtuT5Br3mD9WBBsM1rHC/3wIi2SrZNM6/+j9CIeuEM5oCn+AtO2Y0+rzzFyOdC9afAg==",
             "dev": true
         },
         "handle-thing": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
                 "@inertiajs/inertia-vue": "^0.7.2",
                 "@wmde/wikit-tokens": "^2.0.0",
                 "@wmde/wikit-vue-components": "^2.0.0",
-                "vue": "^2.6.14"
+                "vue": "^2.6.14",
+                "vue-banana-i18n": "^1.5.0"
             },
             "devDependencies": {
                 "@types/jest": "^27.0.1",
@@ -3785,6 +3786,11 @@
             "version": "1.0.2",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
+        },
+        "node_modules/banana-i18n": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/banana-i18n/-/banana-i18n-2.2.0.tgz",
+            "integrity": "sha512-PD8mgDtaDpVJiWUNGiXSTUhUzdSHDtkr1urz6d2PZ8lgjHdLvFKk32KDPKndf8ROfBN68UK2Gs7/SsRYRZQnSA=="
         },
         "node_modules/base": {
             "version": "0.11.2",
@@ -14343,6 +14349,14 @@
             "version": "2.6.14",
             "integrity": "sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ=="
         },
+        "node_modules/vue-banana-i18n": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/vue-banana-i18n/-/vue-banana-i18n-1.5.0.tgz",
+            "integrity": "sha512-HG7Rr2lKdWS23ydF4HUNCTnCVQk5Q3G6qRPW+IXvd3QpE+UZXC7bRDFED4CSPQnzAKXtAkUR58jDv7nRlG7gbg==",
+            "dependencies": {
+                "banana-i18n": "^2.2.0"
+            }
+        },
         "node_modules/vue-eslint-parser": {
             "version": "7.10.0",
             "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-7.10.0.tgz",
@@ -17927,6 +17941,11 @@
             "version": "1.0.2",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
+        },
+        "banana-i18n": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/banana-i18n/-/banana-i18n-2.2.0.tgz",
+            "integrity": "sha512-PD8mgDtaDpVJiWUNGiXSTUhUzdSHDtkr1urz6d2PZ8lgjHdLvFKk32KDPKndf8ROfBN68UK2Gs7/SsRYRZQnSA=="
         },
         "base": {
             "version": "0.11.2",
@@ -26030,6 +26049,14 @@
         "vue": {
             "version": "2.6.14",
             "integrity": "sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ=="
+        },
+        "vue-banana-i18n": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/vue-banana-i18n/-/vue-banana-i18n-1.5.0.tgz",
+            "integrity": "sha512-HG7Rr2lKdWS23ydF4HUNCTnCVQk5Q3G6qRPW+IXvd3QpE+UZXC7bRDFED4CSPQnzAKXtAkUR58jDv7nRlG7gbg==",
+            "requires": {
+                "banana-i18n": "^2.2.0"
+            }
         },
         "vue-eslint-parser": {
             "version": "7.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "wikidata-mismatch-finder",
+    "name": "html",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
@@ -12,6 +12,7 @@
                 "vue": "^2.6.14"
             },
             "devDependencies": {
+                "@types/jest": "^27.0.1",
                 "@typescript-eslint/eslint-plugin": "^4.29.1",
                 "@typescript-eslint/parser": "^4.29.1",
                 "@vue/eslint-config-typescript": "^7.0.0",
@@ -27,6 +28,7 @@
                 "resolve-url-loader": "^4.0.0",
                 "sass": "^1.35.2",
                 "sass-loader": "^12.1.0",
+                "ts-jest": "^26.5.6",
                 "ts-loader": "^9.2.5",
                 "typescript": "^4.3.5",
                 "vue-jest": "^3.0.7",
@@ -2290,6 +2292,101 @@
                 "@types/istanbul-lib-report": "*"
             }
         },
+        "node_modules/@types/jest": {
+            "version": "27.0.1",
+            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.0.1.tgz",
+            "integrity": "sha512-HTLpVXHrY69556ozYkcq47TtQJXpcWAWfkoqz+ZGz2JnmZhzlRjprCIyFnetSy8gpDWwTTGBcRVv1J1I1vBrHw==",
+            "dev": true,
+            "dependencies": {
+                "jest-diff": "^27.0.0",
+                "pretty-format": "^27.0.0"
+            }
+        },
+        "node_modules/@types/jest/node_modules/@jest/types": {
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
+            "integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
+            "dev": true,
+            "dependencies": {
+                "@types/istanbul-lib-coverage": "^2.0.0",
+                "@types/istanbul-reports": "^3.0.0",
+                "@types/node": "*",
+                "@types/yargs": "^16.0.0",
+                "chalk": "^4.0.0"
+            },
+            "engines": {
+                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+            }
+        },
+        "node_modules/@types/jest/node_modules/@types/yargs": {
+            "version": "16.0.4",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+            "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+            "dev": true,
+            "dependencies": {
+                "@types/yargs-parser": "*"
+            }
+        },
+        "node_modules/@types/jest/node_modules/ansi-styles": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@types/jest/node_modules/diff-sequences": {
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.0.6.tgz",
+            "integrity": "sha512-ag6wfpBFyNXZ0p8pcuIDS//D8H062ZQJ3fzYxjpmeKjnz8W4pekL3AI8VohmyZmsWW2PWaHgjsmqR6L13101VQ==",
+            "dev": true,
+            "engines": {
+                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+            }
+        },
+        "node_modules/@types/jest/node_modules/jest-diff": {
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.0.6.tgz",
+            "integrity": "sha512-Z1mqgkTCSYaFgwTlP/NUiRzdqgxmmhzHY1Tq17zL94morOHfHu3K4bgSgl+CR4GLhpV8VxkuOYuIWnQ9LnFqmg==",
+            "dev": true,
+            "dependencies": {
+                "chalk": "^4.0.0",
+                "diff-sequences": "^27.0.6",
+                "jest-get-type": "^27.0.6",
+                "pretty-format": "^27.0.6"
+            },
+            "engines": {
+                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+            }
+        },
+        "node_modules/@types/jest/node_modules/jest-get-type": {
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.0.6.tgz",
+            "integrity": "sha512-XTkK5exIeUbbveehcSR8w0bhH+c0yloW/Wpl+9vZrjzztCPWrxhHwkIFpZzCt71oRBsgxmuUfxEqOYoZI2macg==",
+            "dev": true,
+            "engines": {
+                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+            }
+        },
+        "node_modules/@types/jest/node_modules/pretty-format": {
+            "version": "27.0.6",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.6.tgz",
+            "integrity": "sha512-8tGD7gBIENgzqA+UBzObyWqQ5B778VIFZA/S66cclyd5YkFLYs2Js7gxDKf0MXtTc9zcS7t1xhdfcElJ3YIvkQ==",
+            "dev": true,
+            "dependencies": {
+                "@jest/types": "^27.0.6",
+                "ansi-regex": "^5.0.0",
+                "ansi-styles": "^5.0.0",
+                "react-is": "^17.0.1"
+            },
+            "engines": {
+                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+            }
+        },
         "node_modules/@types/json-schema": {
             "version": "7.0.7",
             "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
@@ -3950,6 +4047,18 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/browserslist"
+            }
+        },
+        "node_modules/bs-logger": {
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+            "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+            "dev": true,
+            "dependencies": {
+                "fast-json-stable-stringify": "2.x"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/bser": {
@@ -9395,6 +9504,12 @@
                 "semver": "bin/semver.js"
             }
         },
+        "node_modules/make-error": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+            "dev": true
+        },
         "node_modules/makeerror": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
@@ -13747,6 +13862,46 @@
                 "node": ">=8"
             }
         },
+        "node_modules/ts-jest": {
+            "version": "26.5.6",
+            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.5.6.tgz",
+            "integrity": "sha512-rua+rCP8DxpA8b4DQD/6X2HQS8Zy/xzViVYfEs2OQu68tkCuKLV0Md8pmX55+W24uRIyAsf/BajRfxOs+R2MKA==",
+            "dev": true,
+            "dependencies": {
+                "bs-logger": "0.x",
+                "buffer-from": "1.x",
+                "fast-json-stable-stringify": "2.x",
+                "jest-util": "^26.1.0",
+                "json5": "2.x",
+                "lodash": "4.x",
+                "make-error": "1.x",
+                "mkdirp": "1.x",
+                "semver": "7.x",
+                "yargs-parser": "20.x"
+            },
+            "bin": {
+                "ts-jest": "cli.js"
+            },
+            "engines": {
+                "node": ">= 10"
+            },
+            "peerDependencies": {
+                "jest": ">=26 <27",
+                "typescript": ">=3.8 <5.0"
+            }
+        },
+        "node_modules/ts-jest/node_modules/mkdirp": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+            "dev": true,
+            "bin": {
+                "mkdirp": "bin/cmd.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/ts-loader": {
             "version": "9.2.5",
             "integrity": "sha512-al/ATFEffybdRMUIr5zMEWQdVnCGMUA9d3fXJ8dBVvBlzytPvIszoG9kZoR+94k6/i293RnVOXwMaWbXhNy9pQ==",
@@ -16547,6 +16702,82 @@
                 "@types/istanbul-lib-report": "*"
             }
         },
+        "@types/jest": {
+            "version": "27.0.1",
+            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.0.1.tgz",
+            "integrity": "sha512-HTLpVXHrY69556ozYkcq47TtQJXpcWAWfkoqz+ZGz2JnmZhzlRjprCIyFnetSy8gpDWwTTGBcRVv1J1I1vBrHw==",
+            "dev": true,
+            "requires": {
+                "jest-diff": "^27.0.0",
+                "pretty-format": "^27.0.0"
+            },
+            "dependencies": {
+                "@jest/types": {
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.0.6.tgz",
+                    "integrity": "sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==",
+                    "dev": true,
+                    "requires": {
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^3.0.0",
+                        "@types/node": "*",
+                        "@types/yargs": "^16.0.0",
+                        "chalk": "^4.0.0"
+                    }
+                },
+                "@types/yargs": {
+                    "version": "16.0.4",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+                    "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+                    "dev": true,
+                    "requires": {
+                        "@types/yargs-parser": "*"
+                    }
+                },
+                "ansi-styles": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+                    "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+                    "dev": true
+                },
+                "diff-sequences": {
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.0.6.tgz",
+                    "integrity": "sha512-ag6wfpBFyNXZ0p8pcuIDS//D8H062ZQJ3fzYxjpmeKjnz8W4pekL3AI8VohmyZmsWW2PWaHgjsmqR6L13101VQ==",
+                    "dev": true
+                },
+                "jest-diff": {
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.0.6.tgz",
+                    "integrity": "sha512-Z1mqgkTCSYaFgwTlP/NUiRzdqgxmmhzHY1Tq17zL94morOHfHu3K4bgSgl+CR4GLhpV8VxkuOYuIWnQ9LnFqmg==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^4.0.0",
+                        "diff-sequences": "^27.0.6",
+                        "jest-get-type": "^27.0.6",
+                        "pretty-format": "^27.0.6"
+                    }
+                },
+                "jest-get-type": {
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.0.6.tgz",
+                    "integrity": "sha512-XTkK5exIeUbbveehcSR8w0bhH+c0yloW/Wpl+9vZrjzztCPWrxhHwkIFpZzCt71oRBsgxmuUfxEqOYoZI2macg==",
+                    "dev": true
+                },
+                "pretty-format": {
+                    "version": "27.0.6",
+                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.0.6.tgz",
+                    "integrity": "sha512-8tGD7gBIENgzqA+UBzObyWqQ5B778VIFZA/S66cclyd5YkFLYs2Js7gxDKf0MXtTc9zcS7t1xhdfcElJ3YIvkQ==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^27.0.6",
+                        "ansi-regex": "^5.0.0",
+                        "ansi-styles": "^5.0.0",
+                        "react-is": "^17.0.1"
+                    }
+                }
+            }
+        },
         "@types/json-schema": {
             "version": "7.0.7",
             "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
@@ -17871,6 +18102,15 @@
                 "electron-to-chromium": "^1.3.723",
                 "escalade": "^3.1.1",
                 "node-releases": "^1.1.71"
+            }
+        },
+        "bs-logger": {
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+            "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+            "dev": true,
+            "requires": {
+                "fast-json-stable-stringify": "2.x"
             }
         },
         "bser": {
@@ -22095,6 +22335,12 @@
                 }
             }
         },
+        "make-error": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+            "dev": true
+        },
         "makeerror": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
@@ -25372,6 +25618,32 @@
             "dev": true,
             "requires": {
                 "punycode": "^2.1.1"
+            }
+        },
+        "ts-jest": {
+            "version": "26.5.6",
+            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.5.6.tgz",
+            "integrity": "sha512-rua+rCP8DxpA8b4DQD/6X2HQS8Zy/xzViVYfEs2OQu68tkCuKLV0Md8pmX55+W24uRIyAsf/BajRfxOs+R2MKA==",
+            "dev": true,
+            "requires": {
+                "bs-logger": "0.x",
+                "buffer-from": "1.x",
+                "fast-json-stable-stringify": "2.x",
+                "jest-util": "^26.1.0",
+                "json5": "2.x",
+                "lodash": "4.x",
+                "make-error": "1.x",
+                "mkdirp": "1.x",
+                "semver": "7.x",
+                "yargs-parser": "20.x"
+            },
+            "dependencies": {
+                "mkdirp": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+                    "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+                    "dev": true
+                }
             }
         },
         "ts-loader": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
                 "@vue/eslint-config-typescript": "^7.0.0",
                 "@vue/test-utils": "^1.2.2",
                 "axios": "^0.21",
+                "axios-mock-adapter": "^1.20.0",
                 "babel-core": "^7.0.0-bridge.0",
                 "eslint": "^7.32.0",
                 "eslint-plugin-vue": "^7.16.0",
@@ -3359,6 +3360,43 @@
             "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
             "dependencies": {
                 "follow-redirects": "^1.10.0"
+            }
+        },
+        "node_modules/axios-mock-adapter": {
+            "version": "1.20.0",
+            "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.20.0.tgz",
+            "integrity": "sha512-shZRhTjLP0WWdcvHKf3rH3iW9deb3UdKbdnKUoHmmsnBhVXN3sjPJM6ZvQ2r/ywgvBVQrMnjrSyQab60G1sr2w==",
+            "dev": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "is-blob": "^2.1.0",
+                "is-buffer": "^2.0.5"
+            },
+            "peerDependencies": {
+                "axios": ">= 0.9.0"
+            }
+        },
+        "node_modules/axios-mock-adapter/node_modules/is-buffer": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+            "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/babel-code-frame": {
@@ -7803,6 +7841,18 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/is-blob": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-blob/-/is-blob-2.1.0.tgz",
+            "integrity": "sha512-SZ/fTft5eUhQM6oF/ZaASFDEdbFVe89Imltn9uZr03wdKMcWNVYSMjQPFtg05QuNkt5l5c135ElvXEQG0rk4tw==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-buffer": {
@@ -17530,6 +17580,25 @@
                 "follow-redirects": "^1.10.0"
             }
         },
+        "axios-mock-adapter": {
+            "version": "1.20.0",
+            "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.20.0.tgz",
+            "integrity": "sha512-shZRhTjLP0WWdcvHKf3rH3iW9deb3UdKbdnKUoHmmsnBhVXN3sjPJM6ZvQ2r/ywgvBVQrMnjrSyQab60G1sr2w==",
+            "dev": true,
+            "requires": {
+                "fast-deep-equal": "^3.1.3",
+                "is-blob": "^2.1.0",
+                "is-buffer": "^2.0.5"
+            },
+            "dependencies": {
+                "is-buffer": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+                    "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+                    "dev": true
+                }
+            }
+        },
         "babel-code-frame": {
             "version": "6.26.0",
             "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
@@ -21009,6 +21078,12 @@
             "requires": {
                 "binary-extensions": "^2.0.0"
             }
+        },
+        "is-blob": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-blob/-/is-blob-2.1.0.tgz",
+            "integrity": "sha512-SZ/fTft5eUhQM6oF/ZaASFDEdbFVe89Imltn9uZr03wdKMcWNVYSMjQPFtg05QuNkt5l5c135ElvXEQG0rk4tw==",
+            "dev": true
         },
         "is-buffer": {
             "version": "1.1.6",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
         "@vue/eslint-config-typescript": "^7.0.0",
         "@vue/test-utils": "^1.2.2",
         "axios": "^0.21",
+        "axios-mock-adapter": "^1.20.0",
         "babel-core": "^7.0.0-bridge.0",
         "eslint": "^7.32.0",
         "eslint-plugin-vue": "^7.16.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "scripts": {
         "lint": "eslint --ext .js,.vue resources/js",
         "lint:fix": "eslint --fix --ext .js,.vue resources/js",
+        "i18n:validate": "banana-checker public/i18n",
         "test": "jest",
         "dev": "npm run development",
         "development": "mix",
@@ -23,6 +24,7 @@
         "babel-core": "^7.0.0-bridge.0",
         "eslint": "^7.32.0",
         "eslint-plugin-vue": "^7.16.0",
+        "grunt-banana-checker": "^0.9.0",
         "jest": "^26.6.3",
         "laravel-mix": "^6.0.6",
         "lodash": "^4.17.19",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
         "production": "mix --production"
     },
     "devDependencies": {
+        "@types/jest": "^27.0.1",
         "@typescript-eslint/eslint-plugin": "^4.29.1",
         "@typescript-eslint/parser": "^4.29.1",
         "@vue/eslint-config-typescript": "^7.0.0",
@@ -28,6 +29,7 @@
         "resolve-url-loader": "^4.0.0",
         "sass": "^1.35.2",
         "sass-loader": "^12.1.0",
+        "ts-jest": "^26.5.6",
         "ts-loader": "^9.2.5",
         "typescript": "^4.3.5",
         "vue-jest": "^3.0.7",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
         "@inertiajs/inertia-vue": "^0.7.2",
         "@wmde/wikit-tokens": "^2.0.0",
         "@wmde/wikit-vue-components": "^2.0.0",
-        "vue": "^2.6.14"
+        "vue": "^2.6.14",
+        "vue-banana-i18n": "^1.5.0"
     }
 }

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -1,0 +1,3 @@
+{
+    "some-key": "Some English value"
+}

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -1,3 +1,3 @@
 {
-    "some-key": "Some English value"
+    "test-string": "This is a test string to ensure i18n is working, it should be deleted ASAP"
 }

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -1,3 +1,10 @@
 {
+    "@metadata": {
+        "authors": [
+            "ItamarWMDE"
+        ],
+        "locale": "en",
+        "message-documentation": "qqq"
+    },
     "test-string": "This is a test string to ensure i18n is working, it should be deleted ASAP"
 }

--- a/public/i18n/qqq.json
+++ b/public/i18n/qqq.json
@@ -1,0 +1,3 @@
+{
+    "test-string": "This is string that describes a test string which should be deleted ASAP"
+}

--- a/public/i18n/qqq.json
+++ b/public/i18n/qqq.json
@@ -1,3 +1,8 @@
 {
+    "@metadata": {
+        "authors": [
+            "ItamarWMDE"
+        ]
+    },
     "test-string": "This is string that describes a test string which should be deleted ASAP"
 }

--- a/resources/js/Pages/Error.vue
+++ b/resources/js/Pages/Error.vue
@@ -1,0 +1,17 @@
+<template>
+  <div>
+    <H1>{{ title }}</H1>
+    <div>{{ description }}</div>
+  </div>
+</template>
+
+<script>
+import Vue from 'vue';
+
+export default Vue.extend({
+  props: {
+    title: String,
+    description: String
+  }
+});
+</script>

--- a/resources/js/Pages/Home.vue
+++ b/resources/js/Pages/Home.vue
@@ -3,6 +3,7 @@
     <Head title="Mismatch Finder" />
     <h1>Mismatch Finder</h1>
     <p>This page is coming soon!</p>
+    <p>{{ $i18n('test-string') }}</p>
     <auth-widget v-bind:user="user" />
     <Button type="progressive" variant="primary" @click.native="console">Test Wikit Component</Button>
   </div>

--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -1,14 +1,33 @@
-// import './bootstrap';
+import './bootstrap';
 import Vue from 'vue';
+import i18n from 'vue-banana-i18n';
 import { createInertiaApp } from '@inertiajs/inertia-vue';
-
-const app = document.getElementById('app');
+import i18nMessages from './lib/i18n';
+import Error from './Pages/Error.vue';
 
 createInertiaApp({
   resolve: name => require(`./Pages/${name}`),
   setup({ el, app, props }) {
-    new Vue({
-      render: h => h(app, props),
-    }).$mount(el)
+      (async () => {
+        try {
+            const locale = document.documentElement.lang;
+            const messages = await i18nMessages(locale);
+
+            Vue.use(i18n, { locale, messages });
+
+            new Vue({
+                render: h => h(app, props),
+            }).$mount(el)
+        } catch (e) {
+            new Vue({
+                render: h => h(Error, {
+                    props: {
+                        title: 'Oops!',
+                        description: 'Something unexpected happened, but we are working on it!'
+                    }
+                }),
+            }).$mount(el)
+        }
+      })()
   },
 })

--- a/resources/js/lib/i18n.ts
+++ b/resources/js/lib/i18n.ts
@@ -1,0 +1,21 @@
+import axios from 'axios';
+
+export default async function getMessages(lang:string = 'en'): Promise<Object> {
+    let messages: {[p: string]: Object} = {
+        'en': (await axios.get('i18n/en.json')).data
+    };
+
+    if (lang !== 'en') {
+        try {
+            messages[lang] = (await axios.get(`i18n/${lang}.json`)).data;
+        } catch (error) {
+            if (error.response.status !== 404){
+                throw error;
+            }
+
+            console.warn( 'The language requested could not be retrieved, falling back to English' );
+        }
+    }
+
+    return messages;
+}

--- a/resources/js/shims-vue.d.ts
+++ b/resources/js/shims-vue.d.ts
@@ -2,3 +2,5 @@ declare module "*.vue" {
     import Vue from 'vue'
     export default Vue
 }
+
+declare module 'vue-banana-i18n';

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="{{ App::currentLocale() }}">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />

--- a/tests/Feature/WebRouteTest.php
+++ b/tests/Feature/WebRouteTest.php
@@ -7,6 +7,8 @@ use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 use Inertia\Testing\Assert;
 use App\Models\User;
+use Illuminate\Support\Facades\App;
+use Hamcrest\Core\IsSame;
 
 class WebRouteTest extends TestCase
 {
@@ -45,6 +47,34 @@ class WebRouteTest extends TestCase
                 $page->component('Home')
                     ->where('user.name', $user->username);
             });
+    }
+
+    /**
+     * Test the / route with a language code
+     *
+     *  @return void
+     */
+    public function test_home_page_accepts_translated_locales()
+    {
+        // qqq should always exist
+        $response = $this->get(route('home', ['uselang' => 'qqq']));
+
+        $response->assertSuccessful();
+        $this->assertSame(App::currentLocale(), 'qqq');
+    }
+
+    /**
+     * Test the / route with a non translated language code
+     *
+     *  @return void
+     */
+    public function test_home_page_locale_falls_back_to_english()
+    {
+        // xtravagent-test is not a language
+        $response = $this->get(route('home', ['uselang' => 'xtravagent-test']));
+
+        $response->assertSuccessful();
+        $this->assertSame(App::currentLocale(), 'en');
     }
 
     /**

--- a/tests/Vue/lib/i18n.spec.js
+++ b/tests/Vue/lib/i18n.spec.js
@@ -1,0 +1,65 @@
+import getMessages from '@/lib/i18n';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+
+
+
+describe('i18n.getMessages()', () => {
+    it('resolves with "en" messages by default', () => {
+        const mockMessages = { "some-translation-key": "Some sentence to translate" };
+        const fakeServer = new MockAdapter(axios);
+
+        fakeServer.onGet('/i18n/en.json').reply(200, mockMessages);
+
+        const promise = getMessages();
+
+        return expect(promise).resolves.toEqual({ en: mockMessages });
+    });
+
+    it('rejects and throws when "en" messages file is not found', () => {
+        const fakeServer = new MockAdapter(axios);
+
+        fakeServer.onGet('/i18n/en.json').reply(404);
+
+        return expect(getMessages()).rejects.toThrow('404');
+    });
+
+    it('resolves additionally requested languages', () => {
+        const mockEnglishMessages = { "some-translation-key": "Some sentence to translate" };
+        const mockHebrewMessages = { "some-translation-key": "משפט כלשהו לתרגום" };
+        const fakeServer = new MockAdapter(axios);
+
+        fakeServer.onGet('/i18n/en.json').reply(200, mockEnglishMessages);
+        fakeServer.onGet('/i18n/he.json').reply(200, mockHebrewMessages);
+
+        const promise = getMessages('he');
+
+        return expect(promise).resolves.toEqual({
+            en: mockEnglishMessages,
+            he: mockHebrewMessages
+        });
+    });
+
+    it('falls back to "en" if additional messages files are not found', () => {
+        const mockMessages = { "some-translation-key": "Some sentence to translate" };
+        const fakeServer = new MockAdapter(axios);
+
+        fakeServer.onGet('/i18n/en.json').reply(200, mockMessages);
+        fakeServer.onGet('/i18n/he.json').reply(404);
+        jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const promise = getMessages('he');
+        return expect(promise).resolves.toEqual({ en: mockMessages });
+    });
+
+
+    it('rejects and throws when other server errors occur', () => {
+        const fakeServer = new MockAdapter(axios);
+
+        fakeServer.onGet('/i18n/en.json').reply(200, {});
+        fakeServer.onGet('/i18n/he.json').reply(500);
+
+        const promise = getMessages('he');
+        return expect(promise).rejects.toThrow('500');
+    });
+});


### PR DESCRIPTION
This change sets up localization for our client side application, by adding a middleware to infer the locale from a `uselang` query parameter, and requesting the correct translation strings from the public folder using a small HTTP client. The translation strings should follow the banana-i18n format, as is common in other WMDE tools.

Additionally, a provisional Error page component has been added, in case an error occurs while trying to retrieve localization files or starting up the client-side application.

Bug: [T287356](https://phabricator.wikimedia.org/T287356)