### PR TITLE
Align class name with file name

### DIFF
--- a/tests/Feature/ApiUserRouteTest.php
+++ b/tests/Feature/ApiUserRouteTest.php
@@ -8,7 +8,7 @@ use Tests\TestCase;
 use Laravel\Sanctum\Sanctum;
 use Illuminate\Foundation\Testing\WithFaker;
 
-class ApiRouteTest extends TestCase
+class ApiUserRouteTest extends TestCase
 {
     use RefreshDatabase, WithFaker;
 


### PR DESCRIPTION
This quick fix allows developers to run
`sail artisan test tests/Feature/ApiUserRouteTest.php`
which previously failed because:

> Class 'ApiUserRouteTest' could not be found