### PR TITLE
Fix URL generation issue

### DIFF
--- a/app/Http/Controllers/OAuthUserController.php
+++ b/app/Http/Controllers/OAuthUserController.php
@@ -7,7 +7,6 @@ use Laravel\Socialite\Facades\Socialite;
 use Illuminate\Support\Facades\Auth;
 use App\Models\User;
 use Illuminate\Support\Facades\Redirect;
-use Illuminate\Support\Facades\Log;
 
 class OAuthUserController extends Controller
 {
@@ -20,7 +19,6 @@ class OAuthUserController extends Controller
     public function login(Request $request)
     {
         $referer = $request->headers->get('referer');
-        Log::debug($referer);
         Redirect::setIntendedUrl($referer);
 
         return Socialite::driver('mediawiki')->redirect();
@@ -42,7 +40,6 @@ class OAuthUserController extends Controller
     public function logout(Request $request)
     {
         $referer = $request->headers->get('referer');
-        Log::debug($referer);
         Auth::guard()->logout();
 
         $request->session()->invalidate();

--- a/app/Http/Controllers/OAuthUserController.php
+++ b/app/Http/Controllers/OAuthUserController.php
@@ -7,6 +7,7 @@ use Laravel\Socialite\Facades\Socialite;
 use Illuminate\Support\Facades\Auth;
 use App\Models\User;
 use Illuminate\Support\Facades\Redirect;
+use Illuminate\Support\Facades\Log;
 
 class OAuthUserController extends Controller
 {
@@ -19,6 +20,7 @@ class OAuthUserController extends Controller
     public function login(Request $request)
     {
         $referer = $request->headers->get('referer');
+        Log::debug($referer);
         Redirect::setIntendedUrl($referer);
 
         return Socialite::driver('mediawiki')->redirect();
@@ -40,6 +42,7 @@ class OAuthUserController extends Controller
     public function logout(Request $request)
     {
         $referer = $request->headers->get('referer');
+        Log::debug($referer);
         Auth::guard()->logout();
 
         $request->session()->invalidate();

--- a/app/Http/Controllers/OAuthUserController.php
+++ b/app/Http/Controllers/OAuthUserController.php
@@ -46,6 +46,7 @@ class OAuthUserController extends Controller
         Auth::guard()->logout();
 
         $request->session()->invalidate();
-        return redirect($referer);
+
+        return redirect($referer ?? '/');
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,6 +4,8 @@ namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\URL;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -25,5 +27,10 @@ class AppServiceProvider extends ServiceProvider
     public function boot()
     {
         JsonResource::withoutWrapping();
+
+        // Ensure urls are generated with the correct scheme in production.
+        if (App::environment('production')) {
+            URL::forceScheme('https');
+        }
     }
 }

--- a/resources/views/components/layout.blade.php
+++ b/resources/views/components/layout.blade.php
@@ -12,9 +12,9 @@
         <h1>{{__('store-layout.mismatch-finder')}}</h1>
         <div class="top-nav-right">
             @auth
-                <a href='https://www.wikidata.org/wiki/User:{{ Auth::user()->username}}'><img src="{{ asset('/svg/user.svg') }}" class="icon-user" /><span class="username">{{ Auth::user()->username }}</span></a><a href="{{ route('logout') }}">Logout</a>
+                <a href='https://www.wikidata.org/wiki/User:{{ Auth::user()->username}}'><img src="{{ asset('/svg/user.svg') }}" class="icon-user" /><span class="username">{{ Auth::user()->username }}</span></a><a href="{{ route('logout') }}" referrerpolicy="same-origin">Logout</a>
             @else
-                <a href="{{ route('login') }}">Log in</a>
+                <a href="{{ route('login') }}" referrerpolicy="same-origin">Log in</a>
             @endauth
         </div>
     </header>

--- a/resources/views/components/layout.blade.php
+++ b/resources/views/components/layout.blade.php
@@ -12,9 +12,9 @@
         <h1>{{__('store-layout.mismatch-finder')}}</h1>
         <div class="top-nav-right">
             @auth
-                <a href='https://www.wikidata.org/wiki/User:{{ Auth::user()->username}}'><img src="{{ asset('/svg/user.svg') }}" class="icon-user" /><span class="username">{{ Auth::user()->username }}</span></a><a href="{{ route('logout') }}" referrerpolicy="same-origin">Logout</a>
+                <a href='https://www.wikidata.org/wiki/User:{{ Auth::user()->username}}'><img src="{{ asset('/svg/user.svg') }}" class="icon-user" /><span class="username">{{ Auth::user()->username }}</span></a><a href="{{ route('logout') }}">Logout</a>
             @else
-                <a href="{{ route('login') }}" referrerpolicy="same-origin">Log in</a>
+                <a href="{{ route('login') }}">Log in</a>
             @endauth
         </div>
     </header>


### PR DESCRIPTION
This change ensures that Laravel will produce URLs with the correct `https` schemes in production. It turns out, that Laravel cannot detect the correct URL scheme's to generate under [certain circumstances](https://laravel.com/docs/8.x/requests#configuring-trusted-proxies). 

This lead to an issue where the required `Referer: ` header was not included in the login and logout requests that depended on it due to the default `strict-origin-when-cross-origin` [referrer policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy).

In addition, this change ensures that even when a referrer is not specified, the logout request will redirect back to `/` as a fallback.

Bug: [T289251](https://phabricator.wikimedia.org/T289251)