### PR TITLE
Implement app loading state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
                 "@wmde/wikit-vue-components": "^2.1.0-alpha.2",
                 "ress": "^3.0.0",
                 "vue": "^2.6.14",
-                "vue-banana-i18n": "^1.5.0"
+                "vue-banana-i18n": "^1.5.0",
+                "vuex": "^3.6.2"
             },
             "devDependencies": {
                 "@types/jest": "^27.0.1",
@@ -14531,6 +14532,14 @@
             "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
             "dev": true
         },
+        "node_modules/vuex": {
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.6.2.tgz",
+            "integrity": "sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw==",
+            "peerDependencies": {
+                "vue": "^2.0.0"
+            }
+        },
         "node_modules/w3c-hr-time": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
@@ -26199,6 +26208,12 @@
             "version": "1.9.1",
             "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
             "dev": true
+        },
+        "vuex": {
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.6.2.tgz",
+            "integrity": "sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw==",
+            "requires": {}
         },
         "w3c-hr-time": {
             "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,8 @@
             "dependencies": {
                 "@inertiajs/inertia": "^0.10.1",
                 "@inertiajs/inertia-vue": "^0.7.2",
-                "@wmde/wikit-tokens": "^2.1.0-alpha.1",
-                "@wmde/wikit-vue-components": "^2.1.0-alpha.1",
+                "@wmde/wikit-tokens": "^2.1.0-alpha.2",
+                "@wmde/wikit-vue-components": "^2.1.0-alpha.2",
                 "ress": "^3.0.0",
                 "vue": "^2.6.14",
                 "vue-banana-i18n": "^1.5.0"
@@ -2949,17 +2949,17 @@
             }
         },
         "node_modules/@wmde/wikit-tokens": {
-            "version": "2.1.0-alpha.1",
-            "resolved": "https://registry.npmjs.org/@wmde/wikit-tokens/-/wikit-tokens-2.1.0-alpha.1.tgz",
-            "integrity": "sha512-T+1/zNPORyfnLN1QaVey0IJ4gw9lNM1KGKTJ0JKejp54dRnH6XUhpd8y+ZHgVaEbcGkF1IsPG1qm0Be3NeJCqg=="
+            "version": "2.1.0-alpha.2",
+            "resolved": "https://registry.npmjs.org/@wmde/wikit-tokens/-/wikit-tokens-2.1.0-alpha.2.tgz",
+            "integrity": "sha512-xX9rItU2Z7NCz0HyvI0AGxlHmJnpIHOrczCea6sU8aNGEI6lzcaRHsLHvcka6FK9RnhqgjEAtS7egE3MKb5YZw=="
         },
         "node_modules/@wmde/wikit-vue-components": {
-            "version": "2.1.0-alpha.1",
-            "resolved": "https://registry.npmjs.org/@wmde/wikit-vue-components/-/wikit-vue-components-2.1.0-alpha.1.tgz",
-            "integrity": "sha512-5RVfH5s+Ukjmmz5gF62cSAux2CTiDxteFQA22xtx3hUKPcMWA7cJvF0rMymPlXc2zPlNjpFDGgCXZXM03/A9Fw==",
+            "version": "2.1.0-alpha.2",
+            "resolved": "https://registry.npmjs.org/@wmde/wikit-vue-components/-/wikit-vue-components-2.1.0-alpha.2.tgz",
+            "integrity": "sha512-2rYZbjv9InY+2j+4g9t22K+XtIyJUUbiILvVFsv6BKgFqWCn+rtIK+D+9KXJFir2eTMyVJAzFL4zGL6btX2GGg==",
             "dependencies": {
                 "@vue/composition-api": "^1.0.0-beta.20",
-                "@wmde/wikit-tokens": "^2.1.0-alpha.1",
+                "@wmde/wikit-tokens": "^2.1.0-alpha.2",
                 "core-js": "^3.7.0",
                 "lodash.debounce": "^4.0.8",
                 "lodash.isequal": "^4.5.0",
@@ -17288,17 +17288,17 @@
             "requires": {}
         },
         "@wmde/wikit-tokens": {
-            "version": "2.1.0-alpha.1",
-            "resolved": "https://registry.npmjs.org/@wmde/wikit-tokens/-/wikit-tokens-2.1.0-alpha.1.tgz",
-            "integrity": "sha512-T+1/zNPORyfnLN1QaVey0IJ4gw9lNM1KGKTJ0JKejp54dRnH6XUhpd8y+ZHgVaEbcGkF1IsPG1qm0Be3NeJCqg=="
+            "version": "2.1.0-alpha.2",
+            "resolved": "https://registry.npmjs.org/@wmde/wikit-tokens/-/wikit-tokens-2.1.0-alpha.2.tgz",
+            "integrity": "sha512-xX9rItU2Z7NCz0HyvI0AGxlHmJnpIHOrczCea6sU8aNGEI6lzcaRHsLHvcka6FK9RnhqgjEAtS7egE3MKb5YZw=="
         },
         "@wmde/wikit-vue-components": {
-            "version": "2.1.0-alpha.1",
-            "resolved": "https://registry.npmjs.org/@wmde/wikit-vue-components/-/wikit-vue-components-2.1.0-alpha.1.tgz",
-            "integrity": "sha512-5RVfH5s+Ukjmmz5gF62cSAux2CTiDxteFQA22xtx3hUKPcMWA7cJvF0rMymPlXc2zPlNjpFDGgCXZXM03/A9Fw==",
+            "version": "2.1.0-alpha.2",
+            "resolved": "https://registry.npmjs.org/@wmde/wikit-vue-components/-/wikit-vue-components-2.1.0-alpha.2.tgz",
+            "integrity": "sha512-2rYZbjv9InY+2j+4g9t22K+XtIyJUUbiILvVFsv6BKgFqWCn+rtIK+D+9KXJFir2eTMyVJAzFL4zGL6btX2GGg==",
             "requires": {
                 "@vue/composition-api": "^1.0.0-beta.20",
-                "@wmde/wikit-tokens": "^2.1.0-alpha.1",
+                "@wmde/wikit-tokens": "^2.1.0-alpha.2",
                 "core-js": "^3.7.0",
                 "lodash.debounce": "^4.0.8",
                 "lodash.isequal": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
         "@wmde/wikit-vue-components": "^2.1.0-alpha.2",
         "ress": "^3.0.0",
         "vue": "^2.6.14",
-        "vue-banana-i18n": "^1.5.0"
+        "vue-banana-i18n": "^1.5.0",
+        "vuex": "^3.6.2"
     }
 }

--- a/resources/js/Pages/Home.vue
+++ b/resources/js/Pages/Home.vue
@@ -12,6 +12,7 @@
                     :label="$i18n('item-form-id-input-label')"
                     :placeholder="$i18n('item-form-id-input-placeholder')"
                     :rows="8"
+                    :loading="loading"
                     v-model="form.itemsInput"
                 />
                 <div class="form-buttons">
@@ -92,7 +93,8 @@
                 form: {
                     itemsInput: ''
                 },
-                error: null
+                error: null,
+                loading: false
             }
         }
     });

