### PR TITLE
Fix header tokens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2950,17 +2950,17 @@
             }
         },
         "node_modules/@wmde/wikit-tokens": {
-            "version": "2.1.0-alpha.2",
-            "resolved": "https://registry.npmjs.org/@wmde/wikit-tokens/-/wikit-tokens-2.1.0-alpha.2.tgz",
-            "integrity": "sha512-xX9rItU2Z7NCz0HyvI0AGxlHmJnpIHOrczCea6sU8aNGEI6lzcaRHsLHvcka6FK9RnhqgjEAtS7egE3MKb5YZw=="
+            "version": "2.1.0-alpha.3",
+            "resolved": "https://registry.npmjs.org/@wmde/wikit-tokens/-/wikit-tokens-2.1.0-alpha.3.tgz",
+            "integrity": "sha512-ODSDonucIgwbfbnV0Cwj1t9t5jzktjfO6NQ174P7xvIuRCRT9aBmkQSKFp80rgzwJh1UeunE7gHO93mMpK7jeg=="
         },
         "node_modules/@wmde/wikit-vue-components": {
-            "version": "2.1.0-alpha.2",
-            "resolved": "https://registry.npmjs.org/@wmde/wikit-vue-components/-/wikit-vue-components-2.1.0-alpha.2.tgz",
-            "integrity": "sha512-2rYZbjv9InY+2j+4g9t22K+XtIyJUUbiILvVFsv6BKgFqWCn+rtIK+D+9KXJFir2eTMyVJAzFL4zGL6btX2GGg==",
+            "version": "2.1.0-alpha.3",
+            "resolved": "https://registry.npmjs.org/@wmde/wikit-vue-components/-/wikit-vue-components-2.1.0-alpha.3.tgz",
+            "integrity": "sha512-fC1Yh4w7HLdvWRByDnelMeOLQ5WKDGMM9Zpgk75742NcYSi8sgiUkGx3L2ntsptT3kHiwErqHKiJ2q7SbUuSGw==",
             "dependencies": {
                 "@vue/composition-api": "^1.0.0-beta.20",
-                "@wmde/wikit-tokens": "^2.1.0-alpha.2",
+                "@wmde/wikit-tokens": "^2.1.0-alpha.3",
                 "core-js": "^3.7.0",
                 "lodash.debounce": "^4.0.8",
                 "lodash.isequal": "^4.5.0",
@@ -17297,17 +17297,17 @@
             "requires": {}
         },
         "@wmde/wikit-tokens": {
-            "version": "2.1.0-alpha.2",
-            "resolved": "https://registry.npmjs.org/@wmde/wikit-tokens/-/wikit-tokens-2.1.0-alpha.2.tgz",
-            "integrity": "sha512-xX9rItU2Z7NCz0HyvI0AGxlHmJnpIHOrczCea6sU8aNGEI6lzcaRHsLHvcka6FK9RnhqgjEAtS7egE3MKb5YZw=="
+            "version": "2.1.0-alpha.3",
+            "resolved": "https://registry.npmjs.org/@wmde/wikit-tokens/-/wikit-tokens-2.1.0-alpha.3.tgz",
+            "integrity": "sha512-ODSDonucIgwbfbnV0Cwj1t9t5jzktjfO6NQ174P7xvIuRCRT9aBmkQSKFp80rgzwJh1UeunE7gHO93mMpK7jeg=="
         },
         "@wmde/wikit-vue-components": {
-            "version": "2.1.0-alpha.2",
-            "resolved": "https://registry.npmjs.org/@wmde/wikit-vue-components/-/wikit-vue-components-2.1.0-alpha.2.tgz",
-            "integrity": "sha512-2rYZbjv9InY+2j+4g9t22K+XtIyJUUbiILvVFsv6BKgFqWCn+rtIK+D+9KXJFir2eTMyVJAzFL4zGL6btX2GGg==",
+            "version": "2.1.0-alpha.3",
+            "resolved": "https://registry.npmjs.org/@wmde/wikit-vue-components/-/wikit-vue-components-2.1.0-alpha.3.tgz",
+            "integrity": "sha512-fC1Yh4w7HLdvWRByDnelMeOLQ5WKDGMM9Zpgk75742NcYSi8sgiUkGx3L2ntsptT3kHiwErqHKiJ2q7SbUuSGw==",
             "requires": {
                 "@vue/composition-api": "^1.0.0-beta.20",
-                "@wmde/wikit-tokens": "^2.1.0-alpha.2",
+                "@wmde/wikit-tokens": "^2.1.0-alpha.3",
                 "core-js": "^3.7.0",
                 "lodash.debounce": "^4.0.8",
                 "lodash.isequal": "^4.5.0",

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -25,6 +25,12 @@ section {
 
 h1, .h1 {
     @include heading-1;
+
+    margin: $dimension-layout-xsmall 0;
+
+    @media (min-width: $width-breakpoint-tablet) {
+        margin: $dimension-layout-small 0;
+    }
 }
 
 h4, .h4 {
@@ -58,8 +64,13 @@ a {
 
 .store header{
     flex-direction: row;
+
     @media (max-width: $width-breakpoint-tablet) {
         flex-direction: column-reverse;
+    }
+
+    h1 {
+        margin: 0;
     }
 
     .auth-widget {
@@ -81,11 +92,6 @@ a {
             flex-direction: column;
         }
     }
-    h1 {
-        @media (max-width: $width-breakpoint-tablet) {
-            margin: $dimension-layout-xxsmall 0;
-        }
-    }
 }
 
 header {
@@ -95,7 +101,7 @@ header {
 
     @media (max-width: $width-breakpoint-tablet) {
         margin: $dimension-layout-xsmall 0;
-    }  
+    }
 
     .auth-widget {
         font-family: 'Lato', sans-serif;


### PR DESCRIPTION
This change reverts the headers token back to their correct assignment as based on the Mismatch Finder website's [figma specification](https://www.figma.com/file/sgK1Go5my7ShZ1HQIxV2FI/Mismatch-Finder?node-id=1119%3A22624) and to ensure the consistency of our global styles.

In addition, the WiKit version is updated in order to ensure the correct sizing of layout tokens, as they were corrected in WiKit itself.

Bug: [T290634](https://phabricator.wikimedia.org/T290634)