### PR TITLE
Apply QID validation on results web route

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Auth;
+use App\Http\Requests\MismatchGetRequest;
 
 /*
 |--------------------------------------------------------------------------
@@ -28,13 +29,12 @@ Route::get('/', function () {
     ]);
 })->name('home');
 
-Route::get('/results', function (Request $request) {
+Route::get('/results', function (MismatchGetRequest $request) {
     $user = Auth::user() ? [
         'name' => Auth::user()->username
     ] : null;
 
-    $separator = config('mismatches.id_separator');
-    $ids = explode($separator, $request->input('ids'));
+    $ids = $request->input('ids');
 
     return inertia('Results', [
         'item_ids' => $ids,

--- a/tests/Browser/ItemsFormTest.php
+++ b/tests/Browser/ItemsFormTest.php
@@ -31,7 +31,7 @@ class ItemsFormTest extends DuskTestCase
                     ->press('button')
                     ->waitFor('@results')
                     ->assertTitle('Mismatch Finder - Results')
-                    ->assertSee('[ "Q1", "q2" ]');
+                    ->assertSee('[ "Q1", "Q2" ]');
         });
     }
 

--- a/tests/Browser/Pages/ResultsPage.php
+++ b/tests/Browser/Pages/ResultsPage.php
@@ -8,13 +8,24 @@ use Laravel\Dusk\Page;
 class ResultsPage extends Page
 {
     /**
+     * @var string
+     */
+    private $ids;
+
+    public function __construct(?string $ids = null)
+    {
+        $this->ids = $ids;
+    }
+    /**
      * Get the URL for the page.
      *
      * @return string
      */
     public function url()
     {
-        return route('results');
+        return route('results', [
+            'ids' => $this->ids
+        ]);
     }
 
     /**

--- a/tests/Browser/ResultsTest.php
+++ b/tests/Browser/ResultsTest.php
@@ -11,7 +11,7 @@ class ResultsTest extends DuskTestCase
     public function test_shows_results()
     {
         $this->browse(function (Browser $browser) {
-            $browser->visit(new ResultsPage)
+            $browser->visit(new ResultsPage('Q1|Q2'))
                 ->assertSee('Results');
         });
     }

--- a/tests/Feature/WebRouteTest.php
+++ b/tests/Feature/WebRouteTest.php
@@ -64,6 +64,54 @@ class WebRouteTest extends TestCase
     }
 
     /**
+     * Test the /results route
+     *
+     *  @return void
+     */
+    public function test_results_route()
+    {
+        $response = $this->get(route('results', [
+            'ids' => 'Q1|Q2'
+        ]));
+
+        $response->assertSuccessful();
+        $response->assertViewIs('app')
+            ->assertInertia(function (Assert $page) {
+                $page->component('Results');
+            });
+    }
+
+    /**
+     * Test the /results redirects when no ids provided
+     *
+     *  @return void
+     */
+    public function test_results_route_redirects_on_missing_ids()
+    {
+        $response = $this->get(route('results'));
+
+        $response->assertRedirect(route('home'));
+    }
+
+    /**
+     * Test the /results route accepts lowercase QIDs
+     *
+     *  @return void
+     */
+    public function test_results_route_accepts_lowercase_ids()
+    {
+        $response = $this->get(route('results', [
+            'ids' => 'q1|q2'
+        ]));
+
+        $response->assertSuccessful();
+        $response->assertViewIs('app')
+            ->assertInertia(function (Assert $page) {
+                $page->component('Results');
+            });
+    }
+
+    /**
      * Test the / route with a non translated language code
      *
      *  @return void


### PR DESCRIPTION
This change applies to the `results` web route, the same validation and sanitization logic that we apply to our `mismatches` api route.