--- a/resources/js/Pages/Home.vue
+++ b/resources/js/Pages/Home.vue
@@ -12,11 +12,14 @@
                     :label="$i18n('item-form-id-input-label')"
                     :placeholder="$i18n('item-form-id-input-placeholder')"
                     :rows="8"
-                    :error="error"
                     v-model="form.itemsInput"
                 />
                 <div class="form-buttons">
-                    <wikit-button native-type="submit">
+                    <wikit-button
+                        variant="primary"
+                        type="progressive"
+                        native-type="submit"
+                    >
                         {{ $i18n('item-form-submit') }}
                     </wikit-button>
                 </div>

--- a/resources/js/Pages/Home.vue
+++ b/resources/js/Pages/Home.vue
@@ -13,6 +13,7 @@
                     :placeholder="$i18n('item-form-id-input-placeholder')"
                     :rows="8"
                     :loading="loading"
+                    :error="error"
                     v-model="form.itemsInput"
                 />
                 <div class="form-buttons">
@@ -20,6 +21,7 @@
                         variant="primary"
                         type="progressive"
                         native-type="submit"
+                        :disabled="loading"
                     >
                         {{ $i18n('item-form-submit') }}
                     </wikit-button>
@@ -88,13 +90,17 @@
                 this.$inertia.get( '/results?ids=' + this.serializeInput() );
             },
         },
+        computed: {
+            loading(){
+                return this.$store.state.loading
+            }
+        },
         data(){
             return {
                 form: {
                     itemsInput: ''
                 },
-                error: null,
-                loading: false
+                error: null
             }
         }
     });

--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -12,32 +12,35 @@ async function setupI18n(locale: string): Promise<void>{
     Vue.use(i18n, { locale, messages });
 }
 
