### PR TITLE
Update the Mismatch concept

### DIFF
--- a/app/Http/Controllers/MismatchController.php
+++ b/app/Http/Controllers/MismatchController.php
@@ -23,7 +23,7 @@ class MismatchController extends Controller
         // limit to 'pending',
         // unless include_reviewed parameter is provided
         if (!$request->boolean('include_reviewed')) {
-            $query->where('status', 'pending');
+            $query->where('review_status', 'pending');
         }
 
         // limit to non-expired,

--- a/app/Http/Resources/MismatchResource.php
+++ b/app/Http/Resources/MismatchResource.php
@@ -22,7 +22,8 @@ class MismatchResource extends JsonResource
             'wikidata_value' => $this->wikidata_value,
             'external_value' => $this->external_value,
             'external_url' => $this->external_url,
-            'status' => $this->status,
+            'review_status' => $this->review_status,
+            'reviewer' => new UserResource($this->user),
             'import' => new ImportMetaResource($this->importMeta)
         ];
     }

--- a/app/Models/Mismatch.php
+++ b/app/Models/Mismatch.php
@@ -28,12 +28,17 @@ class Mismatch extends Model
      * @var array
      */
     protected $attributes = [
-        'status' => 'pending'
+        'review_status' => 'pending'
     ];
 
     public function importMeta()
     {
         return $this->belongsTo(ImportMeta::class, 'import_id')->withDefault();
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
     }
 
     /**

--- a/database/factories/MismatchFactory.php
+++ b/database/factories/MismatchFactory.php
@@ -39,7 +39,7 @@ class MismatchFactory extends Factory
     {
         return $this->state(function (array $attributes) {
             return [
-                'status' => $this->getRandomReviewStatus()
+                'review_status' => $this->getRandomReviewStatus()
             ];
         });
     }

--- a/database/migrations/2021_08_18_121955_rename_mismatch_status.php
+++ b/database/migrations/2021_08_18_121955_rename_mismatch_status.php
@@ -1,0 +1,117 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Schema;
+
+class RenameMismatchStatus extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        if (App::environment() == 'testing') {
+            // SQLite doesn't support renaming or dropping columns,
+            // so for testing we re-do the entire table
+            $this->dropAndRecreateMismatchesTable();
+        } else {
+            // Laravel doesn't support renaming enum columns,
+            // so we drop and re-create the entire column
+            $this->dropAndRecreateColumn();
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        if (App::environment() == 'testing') {
+            $this->dropAndRestoreMismatchesTable();
+        } else {
+            $this->dropAndRestoreColumn();
+        }
+    }
+
+    private function dropAndRecreateMismatchesTable() {
+        Schema::table('mismatches', function (Blueprint $table) {
+            $table->drop();
+        });
+
+        Schema::create('mismatches', function (Blueprint $table) {
+            $table->id();
+            $table->string('statement_guid');
+            $table->string('item_id');
+            $table->string('property_id');
+            $table->string('wikidata_value', 2048); // Arbitrary length above 1500 chars, upper limit for wikidata value
+            $table->string('external_value', 2048); // Arbitrary length above 1500 chars, upper limit for external value
+            $table->string('external_url', 2048)->nullable(); // Arbitrary length above 1500 chars, upper limit for url
+            $table->enum('review_status', [
+                'pending',
+                'wikidata',
+                'external',
+                'both',
+                'none'
+            ])->default('pending');
+            $table->foreignId('import_id')->constrained('import_meta');
+            $table->timestamps();
+        });
+    }
+
+    private function dropAndRecreateColumn() {
+        Schema::table('mismatches', function (Blueprint $table) {
+            $table->dropColumn('status');
+            $table->enum('review_status', [
+                'pending',
+                'wikidata',
+                'external',
+                'both',
+                'none'
+            ])->after('external_url')->default('pending');
+        });
+    }
+
+    private function dropAndRestoreMismatchesTable() {
+        Schema::table('mismatches', function (Blueprint $table) {
+            $table->drop();
+        });
+
+        Schema::create('mismatches', function (Blueprint $table) {
+            $table->id();
+            $table->string('statement_guid');
+            $table->string('item_id');
+            $table->string('property_id');
+            $table->string('wikidata_value', 2048); // Arbitrary length above 1500 chars, upper limit for wikidata value
+            $table->string('external_value', 2048); // Arbitrary length above 1500 chars, upper limit for external value
+            $table->string('external_url', 2048)->nullable(); // Arbitrary length above 1500 chars, upper limit for url
+            $table->enum('status', [
+                'pending',
+                'wikidata',
+                'external',
+                'both',
+                'none'
+            ])->default('pending');
+            $table->foreignId('import_id')->constrained('import_meta');
+            $table->timestamps();
+        });
+    }
+
+    private function dropAndRestoreColumn() {
+        Schema::table('mismatches', function (Blueprint $table) {
+            $table->dropColumn('review_status');
+            $table->enum('status', [
+                'pending',
+                'wikidata',
+                'external',
+                'both',
+                'none'
+            ])->after('external_url')->default('pending');
+        });
+    }
+}

--- a/database/migrations/2021_08_18_122423_add_reviewer_to_mismatches.php
+++ b/database/migrations/2021_08_18_122423_add_reviewer_to_mismatches.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddReviewerToMismatches extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('mismatches', function (Blueprint $table) {
+            $table->foreignId('user_id')->nullable()->constrained('users');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('mismatches', function (Blueprint $table) {
+            $table->dropForeign('mismatches_user_id_foreign');
+            $table->dropColumn('user_id');
+        });
+    }
+}

--- a/tests/Feature/ApiMismatchRouteTest.php
+++ b/tests/Feature/ApiMismatchRouteTest.php
@@ -32,12 +32,21 @@ class ApiMismatchRouteTest extends TestCase
            ->for(User::factory()->uploader())
            ->create();
 
-        $mismatch = Mismatch::factory()->for($import)->create();
+        $reviewer = User::factory()->create();
+
+        $mismatch = Mismatch::factory()
+            ->for($import)
+            ->reviewed()
+            ->for($reviewer)
+            ->create();
 
         $response = $this->json(
             'GET',
             self::MISMATCH_ROUTE,
-            [ 'ids' => $mismatch->item_id ]
+            [
+                 'ids' => $mismatch->item_id,
+                 'include_reviewed' => 'true'
+            ]
         );
 
         $response->assertSuccessful()
@@ -50,7 +59,12 @@ class ApiMismatchRouteTest extends TestCase
                     'wikidata_value',
                     'external_value',
                     'external_url',
-                    'status',
+                    'review_status',
+                    'reviewer' => [
+                        'id',
+                        'username',
+                        'mw_userid',
+                    ],
                     'import' => [
                         'id',
                         'status',
@@ -63,6 +77,15 @@ class ApiMismatchRouteTest extends TestCase
                             'mw_userid'
                         ]
                     ]
+                ]]
+            )->assertJson(
+                [[
+                    'import' => [
+                        'status' => $import->status
+                    ],
+                    'reviewer' => [
+                        'id' => $reviewer->id
+                        ]
                 ]]
             );
     }


### PR DESCRIPTION
This modifies the Mismatch model to include a reviewer and renames the
'status' field to 'review_status

For these changes to take effect, several components had to be touched:
 * the Mismatch model,
 * migrations for the 'mismatches' database table,
 * the factory, controller and resource,
 * the API route test.

Since Laravel currently does not support renaming an 'enum' column, the
db migration drops and re-creates it at the same position with 'pending'
as its default value. This will do no harm, because no review decisions
have been recorded so far. SQLite does not even allow dropping and
adding columns, therefore in the 'testing' environment, the entire
table will be dropped and re-created with the new column name.

Bug: [T289132](https://phabricator.wikimedia.org/T289132)