### PR TITLE
Ensure too long description in validation test

### DIFF
--- a/tests/Feature/ApiImportRouteTest.php
+++ b/tests/Feature/ApiImportRouteTest.php
@@ -167,7 +167,7 @@ class ApiImportRouteTest extends TestCase
         Sanctum::actingAs($user);
 
         $response = $this->postJson(self::IMPORTS_ROUTE, [
-            'description' => $this->faker->realText($maxLength + 10)
+            'description' => $this->faker->realTextBetween($maxLength + 10, $maxLength + 100)
         ]);
 
         $response


### PR DESCRIPTION
This quick fix avoids rare test failures in the import test.