### PR TITLE
Add basic table component

### DIFF
--- a/resources/js/Components/Table.vue
+++ b/resources/js/Components/Table.vue
@@ -25,6 +25,62 @@ export default Vue.extend({
 <style lang="scss">
     @import '~@wmde/wikit-tokens/dist/_variables.scss';
 
+    @mixin LinearTable {
+        /**
+        * Wipe the thead from the face of the earth
+        * modern screen readers will expose the
+        * generated content
+        */
+        thead {
+            display: none;
+            visibility: hidden;
+        }
+
+        /**
+        * make everything display flex for alignment
+        */
+        tbody, tr, th, td {
+            height: auto;
+            display: flex;
+            flex-direction: column;
+        }
+
+        td, th {
+            flex-direction: row;
+            flex-basis: 60%;
+        }
+
+        /**
+        * Labeling
+        *
+        * Adding a data-title attribute to the cells
+        * lets us add text before the content to provide
+        * the missing context.
+        *
+        * Markup:
+        *   <td data-title="Column Header">Content Here</td>
+        *
+        * Display:
+        *   Column Header: Content Here
+        */
+        th[data-header]:before,
+        td[data-header]:before {
+            content: attr(data-header);
+            display: block;
+            font-weight: bold;
+            flex-basis: 40%;
+        }
+
+        th:not([data-header]) {
+            font-weight: bold;
+        }
+
+        // hide empty cells
+        td:empty {
+            display: none;
+        }
+    }
+
     .wikit-Table {
         /**
         * Layout
@@ -97,5 +153,22 @@ export default Vue.extend({
         }
 
 
+        &--linear-mobile {
+            @media (max-width: $width-breakpoint-mobile){
+                @include LinearTable;
+            }
+        }
+
+        &--linear-tablet {
+            @media (max-width: $width-breakpoint-tablet){
+                @include LinearTable;
+            }
+        }
+
+        &--linear-desktop {
+            @media (max-width: $width-breakpoint-desktop){
+                @include LinearTable;
+            }
+        }
     }
 </style>

--- a/resources/js/Components/Table.vue
+++ b/resources/js/Components/Table.vue
@@ -2,7 +2,7 @@
     <table :class="[
         'wikit',
         'wikit-Table',
-        `wikit-Table--linear-${linearize}`
+        `wikit-Table--linear-${breakpoint}`
     ]">
         <slot></slot>
     </table>
@@ -10,15 +10,23 @@
 
 <script lang="ts">
 import Vue, { PropType } from 'vue';
+import { Breakpoint, validateBreakpoint } from '../types/Breakpoint';
 
 export default Vue.extend({
     props: {
         linearize: {
-            type: String,
-            default: 'tablet'
+            type: String as PropType<Breakpoint>,
+            validator( value: Breakpoint ): boolean {
+                return validateBreakpoint(value);
+            },
+            default: Breakpoint.Tablet
         }
     },
-    components: {}
+    computed: {
+        breakpoint(): string {
+            return validateBreakpoint( this. linearize ) ? this.linearize : 'tablet';
+        }
+    }
 });
 </script>
 

--- a/resources/js/Components/Table.vue
+++ b/resources/js/Components/Table.vue
@@ -102,7 +102,6 @@ export default Vue.extend({
         table-layout: auto;
         width: 100%;
 
-
         /**
         * Borders
         */
@@ -159,7 +158,6 @@ export default Vue.extend({
             */
             font-weight: $font-weight-bold;
         }
-
 
         &--linear-mobile {
             @media (max-width: $width-breakpoint-mobile){

--- a/resources/js/Components/Table.vue
+++ b/resources/js/Components/Table.vue
@@ -1,0 +1,101 @@
+<template>
+    <table :class="[
+        'wikit',
+        'wikit-Table',
+        `wikit-Table--linear-${linearize}`
+    ]">
+        <slot></slot>
+    </table>
+</template>
+
+<script lang="ts">
+import Vue, { PropType } from 'vue';
+
+export default Vue.extend({
+    props: {
+        linearize: {
+            type: String,
+            default: 'tablet'
+        }
+    },
+    components: {}
+});
+</script>
+
+<style lang="scss">
+    @import '~@wmde/wikit-tokens/dist/_variables.scss';
+
+    .wikit-Table {
+        /**
+        * Layout
+        */
+        // As the specificationn state that the table columns should gain their
+        // width from cell content (instead of just header content / width) we
+        // revert to using the default table layout algorithm. This is done in
+        // order to avoid changing the table's display proterty and thus
+        // oblitirating it's inehrit accesibility:
+        // See: https://www.tpgi.com/short-note-on-what-css-display-properties-do-to-table-semantics/
+        table-layout: auto;
+        width: 100%;
+
+
+        /**
+        * Borders
+        */
+        border-collapse: collapse;
+
+        /**
+        * Colors
+        */
+        background-color: $background-color-base-default;
+        color: $font-color-base;
+
+        /**
+        * Typography
+        */
+        font-family: $font-family-style-body;
+        font-size: $font-size-style-body;
+        font-weight: $font-weight-style-body;
+
+        tr {
+            /**
+            * Layout
+            */
+            height: $dimension-min-height-xlarge;
+
+            /**
+            * Borders
+            */
+            border-bottom-style: $border-style-base;
+            border-bottom-width: $border-width-thin;
+            border-radius: $border-radius-none;
+            border-bottom-color: $border-color-base-subtle;
+        }
+
+        th, td {
+            /**
+            * Layout
+            */
+            padding-inline: $dimension-spacing-medium;
+            padding-block: $dimension-spacing-small;
+
+            /**
+            * Typography
+            */
+            line-height: $font-line-height-style-label;
+            text-align: start;
+            vertical-align: middle;
+            overflow-wrap: break-word;
+            hyphens: auto;
+        }
+
+        th {
+            /**
+            * Typography
+            */
+            font-weight: $font-weight-bold;
+        }
+
+
+    }
+</style>

--- a/resources/js/Pages/Playground.vue
+++ b/resources/js/Pages/Playground.vue
@@ -3,10 +3,7 @@
     <Head title="Mismatch Finder - Component Playground" />
     <h2>Mismatch Finder - Playground!</h2>
     <p>Feel free to throw any component you want to try, in here</p>
-    <!-- <auth-widget v-bind:user="user" />
-    <text-area :rows="10" label="I am from Wikit" resize="horizontal" value="With a default value" @input="printVal" />
-    <wikit-button type="progressive" variant="primary" @click.native="console">Test Wikit Component</wikit-button> -->
-    <wikit-table id="some-table" linearize="mobile">
+    <wikit-table id="some-table" linearize="desktop">
         <thead>
             <tr>
                 <th scope="col">Name</th>

--- a/resources/js/Pages/Playground.vue
+++ b/resources/js/Pages/Playground.vue
@@ -15,7 +15,10 @@
             <tr v-for="dessert in desserts" :key="dessert.name">
                 <!-- When using the table make sure to include the
                     data-header for linearization and accesibility -->
-                <td data-header="Name">{{dessert.name}}</td>
+                <td data-header="Name">
+                    <Link v-if="dessert.url" :href="dessert.url">{{dessert.name}}</Link>
+                    <div v-else>{{dessert.name}}</div>
+                </td>
                 <td data-header="Calories">{{dessert.calories}}</td>
             </tr>
         </tbody>
@@ -27,10 +30,12 @@
     import { Head } from '@inertiajs/inertia-vue'
     import WikitTable from '../Components/Table.vue';
     import defineComponent from '../types/defineComponent';
+    import { Link } from '@wmde/wikit-vue-components';
 
     export default defineComponent({
         components: {
             Head,
+            Link,
             WikitTable
         },
         props: {
@@ -49,6 +54,7 @@
                 desserts: [
                     {
                         name: 'Frozen Yogurt',
+                        url: 'https://commons.wikimedia.org/wiki/File:Blueberry_frozen_yoghurt_(4937999312).jpg',
                         calories: 159,
                     },
                     {

--- a/resources/js/Pages/Playground.vue
+++ b/resources/js/Pages/Playground.vue
@@ -1,25 +1,40 @@
 <template>
-  <div>
+  <div lang="en">
     <Head title="Mismatch Finder - Component Playground" />
-    <h1>Mismatch Finder - Playground!</h1>
+    <h2>Mismatch Finder - Playground!</h2>
     <p>Feel free to throw any component you want to try, in here</p>
-    <auth-widget v-bind:user="user" />
+    <!-- <auth-widget v-bind:user="user" />
     <text-area :rows="10" label="I am from Wikit" resize="horizontal" value="With a default value" @input="printVal" />
-    <wikit-button type="progressive" variant="primary" @click.native="console">Test Wikit Component</wikit-button>
+    <wikit-button type="progressive" variant="primary" @click.native="console">Test Wikit Component</wikit-button> -->
+    <wikit-table id="some-table" linearize="mobile">
+        <thead>
+            <tr>
+                <th scope="col">Name</th>
+                <th scope="col">Calories</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr v-for="dessert in desserts" :key="dessert.name">
+                <td data-header="Name">{{dessert.name}}</td>
+                <td data-header="Calories">{{dessert.calories}}</td>
+            </tr>
+        </tbody>
+    </wikit-table>
   </div>
 </template>
 
 <script lang="ts">
     import { Head } from '@inertiajs/inertia-vue'
     import AuthWidget from '../Components/AuthWidget.vue';
+    import WikitTable from '../Components/Table.vue';
     import { Button as WikitButton, TextArea } from '@wmde/wikit-vue-components';
-
     import defineComponent from '../types/defineComponent';
 
     export default defineComponent({
         components: {
             Head,
             AuthWidget,
+            WikitTable,
             TextArea,
             WikitButton
         },
@@ -33,19 +48,56 @@
             printVal(v: string) {
                 console.log(v);
             }
+        },
+        data(){
+            return {
+                desserts: [
+                    {
+                        name: 'Frozen Yogurt',
+                        calories: 159,
+                    },
+                    {
+                        name: 'Ice cream sandwich',
+                        calories: 237,
+                    },
+                    {
+                        name: 'Eclair',
+                        calories: 262,
+                    },
+                    {
+                        name: 'Cupcake',
+                        calories: 305,
+                    },
+                    {
+                        name: 'Gingerbread',
+                        calories: 356,
+                    },
+                    {
+                        name: 'Jelly bean',
+                        calories: 375,
+                    },
+                    {
+                        name: 'Lollipop',
+                        calories: 392,
+                    },
+                    {
+                        name: 'Honeycomb',
+                        calories: 408,
+                    },
+                    {
+                        name: 'Donut',
+                        calories: 452,
+                    },
+                    {
+                        name: 'KitKat',
+                        calories: 518,
+                    },
+                ],
+            }
         }
     });
 </script>
 
 <style lang="scss">
-@import url('https://fonts.googleapis.com/css2?family=Lato&family=Source+Serif+Pro&display=swap');
 
-h1 {
-    font-family: 'Source Serif Pro', serif;
-    font-size: 32px;
-    line-height: 40px;
-    margin: 0;
-    padding: 0 0 28px 0;
-    font-weight: 400;
-}
 </style>

--- a/resources/js/Pages/Playground.vue
+++ b/resources/js/Pages/Playground.vue
@@ -3,6 +3,7 @@
     <Head title="Mismatch Finder - Component Playground" />
     <h2>Mismatch Finder - Playground!</h2>
     <p>Feel free to throw any component you want to try, in here</p>
+
     <wikit-table id="some-table" linearize="desktop">
         <thead>
             <tr>
@@ -22,18 +23,13 @@
 
 <script lang="ts">
     import { Head } from '@inertiajs/inertia-vue'
-    import AuthWidget from '../Components/AuthWidget.vue';
     import WikitTable from '../Components/Table.vue';
-    import { Button as WikitButton, TextArea } from '@wmde/wikit-vue-components';
     import defineComponent from '../types/defineComponent';
 
     export default defineComponent({
         components: {
             Head,
-            AuthWidget,
-            WikitTable,
-            TextArea,
-            WikitButton
+            WikitTable
         },
         props: {
             user: Object,

--- a/resources/js/Pages/Playground.vue
+++ b/resources/js/Pages/Playground.vue
@@ -13,6 +13,8 @@
         </thead>
         <tbody>
             <tr v-for="dessert in desserts" :key="dessert.name">
+                <!-- When using the table make sure to include the
+                    data-header for linearization and accesibility -->
                 <td data-header="Name">{{dessert.name}}</td>
                 <td data-header="Calories">{{dessert.calories}}</td>
             </tr>

--- a/resources/js/types/Breakpoint.ts
+++ b/resources/js/types/Breakpoint.ts
@@ -1,0 +1,15 @@
+enum Breakpoint {
+    Mobile = 'mobile',
+    Tablet = 'tablet',
+    Desktop = 'desktop'
+}
+
+function validateBreakpoint(breakpoint: string): boolean {
+    return Object.values( Breakpoint ).includes( breakpoint as Breakpoint );
+}
+
+export {
+    Breakpoint,
+    validateBreakpoint
+};
+

--- a/tests/Vue/Components/Table.spec.js
+++ b/tests/Vue/Components/Table.spec.js
@@ -1,0 +1,24 @@
+import { mount } from '@vue/test-utils';
+import Table from '@/Components/Table.vue';
+import {Breakpoint} from '@/types/Breakpoint.ts';
+
+describe('Table.vue', () => {
+    it('accepts a linerize property', () => {
+        const wrapper = mount(Table, {
+            propsData: {
+                linearize: Breakpoint.Desktop
+            }
+        });
+
+        expect( wrapper.props().linearize ).toBe( Breakpoint.Desktop );
+		expect( wrapper.find( 'table' ).classes() ).toContain( 'wikit-Table--linear-desktop' );
+    });
+
+    it('ignores invalid breakpoint values', () => {
+        const wrapper = mount(Table, {
+            propsData: { linearize: 'nonsense' }
+        });
+
+        expect(wrapper.find('table').classes()).toContain('wikit-Table--linear-tablet');
+    });
+})

--- a/tests/Vue/Components/Table.spec.js
+++ b/tests/Vue/Components/Table.spec.js
@@ -3,7 +3,7 @@ import Table from '@/Components/Table.vue';
 import {Breakpoint} from '@/types/Breakpoint.ts';
 
 describe('Table.vue', () => {
-    it('accepts a linerize property', () => {
+    it('accepts a linearize property', () => {
         const wrapper = mount(Table, {
             propsData: {
                 linearize: Breakpoint.Desktop


### PR DESCRIPTION
This change adds the basic table component required to display mismatch results for our table. This component serves as a wrapper for the generic HTML5 table components, in order to apply styles and responsive fallback to displayed tabular data. See `Playground.vue` for a usage example.

Bug: [T289843](https://phabricator.wikimedia.org/T289843)