### PR TITLE
Enable label fetching from Wikidata

### DIFF
--- a/app/Services/WikibaseAPIClient.php
+++ b/app/Services/WikibaseAPIClient.php
@@ -64,4 +64,14 @@ class WikibaseAPIClient
 
         return $response;
     }
+
+    public function getLabels(array $ids, string $lang): array
+    {
+        $response = $this->formatEntities($ids, $lang);
+
+        // The code below was added due to the fact that wbformatentities only
+        // returns labels formatted as html links, however we only require the
+        // label text. Therefore, we extract the text from the links.
+        return array_map('strip_tags', $response['wbformatentities']);
+    }
 }

--- a/app/Services/WikibaseAPIClient.php
+++ b/app/Services/WikibaseAPIClient.php
@@ -54,4 +54,14 @@ class WikibaseAPIClient
 
         return $response;
     }
+
+    public function formatEntities(array $ids, string $lang): Response
+    {
+        $response = $this->get('wbformatentities', [
+            'ids' => implode('|', $ids),
+            'uselang' => $lang
+        ]);
+
+        return $response;
+    }
 }

--- a/tests/Feature/WikibaseAPIClientTest.php
+++ b/tests/Feature/WikibaseAPIClientTest.php
@@ -8,12 +8,8 @@ use App\Services\WikibaseAPIClient;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Str;
 use App\Exceptions\WikibaseValueParserException;
-use Illuminate\Http\Client\Response;
-use Mockery;
-use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Arr;
 use Kevinrob\GuzzleCache\CacheMiddleware;
-use Kevinrob\GuzzleCache\Strategy\NullCacheStrategy;
+use Mockery;
 
 class WikibaseAPIClientTest extends TestCase
 {

--- a/tests/Feature/WikibaseAPIClientTest.php
+++ b/tests/Feature/WikibaseAPIClientTest.php
@@ -82,6 +82,18 @@ class WikibaseAPIClientTest extends TestCase
         $this->assertSame($fakeResponseBody, $response->json());
     }
 
+    public function test_format_entities_returns_api_responses(): void {
+        $this->markTestIncomplete();
+    }
+
+    public function test_format_entities_returns_stripped_labels(): void {
+        $this->markTestIncomplete();
+    }
+
+    public function test_format_entities_returns_cached_responses(): void {
+        $this->markTestIncomplete();
+    }
+
     private function assertActionRequest(string $url, string $action, array $payload)
     {
         Http::assertSent(function (Request $req) use ($url, $action, $payload) {

--- a/tests/Feature/WikibaseAPIClientTest.php
+++ b/tests/Feature/WikibaseAPIClientTest.php
@@ -87,10 +87,34 @@ class WikibaseAPIClientTest extends TestCase
         $this->assertSame($fakeResponseBody, $response->json());
     }
 
-    }
+    public function test_get_labels_returns_label_array(): void
+    {
+        $fakeIds = ['P1234', 'Q4321'];
+        $fakePayload = [
+            'ids' => implode('|', $fakeIds),
+            'uselang' => 'en'
+        ];
 
-    public function test_format_entities_returns_stripped_labels(): void {
-        $this->markTestIncomplete();
+        $fakeResponseBody = ['wbformatentities' => [
+            'Q4321' => '<a title="Q4321" href="https://www.wikidata.org/wiki/Q4321">some item</a>',
+            'P1234' => '<a title="Property:P1234" href="https://www.wikidata.org/wiki/Property:P1234">some property</a>'
+        ]];
+
+        $expectedResult = [
+            'Q4321' => 'some item',
+            'P1234' => 'some property'
+        ];
+
+        Http::fake(function (Request $req) use ($fakeResponseBody) {
+            return Http::response($fakeResponseBody, 200);
+        });
+
+        $mockCache = Mockery::mock(CacheMiddleware::class)->shouldIgnoreMissing();
+
+        $client = new WikibaseAPIClient(self::FAKE_API_URL, $mockCache);
+        $data = $client->getLabels($fakeIds, $fakePayload['uselang']);
+
+        $this->assertEquals($expectedResult, $data);
     }
 
     public function methodProvider(): iterable


### PR DESCRIPTION
This change adds the capability to retrieve entity labels from Wikidata. An additional utility method was added to the `WikibaseAPIClient` class to fetch labels for entity IDs as an associative array of `<entity-id> => <label>`.

Bug: [T291066](https://phabricator.wikimedia.org/T291066)