### PR TITLE
Add sourcemaps for debugging

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -13,5 +13,6 @@ const mix = require('laravel-mix');
 
 mix.ts('resources/js/app.ts', 'public/js')
     .vue({ version: 2 })
-    .sass('resources/sass/app.scss', 'public/css');
+    .sass('resources/sass/app.scss', 'public/css')
+    .sourceMaps(false); // False prevents source maps in production
 


### PR DESCRIPTION
This change updates Laravel Mix to generate source maps in dev environments. Additionally, this resolves some console warning that were reported beforehand in [T288807](https://phabricator.wikimedia.org/T288807).

Bug: [T288807](https://phabricator.wikimedia.org/T288807)