### PR TITLE
Client/home page error handling

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -43,4 +43,22 @@ class Handler extends ExceptionHandler
             }
         });
     }
+
+    /**
+     * Prepare error messages on failed responses
+     *
+     * @param  \Throwable  $e
+     * @return \Throwable
+     */
+    public function render($request, Throwable $e)
+    {
+        $response = parent::render($request, $e);
+
+        if ($response->status() >= 500) {
+            return redirect(route('home'))
+                ->with('serverErrors', [ 'unexpected' => 'Unexpected error' ]);
+        }
+
+        return $response;
+    }
 }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -62,6 +62,7 @@ class Kernel extends HttpKernel
         'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
         'password.confirm' => \Illuminate\Auth\Middleware\RequirePassword::class,
         'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
+        'simulateError' => \App\Http\Middleware\SimulateError::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
     ];

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -37,7 +37,9 @@ class HandleInertiaRequests extends Middleware
     public function share(Request $request)
     {
         return array_merge(parent::share($request), [
-            //
+            'flash' => [
+                'errors' => fn () => $request->session()->get('serverErrors')
+            ],
         ]);
     }
 }

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -38,7 +38,9 @@ class HandleInertiaRequests extends Middleware
     {
         return array_merge(parent::share($request), [
             'flash' => [
-                'errors' => fn () => $request->session()->get('serverErrors')
+                'errors' => function () use ($request) {
+                    return $request->session()->get('serverErrors');
+                }
             ],
         ]);
     }

--- a/app/Http/Middleware/SimulateError.php
+++ b/app/Http/Middleware/SimulateError.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use RuntimeException;
+
+/**
+ * This middleware will force a RuntimeException for testing purposes, if the
+ * 'X-Mismatch-Results-Error' HTTP header field is sent with the request. It
+ * allows for simple feature tests of the error routing behaviour as well as
+ * easy verification by testers, using a browser extension such as
+ * https://addons.mozilla.org/de/firefox/addon/modheader-firefox/
+ */
+class SimulateError
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        if ($request->header('X-Mismatch-Results-Error')) {
+            throw new RuntimeException("Simulated Server Error");
+        }
+    
+        return $next($request);
+    }
+}

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -18,5 +18,6 @@
     "log-out": "Log out",
     "mismatch-finder-title": "Mismatch Finder",
     "item-form-error-message-empty": "Please provide the Item identifiers in order to perform the check.",
-    "item-form-error-message-invalid": "One or more Item identifiers couldn't be processed. Please make sure to add only one identifier per line, without spaces or commas. Item identifiers should only be a set of valid numbers preceded by the letter Q (for example: Q1459)."
+    "item-form-error-message-invalid": "One or more Item identifiers couldn't be processed. Please make sure to add only one identifier per line, without spaces or commas. Item identifiers should only be a set of valid numbers preceded by the letter Q (for example: Q1256).",
+    "mismatch-query-server-error": "The server encountered a temporary error and could not complete your request. Please try again."
 }

--- a/public/i18n/qqq.json
+++ b/public/i18n/qqq.json
@@ -15,5 +15,6 @@
     "log-out": "The call to action for user log out",
     "mismatch-finder-title": "The main title of the website",
     "item-form-error-message-empty": "A warning message when no Item ids are provided",
-    "item-form-error-message-invalid": "An error message when invalid Item ids are provided"
+    "item-form-error-message-invalid": "An error message when invalid Item ids are provided",
+    "mismatch-query-server-error": "An error message when the server encountered an error retrieving results"
 }

--- a/resources/js/Pages/Home.vue
+++ b/resources/js/Pages/Home.vue
@@ -6,9 +6,11 @@
             <p id="about-description" >{{ $i18n('about-mismatch-finder-description') }}</p>
         </section>
 
-        <Message id="error-message" v-if="unexpectedError" type="error">
-            <span>{{ $i18n('mismatch-query-server-error') }}</span>
-        </Message>
+        <section id="message-section">
+            <Message v-if="unexpectedError" type="error">
+                <span>{{ $i18n('mismatch-query-server-error') }}</span>
+            </Message>
+        </section>
 
         <section id="querying-section">
             <h2 class="h5">{{ $i18n('item-form-title') }}</h2>
@@ -137,6 +139,14 @@
     max-width: 705px;
 }
 
