### PR TITLE
Add querying section to home page

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -9,5 +9,9 @@
     },
     "about-mismatch-finder-title": "About this tool",
     "about-mismatch-finder-description": "The Mismatch Finder shows you data in Wikidata that differs with the data in another database, catalog or website (for example, someone's date of birth in Wikidata doesn't match the corresponding entry in the German National Library catalogue). Mismatches like this need fixing, and the Mismatch Finder helps you to do just that.",
-    "find-more": "Find out more"
+    "find-more": "Find out more",
+    "item-form-title": "For which items should the check be performed?",
+    "item-form-id-input-label": "Please add one Item identifier per line",
+    "item-form-id-input-placeholder": "For example:\nQ345\nQ0987609\nQ4567890",
+    "item-form-submit": "Check Items"
 }

--- a/public/i18n/qqq.json
+++ b/public/i18n/qqq.json
@@ -6,5 +6,9 @@
     },
     "about-mismatch-finder-title": "The title of the tool's \"about\" text",
     "about-mismatch-finder-description": "A short text to describe the Mismatch Finder tool",
-    "find-more": "A call to action for more information"
+    "find-more": "A call to action for more information",
+    "item-form-title": "The title of the form that filters Mismatches by Item id",
+    "item-form-id-input-label": "The label for the Item id input",
+    "item-form-id-input-placeholder": "The placeholder for the Item id input",
+    "item-form-submit": "The call to action on the Item id form's submit button"
 }

--- a/resources/js/Pages/Home.vue
+++ b/resources/js/Pages/Home.vue
@@ -1,21 +1,55 @@
 <template>
-  <div>
+  <div class="page-container">
     <Head title="Mismatch Finder" />
-    <h1 class="h4">{{ $i18n('about-mismatch-finder-title') }}</h1>
-    <p id="about-description" >{{ $i18n('about-mismatch-finder-description') }}</p>
+    <section id="intro-section">
+        <h2 class="h4">{{ $i18n('about-mismatch-finder-title') }}</h2>
+        <p id="about-description" >{{ $i18n('about-mismatch-finder-description') }}</p>
+    </section>
+    <section id="querying-section">
+        <h2 class="h5">{{ $i18n('item-form-title') }}</h2>
+        <form id="item-form" @submit.prevent="send">
+            <text-area
+                :label="$i18n('item-form-id-input-label')"
+                :placeholder="$i18n('item-form-id-input-placeholder')"
+                :rows="8"
+                v-model="form.itemsInput"
+            />
+            <wikit-button native-type="submit" disabled>
+                {{ $i18n('item-form-submit') }}
+            </wikit-button>
+        </form>
+    </section>
   </div>
 </template>
 
 <script>
     import Vue from 'vue';
     import { Head } from '@inertiajs/inertia-vue';
+    import {
+        Button as WikitButton,
+        TextArea
+    } from '@wmde/wikit-vue-components';
 
     export default Vue.extend({
         components: {
-            Head
+            Head,
+            TextArea,
+            WikitButton
         },
         props: {
             user: Object,
+        },
+        methods: {
+            send(){
+                // TODO: Implement validation and form sending logic (See: https://inertiajs.com/forms)
+            }
+        },
+        data(){
+            return {
+                form: {
+                    itemsInput: ''
+                }
+            }
         }
     });
 </script>

--- a/resources/js/Pages/Home.vue
+++ b/resources/js/Pages/Home.vue
@@ -7,16 +7,18 @@
     </section>
     <section id="querying-section">
         <h2 class="h5">{{ $i18n('item-form-title') }}</h2>
-        <form id="item-form" @submit.prevent="send">
+        <form id="items-form" @submit.prevent="send">
             <text-area
                 :label="$i18n('item-form-id-input-label')"
                 :placeholder="$i18n('item-form-id-input-placeholder')"
                 :rows="8"
                 v-model="form.itemsInput"
             />
-            <wikit-button native-type="submit" disabled>
-                {{ $i18n('item-form-submit') }}
-            </wikit-button>
+            <div class="form-buttons">
+                <wikit-button native-type="submit" disabled>
+                    {{ $i18n('item-form-submit') }}
+                </wikit-button>
+            </div>
         </form>
     </section>
   </div>
@@ -55,7 +57,41 @@
 </script>
 
 <style lang="scss">
+@import '~@wmde/wikit-tokens/dist/_variables.scss';
+
 #about-description {
     max-width: 705px;