-createInertiaApp({
-    resolve: name => {
-        const page = require(`./Pages/${name}`).default;
-        // Ensure that every page uses the Mismatch Finder layout
-        page.layout = page.layout || Layout;
+// Only bootstrap inertia if i18nMessages are available. Display generic error
+// component otherwise
+(async () => {
+    try {
+        await setupI18n(document.documentElement.lang);
 
-        return page
-    },
-    setup({ el, app, props }) {
-        (async () => {
-            try {
-                await setupI18n(document.documentElement.lang);
+        createInertiaApp({
+            resolve: name => {
+                const page = require(`./Pages/${name}`).default;
+                // Ensure that every page uses the Mismatch Finder layout
+                page.layout = page.layout || Layout;
 
+                return page
+            },
+            setup({ el, app, props }) {
                 new Vue({
-                    render: h => h(app, props),
-                }).$mount(el)
-            } catch (e) {
-                new Vue({
-                    render: h => h(Error, {
-                        props: {
-                            title: 'Oops!',
-                            description: 'Something unexpected happened, but we are working on it... please try to refresh, or come back later.'
-                        }
-                    }),
-                }).$mount(el)
+                    render: h => h(app, props)
+                }).$mount(el);
             }
-        })()
-    },
-})
+        });
+    } catch (e) {
+        new Vue({
+            render: h => h(Error, {
+                props: {
+                    title: 'Oops!',
+                    description: 'Something unexpected happened, but we are working on it... please try to refresh, or come back later.'
+                }
+            }),
+        }).$mount('#app');
+    }
+})();
+

--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -6,6 +6,12 @@ import i18nMessages from './lib/i18n';
 import Error from './Pages/Error.vue';
 import Layout from './Pages/Layout.vue';
 
+// Retrieve i18n messages and setup the Vue instance to handle them.
+async function setupI18n(locale: string): Promise<void>{
+    const messages = await i18nMessages(locale);
+    Vue.use(i18n, { locale, messages });
+}
+
 createInertiaApp({
     resolve: name => {
         const page = require(`./Pages/${name}`).default;
@@ -17,9 +23,7 @@ createInertiaApp({
     setup({ el, app, props }) {
         (async () => {
             try {
-                const locale = document.documentElement.lang;
-                const messages = await i18nMessages(locale);
-                Vue.use(i18n, { locale, messages });
+                await setupI18n(document.documentElement.lang);
 
                 new Vue({
                     render: h => h(app, props),

--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -1,7 +1,10 @@
 import './bootstrap';
 import Vue from 'vue';
+import Vuex, {Store} from 'vuex';
 import i18n from 'vue-banana-i18n';
+import { Inertia } from '@inertiajs/inertia';
 import { createInertiaApp } from '@inertiajs/inertia-vue';
+
 import i18nMessages from './lib/i18n';
 import Error from './Pages/Error.vue';
 import Layout from './Pages/Layout.vue';
@@ -12,11 +15,53 @@ async function setupI18n(locale: string): Promise<void>{
     Vue.use(i18n, { locale, messages });
 }
 
-// Only bootstrap inertia if i18nMessages are available. Display generic error
+// A simple store to manage global client side state. In case this needs to
+// scale up, it is recommended to implement a more robust state management
+// architecture. See https://vuex.vuejs.org/guide/structure.html
+function createStore(): Store<{loading: boolean}>{
+    Vue.use(Vuex);
+
+    const store = new Store({
+        state: {
+            loading: false
+        },
+        mutations: {
+            startLoader (state) {
+                state.loading = true;
+            },
+            stopLoader (state) {
+                state.loading = false;
+            }
+        }
+    });
+
+    let timer: ReturnType<typeof setTimeout>;
+
+    Inertia.on('start', () => {
+        // Only instantiate loading state after 250ms. This is done to
+        // prevent a flash of the loader in case loading is nearly
+        // immediate, which can be visually distracting.
+        timer = setTimeout(() => store.commit('startLoader'), 250);
+    });
+
+    Inertia.on('finish', (event) => {
+        clearTimeout(timer);
+        const status = event.detail.visit;
+
+        if (status.completed || status.cancelled) {
+            store.commit('stopLoader');
+        }
+    });
+
+    return store;
+}
+
+// Only bootstrap inertia if setup is successful. Display generic error
 // component otherwise
 (async () => {
     try {
         await setupI18n(document.documentElement.lang);
+        const store = createStore();
 
         createInertiaApp({
             resolve: name => {
@@ -28,7 +73,8 @@ async function setupI18n(locale: string): Promise<void>{
             },
             setup({ el, app, props }) {
                 new Vue({
-                    render: h => h(app, props)
+                    render: h => h(app, props),
+                    store
                 }).$mount(el);
             }
         });


### PR DESCRIPTION
This change introduces [Vuex](https://vuex.vuejs.org/) as a way to manage shared state between page components. This is needed so that we could pass down the global "loading" state from inertia.js into our page components as needed.

As this store setup is adding more code to our app bootstrapping file: `app.ts`. This file is restructured for better readability, and to ensure that  we are only bootstrapping the inertia app if setup succeeds.

Bug: [T290162](https://phabricator.wikimedia.org/T290162)