+#message-section {
+    max-width: 675px;
+
+    .wikit-Message {
+        border-radius: $border-radius-base;
+    }
+}
+
 #items-form {
     /**
     * Colors
@@ -167,11 +177,5 @@
     .form-buttons {
         text-align: end;
     }
-}
-
-#error-message {
-    max-width: 675px;
-    margin: 40px 0px 40px 0px;
-    border-radius: $border-radius-base;
 }
 </style>

--- a/resources/js/Pages/Home.vue
+++ b/resources/js/Pages/Home.vue
@@ -5,6 +5,13 @@
             <h2 class="h4">{{ $i18n('about-mismatch-finder-title') }}</h2>
             <p id="about-description" >{{ $i18n('about-mismatch-finder-description') }}</p>
         </section>
+
+        <div v-if="unexpectedError">
+            <Message type="error">
+                <span>{{ $i18n('mismatch-query-server-error') }}</span>
+            </Message>
+        </div>
+
         <section id="querying-section">
             <h2 class="h5">{{ $i18n('item-form-title') }}</h2>
             <form id="items-form" @submit.prevent="send">
@@ -36,6 +43,7 @@
     import { Head } from '@inertiajs/inertia-vue';
     import {
         Button as WikitButton,
+        Message,
         TextArea
     } from '@wmde/wikit-vue-components';
 
@@ -51,9 +59,14 @@
         }
     }
 
+    interface FlashMessages {
+        errors : { [ key : string ] : string }
+    }
+
     export default defineComponent({
         components: {
             Head,
+            Message,
             TextArea,
             WikitButton
         },
@@ -98,9 +111,16 @@
                 this.$inertia.get( '/results?ids=' + this.serializeInput() );
             },
         },
-        computed: mapState({
-            loading: 'loading'
-        }),
+        computed: {
+            unexpectedError() {
+                const flashMessages = this.$page.props.flash as FlashMessages;
+                return (flashMessages && flashMessages.errors);
+            },
+            // spread to combine with local computed props
+            ...mapState({
+                loading: 'loading'
+            }),
+        },
         data(): HomeState {
             return {
                 form: {

--- a/resources/js/Pages/Home.vue
+++ b/resources/js/Pages/Home.vue
@@ -13,7 +13,7 @@
                     :placeholder="$i18n('item-form-id-input-placeholder')"
                     :rows="8"
                     :loading="loading"
-                    :error="error"
+                    :error="validationError"
                     v-model="form.itemsInput"
                 />
                 <div class="form-buttons">
@@ -45,7 +45,7 @@
         form: {
             itemsInput: string
         },
-        error: null|{
+        validationError: null|{
             type: string,
             message: string
         }
@@ -66,14 +66,14 @@
             },
             checkEmpty(): void {
                 if( !this.form.itemsInput ) {
-                    this.error = {
+                    this.validationError = {
                         type: 'warning',
                         message: this.$i18n('item-form-error-message-empty')
                     };
                 }
             },
             validate(): void {
-                this.error = null;
+                this.validationError = null;
                 this.checkEmpty();
 
                 let valid = this.splitInput().every( function( currentValue: string ) {
@@ -82,7 +82,7 @@
                 });
 
                 if( !valid ) {
-                    this.error = {
+                    this.validationError = {
                         type: 'error',
                         message: this.$i18n('item-form-error-message-invalid')
                     };
@@ -91,7 +91,7 @@
             send(): void {
                 this.validate();
 
-                if(this.error) {
+                if(this.validationError) {
                     return;
                 }
 
@@ -106,7 +106,7 @@
                 form: {
                     itemsInput: ''
                 },
-                error: null
+                validationError: null
             }
         }
     });

--- a/resources/js/Pages/Home.vue
+++ b/resources/js/Pages/Home.vue
@@ -114,7 +114,7 @@
         computed: {
             unexpectedError() {
                 const flashMessages = this.$page.props.flash as FlashMessages;
-                return (flashMessages && flashMessages.errors);
+                return (flashMessages.errors && flashMessages.errors.unexpected);
             },
             // spread to combine with local computed props
             ...mapState({

--- a/resources/js/Pages/Home.vue
+++ b/resources/js/Pages/Home.vue
@@ -6,11 +6,9 @@
             <p id="about-description" >{{ $i18n('about-mismatch-finder-description') }}</p>
         </section>
 
-        <div v-if="unexpectedError">
-            <Message type="error">
-                <span>{{ $i18n('mismatch-query-server-error') }}</span>
-            </Message>
-        </div>
+        <Message id="error-message" v-if="unexpectedError" type="error">
+            <span>{{ $i18n('mismatch-query-server-error') }}</span>
+        </Message>
 
         <section id="querying-section">
             <h2 class="h5">{{ $i18n('item-form-title') }}</h2>
@@ -169,5 +167,11 @@
     .form-buttons {
         text-align: end;
     }
+}
+
+#error-message {
+    max-width: 675px;
+    margin: 40px 0px 40px 0px;
+    border-radius: $border-radius-base;
 }
 </style>

--- a/routes/web.php
+++ b/routes/web.php
@@ -31,6 +31,11 @@ Route::get('/', function () {
 })->name('home');
 
 Route::get('/results', function (MismatchGetRequest $request) {
+    if ($request->header('X-Mismatch-Results-Error')) {
+        // force a 500 server response for testing purposes
+        throw new RuntimeException("Simulated Server Error");
+    }
+
     $user = Auth::user() ? [
         'name' => Auth::user()->username
     ] : null;

--- a/routes/web.php
+++ b/routes/web.php
@@ -30,27 +30,23 @@ Route::get('/', function () {
     ]);
 })->name('home');
 
-Route::get('/results', function (MismatchGetRequest $request) {
-    if ($request->header('X-Mismatch-Results-Error')) {
-        // force a 500 server response for testing purposes
-        throw new RuntimeException("Simulated Server Error");
-    }
+Route::middleware('simulateError')
+    ->get('/results', function (MismatchGetRequest $request) {
+        $user = Auth::user() ? [
+            'name' => Auth::user()->username
+        ] : null;
 
-    $user = Auth::user() ? [
-        'name' => Auth::user()->username
-    ] : null;
+        $ids = $request->input('ids');
 
-    $ids = $request->input('ids');
-
-    $query = Mismatch::whereIn('item_id', $request->ids);
-    $results = MismatchResource::collection($query->get());
-    
-    return inertia('Results', [
-        'item_ids' => $ids,
-        'user' => $user,
-        'results' => $results,
-    ]);
-})->name('results');
+        $query = Mismatch::whereIn('item_id', $request->ids);
+        $results = MismatchResource::collection($query->get());
+        
+        return inertia('Results', [
+            'item_ids' => $ids,
+            'user' => $user,
+            'results' => $results,
+        ]);
+    })->name('results');
 
 // Mismatch store manager routes, might be converted to inertia routes in the future
 Route::prefix('store')->name('store.')->group(function () {

--- a/tests/Feature/WebRouteTest.php
+++ b/tests/Feature/WebRouteTest.php
@@ -203,14 +203,14 @@ class WebRouteTest extends TestCase
         $redirect = $this
             ->get(
                 route('results', ['ids' => 'Q1']),
-                ['X-Mismatch-Results-Error' => 'true']
-            );
+                ['X-Mismatch-Results-Error' => 'true']  // force error response
+            )->assertRedirect(route('home'));
 
-        $redirect->assertRedirect(route('home'));
-        $response = $this->get($redirect->headers->get('Location'));
-        $response->assertInertia(function (Assert $page) {
+        // follow the redirect
+        $this->get($redirect->headers->get('Location'))
+            ->assertInertia(function (Assert $page) {
                 $page->component('Home')
                     ->where('flash.errors', [ 'unexpected' => 'Unexpected error']);
-        });
+            });
     }
 }

--- a/tests/Feature/WebRouteTest.php
+++ b/tests/Feature/WebRouteTest.php
@@ -192,4 +192,25 @@ class WebRouteTest extends TestCase
         $response->assertSuccessful();
         $response->assertViewIs('importStatus');
     }
+
+    /**
+     * Test error response handling
+     *
+     * @return void
+     */
+    public function test_error_response_handling()
+    {
+        $redirect = $this
+            ->get(
+                route('results', ['ids' => 'Q1']),
+                ['X-Mismatch-Results-Error' => 'true']
+            );
+
+        $redirect->assertRedirect(route('home'));
+        $response = $this->get($redirect->headers->get('Location'));
+        $response->assertInertia(function (Assert $page) {
+                $page->component('Home')
+                    ->where('flash.errors', [ 'unexpected' => 'Unexpected error']);
+        });
+    }
 }


### PR DESCRIPTION
This change redirects any error response by the server back to the home
route and adds an 'errors' flash message to the Inertia response. This
way the Home page can pick up the flash message and indicate a server
error with a Message component, triggered by a computed prop.

Testers will be able to fake/force a server error by sending a
'X-Mismatch-Results-Error' header field with their request to the
results route.

Bug: [T289344](https://phabricator.wikimedia.org/T289344)

