### PR TITLE
Send item IDs to the server

### DIFF
--- a/resources/js/Pages/Home.vue
+++ b/resources/js/Pages/Home.vue
@@ -15,7 +15,7 @@
                 v-model="form.itemsInput"
             />
             <div class="form-buttons">
-                <wikit-button native-type="submit" disabled>
+                <wikit-button native-type="submit">
                     {{ $i18n('item-form-submit') }}
                 </wikit-button>
             </div>
@@ -42,9 +42,12 @@
             user: Object,
         },
         methods: {
-            send(){
-                // TODO: Implement validation and form sending logic (See: https://inertiajs.com/forms)
-            }
+            send() {
+                // TODO: Implement validation
+
+                const idsToSend = this.form.itemsInput.split('\n').join('|');
+                this.$inertia.get('/results?ids=' + idsToSend)
+            },
         },
         data(){
             return {

--- a/resources/js/Pages/Results.vue
+++ b/resources/js/Pages/Results.vue
@@ -2,9 +2,9 @@
   <div>
     <Head title="Mismatch Finder - Results" />
     <h1>Mismatch Finder - Results!</h1>
-    <div class="results">
+    <p class="results">
         Thank you for sending IDs {{item_ids}}. Mismatch results will be displayed in this page soon.
-    </div>
+    </p>
   </div>
 </template>
 

--- a/resources/js/Pages/Results.vue
+++ b/resources/js/Pages/Results.vue
@@ -2,7 +2,9 @@
   <div>
     <Head title="Mismatch Finder - Results" />
     <h1>Mismatch Finder - Results!</h1>
-    <p>Thank you for sending IDs {{item_ids}}. Mismatch results will be displayed in this page soon.</p>
+    <div class="results">
+        Thank you for sending IDs {{item_ids}}. Mismatch results will be displayed in this page soon.
+    </div>
   </div>
 </template>
 

--- a/tests/Browser/ItemsFormTest.php
+++ b/tests/Browser/ItemsFormTest.php
@@ -29,7 +29,7 @@ class ItemsFormTest extends DuskTestCase
             $browser->visit(new HomePage)
                     ->keys('@items-input', 'Q1', '{return_key}', 'Q2')
                     ->press('button')
-                    ->waitFor('div.results')
+                    ->waitFor('@results')
                     ->assertTitle('Mismatch Finder - Results')
                     ->assertSee('[ "Q1", "Q2" ]');
         });

--- a/tests/Browser/ItemsFormTest.php
+++ b/tests/Browser/ItemsFormTest.php
@@ -22,4 +22,16 @@ class ItemsFormTest extends DuskTestCase
                     ->assertInputValue('@items-input', "Q1\nQ2");
         });
     }
+
+    public function test_can_submit_list_of_item_ids()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->visit(new HomePage)
+                    ->keys('@items-input', 'Q1', '{return_key}', 'Q2')
+                    ->press('button')
+                    ->waitFor('div.results')
+                    ->assertTitle('Mismatch Finder - Results')
+                    ->assertSee('[ "Q1", "Q2" ]');
+        });
+    }
 }

--- a/tests/Browser/Pages/HomePage.php
+++ b/tests/Browser/Pages/HomePage.php
@@ -39,7 +39,8 @@ class HomePage extends Page
     {
         return [
             '@form' => '#items-form',
-            '@items-input' => '@form textarea'
+            '@items-input' => '@form textarea',
+            '@results' => 'p.results'
         ];
     }
 }


### PR DESCRIPTION
This change makes use of the '/results' endpoint and Inertia response created in #90. It parses item IDs from the TextArea, sends them to the server and displays the simple Results page.

Bug: [T290158](https://phabricator.wikimedia.org/T290158)