### PR TITLE
Fix buggy check of request parameters

### DIFF
--- a/app/Http/Controllers/MismatchController.php
+++ b/app/Http/Controllers/MismatchController.php
@@ -22,13 +22,13 @@ class MismatchController extends Controller
 
         // limit to 'pending',
         // unless include_reviewed parameter is provided
-        if (!$request->include_reviewed) {
+        if (!$request->boolean('include_reviewed')) {
             $query->where('status', 'pending');
         }
 
         // limit to non-expired,
         // unless include_expired parameter is provided
-        if (!$request->include_expired) {
+        if (!$request->boolean('include_expired')) {
             $query->whereHas('importMeta', function ($import) {
                 $import->where('expires', '>=', now());
             });

--- a/tests/Feature/ApiMismatchRouteTest.php
+++ b/tests/Feature/ApiMismatchRouteTest.php
@@ -92,7 +92,7 @@ class ApiMismatchRouteTest extends TestCase
             self::MISMATCH_ROUTE,
             [
                 'ids' => $this->getSeededMismatchIds(),
-                'include_reviewed' => true
+                'include_reviewed' => 'true'
             ]
         );
 
@@ -100,6 +100,25 @@ class ApiMismatchRouteTest extends TestCase
             ->assertJsonCount(
                 $this->pendingMismatches->count() +
                 $this->reviewedMismatches->count()
+            );
+    }
+
+    public function test_query_including_reviewed_false_does_not_return_reviewed_mismatches()
+    {
+        $this->seedMismatches();
+
+        $response = $this->json(
+            'GET',
+            self::MISMATCH_ROUTE,
+            [
+                'ids' => $this->getSeededMismatchIds(),
+                'include_reviewed' => 'false'
+            ]
+        );
+
+        $response->assertSuccessful()
+            ->assertJsonCount(
+                $this->pendingMismatches->count()
             );
     }
 
@@ -112,7 +131,7 @@ class ApiMismatchRouteTest extends TestCase
             self::MISMATCH_ROUTE,
             [
                 'ids' => $this->getSeededMismatchIds(),
-                'include_expired' => true
+                'include_expired' => 'true'
             ]
         );
 
@@ -120,6 +139,25 @@ class ApiMismatchRouteTest extends TestCase
             ->assertJsonCount(
                 $this->pendingMismatches->count() +
                 $this->expiredMismatches->count()
+            );
+    }
+
+    public function test_query_including_expired_false_does_not_return_expired_mismatches()
+    {
+        $this->seedMismatches();
+
+        $response = $this->json(
+            'GET',
+            self::MISMATCH_ROUTE,
+            [
+                'ids' => $this->getSeededMismatchIds(),
+                'include_expired' => 'false'
+            ]
+        );
+
+        $response->assertSuccessful()
+            ->assertJsonCount(
+                $this->pendingMismatches->count()
             );
     }
 
@@ -132,8 +170,8 @@ class ApiMismatchRouteTest extends TestCase
             self::MISMATCH_ROUTE,
             [
                 'ids' => $this->getSeededMismatchIds(),
-                'include_reviewed' => true,
-                'include_expired' => true
+                'include_reviewed' => 'true',
+                'include_expired' => 'true'
             ]
         );
 


### PR DESCRIPTION
This fix now properly checks whether the request parameters
'include_reviewed' and 'include_expired' have "truthy" values, even if
they are actually strings such as 'true', 'yes' or 'on'. Other values,
including string 'false', are considered to be not true.

Additional feature tests ensure the correct behaviour.

Bug: T285301