+}
+
+#items-form {
+    /**
+    * Colors
+    */
+    background-color: $background-color-neutral-default;
+
+    /**
+    * Border
+    */
+    border-style: $border-style-base;
+    border-width: $border-width-thin;
+    border-color: $border-color-base-subtle;
+    border-radius: $border-radius-base;
+
+    /**
+    * Layout
+    */
+    padding: $dimension-spacing-large;
+    margin: $dimension-layout-xsmall 0;
+
+    // Any direct decendent of this form that has a predecessor element will
+    // get a top margin, this creates the even gutter between elements or "stack"
+    // See https://every-layout.dev/layouts/stack/#the-solution
+    & > * + * {
+        margin-top: $dimension-spacing-large;
+    }
+
+    .form-buttons {
+        text-align: end;
+    }
 }
 </style>

--- a/resources/sass/_typography.scss
+++ b/resources/sass/_typography.scss
@@ -1,5 +1,5 @@
 @mixin link {
-    color: $font-color-base;
+    color: $font-color-primary;
     text-decoration: none;
 
     &:focus-visible { // for chrome

--- a/resources/sass/_typography.scss
+++ b/resources/sass/_typography.scss
@@ -1,5 +1,5 @@
 @mixin link {
-    color: $font-color-primary;
+    color: $font-color-progressive;
     text-decoration: none;
 
     &:focus-visible { // for chrome

--- a/resources/sass/_typography.scss
+++ b/resources/sass/_typography.scss
@@ -1,9 +1,23 @@
+@mixin link {
+    color: $font-color-base;
+    text-decoration: none;
+
+    &:focus-visible { // for chrome
+        outline: dotted;
+        outline-width: 1px;
+        outline-color: gray;
+    }
+
+    &:hover {
+        text-decoration: underline;
+    }
+}
+
 @mixin body-text {
     font-family: $font-family-style-body;
     font-size: $font-size-style-body;
     font-weight: $font-weight-style-body;
     line-height: $font-line-height-style-body;
-    margin-bottom: $dimension-layout-large;
     color: $font-color-base;
 }
 
@@ -12,12 +26,7 @@
     font-size: $font-size-style-h1;
     font-weight: $font-weight-style-h1;
     line-height: $font-line-height-style-heading;
-    margin: $dimension-layout-xsmall 0;
     color: $font-color-emphasized;
-
-    @media(min-width: $width-breakpoint-tablet){
-        margin: $dimension-layout-small 0;
-    }
 }
 
 @mixin heading-4 {
@@ -25,12 +34,7 @@
     font-size: $font-size-style-h4;
     font-weight: $font-weight-style-h4;
     line-height: $font-line-height-style-heading;
-    margin: $dimension-layout-xxsmall 0;
     color: $font-color-emphasized;
-
-    @media(min-width: $width-breakpoint-tablet){
-        margin: $dimension-layout-xsmall 0;
-    }
 }
 
 @mixin heading-5 {
@@ -38,10 +42,5 @@
     font-size: $font-size-style-h5;
     font-weight: $font-weight-style-h5;
     line-height: $font-line-height-style-heading;
-    margin: $dimension-layout-xsmall 0; // This spacing seems to be constant across different widths
     color: $font-color-emphasized;
-
-    @media(min-width: $width-breakpoint-tablet){
-        margin: $dimension-layout-xsmall 0;
-    }
 }

--- a/resources/sass/_typography.scss
+++ b/resources/sass/_typography.scss
@@ -7,11 +7,41 @@
     color: $font-color-base;
 }
 
+@mixin heading-1 {
+    font-family: $font-family-style-heading-serif;
+    font-size: $font-size-style-h1;
+    font-weight: $font-weight-style-h1;
+    line-height: $font-line-height-style-heading;
+    margin: $dimension-layout-xsmall 0;
+    color: $font-color-emphasized;
+
+    @media(min-width: $width-breakpoint-tablet){
+        margin: $dimension-layout-small 0;
+    }
+}
+
 @mixin heading-4 {
     font-family: $font-family-style-heading-sans;
     font-size: $font-size-style-h4;
     font-weight: $font-weight-style-h4;
     line-height: $font-line-height-style-heading;
-    margin-bottom: $dimension-layout-xsmall;
+    margin: $dimension-layout-xxsmall 0;
     color: $font-color-emphasized;
+
+    @media(min-width: $width-breakpoint-tablet){
+        margin: $dimension-layout-xsmall 0;
+    }
+}
+
+@mixin heading-5 {
+    font-family: $font-family-style-heading-sans;
+    font-size: $font-size-style-h5;
+    font-weight: $font-weight-style-h5;
+    line-height: $font-line-height-style-heading;
+    margin: $dimension-layout-xsmall 0; // This spacing seems to be constant across different widths
+    color: $font-color-emphasized;
+
+    @media(min-width: $width-breakpoint-tablet){
+        margin: $dimension-layout-xsmall 0;
+    }
 }

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -5,41 +5,58 @@
 @import '~@wmde/wikit-tokens/dist/_variables.scss';
 @import './_typography.scss';
 
-body, body * {
-    box-sizing: border-box;
-}
-
+/**
+* Layout
+*/
 body {
-    padding: 24px;
     max-width: 1090px;
+    padding: 0 $dimension-layout-xsmall;
     margin: 0 auto;
-
     @include body-text;
 
-    @media (max-width: $width-breakpoint-tablet) {
-        padding: 16px;
+    @media(min-width: $width-breakpoint-tablet){
+        padding: 0 $dimension-layout-small;
+    }
+}
+
+section {
+    margin-bottom: $dimension-layout-large;
+}
+
+h1, .h1 {
+    margin: $dimension-layout-xsmall 0;
+    @include heading-1;
+
+    @media(min-width: $width-breakpoint-tablet){
+        margin: $dimension-layout-small 0;
     }
 }
 
 h4, .h4 {
+    margin: $dimension-layout-xxsmall 0;
     @include heading-4;
+
+    @media(min-width: $width-breakpoint-tablet){
+        margin: $dimension-layout-xsmall 0;
+    }
 }
 
+h5, .h5 {
+    margin: $dimension-layout-xxsmall 0;
+    @include heading-5;
+
+    @media(min-width: $width-breakpoint-tablet){
+        margin: $dimension-layout-xsmall 0;
+    }
+}
 
 a {
-    text-decoration: none;
-
-    &:focus-visible { // for chrome
-        outline: dotted;
-        outline-width: 1px;
-        outline-color: gray;
-    }
-
-    &:hover {
-        text-decoration: underline;
-    }
+    @include link;
 }
 
+/**
+* Legacy
+*/
 .tabs a:hover {
     text-decoration: none;
 }
@@ -47,18 +64,15 @@ a {
 header {
     display: flex;
     justify-content: space-between;
+    margin: $dimension-layout-small 0;
 
     @media (max-width: $width-breakpoint-tablet) {
         flex-direction: column-reverse;
+        margin: $dimension-layout-xsmall 0;
     }
 
     h1 {
-        font-family: 'Source Serif Pro', serif;
-        font-size: 32px;
-        line-height: 40px;
         margin: 0;
-        padding: 0 0 28px 0;
-        font-weight: 400;
     }
 
     .top-nav-right {

--- a/tests/Browser/ItemsFormTest.php
+++ b/tests/Browser/ItemsFormTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Browser;
+
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Laravel\Dusk\Browser;
+use Tests\DuskTestCase;
+use Tests\Browser\Pages\HomePage;
+
+class ItemsFormTest extends DuskTestCase
+{
+    /**
+     * A Dusk test example.
+     *
+     * @return void
+     */
+    public function test_can_enter_list_of_item_ids()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->visit(new HomePage)
+                    ->keys('@items-input', 'Q1', '{return_key}', 'Q2')
+                    ->assertInputValue('@items-input', "Q1\nQ2");
+        });
+    }
+}

--- a/tests/Browser/Pages/HomePage.php
+++ b/tests/Browser/Pages/HomePage.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Browser\Pages;
+
+use Laravel\Dusk\Browser;
+use Laravel\Dusk\Page;
+
+class HomePage extends Page
+{
+    /**
+     * Get the URL for the page.
+     *
+     * @return string
+     */
+    public function url()
+    {
+        return route('home');
+    }
+
+    /**
+     * Assert that the browser is on the page.
+     *
+     * @param  Browser  $browser
+     * @return void
+     */
+    public function assert(Browser $browser)
+    {
+        $browser
+            ->assertPathIs('/')
+            ->assertPresent('@form');
+    }
+
+    /**
+     * Get the element shortcuts for the page.
+     *
+     * @return array
+     */
+    public function elements()
+    {
+        return [
+            '@form' => '#items-form',
+            '@items-input' => '@form textarea'
+        ];
+    }
+}


### PR DESCRIPTION
This change adds the querying section to the home page of the Mismatch Finder application. This section contains a form to send item IDs to the server, which will be used to filter mismatches to retrieve. The submit button is currently disabled, as we cannot yet display the results of the form.

Bug: [T289057](https://phabricator.wikimedia.org/T289057)