### PR TITLE
Update route handler to group results by QID

### DIFF
--- a/resources/js/Pages/Results.vue
+++ b/resources/js/Pages/Results.vue
@@ -2,26 +2,27 @@
     <div>
         <Head title="Mismatch Finder - Results" />
         <h2>Results</h2>
-        <table v-if="results.length">
-            <tbody>
-                <tr v-for="result in results" :key="result.id">
-                    <td>{{result.id}}</td>
-                    <td>{{result.item_id}}</td>
-                    <td>{{result.statement_guid}}</td>
-                    <td>{{result.property_id}}</td>
-                    <td>{{result.wikidata_value}}</td>
-                    <td>{{result.external_value}}</td>
-                    <td>{{result.external_url}}</td>
-                    <td>{{result.review_status}}</td>
-                    <td>{{result.reviewer}}</td>
-                    <td>{{result.import}}</td>
-                    <td>{{result.updated_at}}</td>
-                </tr>
-            </tbody>
-        </table>
+        <section class="results" v-if="Object.keys(results).length">
+            <section v-for="(mismatches, item, idx) in results" :key="idx">
+                <h3>{{item}}</h3>
+                <table>
+                    <tbody>
+                        <tr v-for="mismatch in mismatches" :key="mismatch.id">
+                            <td>{{mismatch.property_id}}</td>
+                            <td>{{mismatch.wikidata_value}}</td>
+                            <td>{{mismatch.external_value}}</td>
+                            <td>
+                                <span>{{mismatch.import_meta.user.username}}</span>
+                                <span>{{mismatch.import_meta.created_at}}</span>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </section>
+        </section>
         <p v-else class="not-found">
-            Thank you for sending IDs {{item_ids}}. 
-            The requested item ids didn't match any entries in our database. 
+            Thank you for sending IDs {{item_ids}}.
+            The requested item ids didn't match any entries in our database.
             Please try with a different set of ids.
         </p>
     </div>
@@ -38,7 +39,7 @@
         },
         props: {
             item_ids: Array,
-            results: Array
+            results: Object
         }
     });
 </script>

--- a/routes/web.php
+++ b/routes/web.php
@@ -31,22 +31,22 @@ Route::get('/', function () {
 
 Route::middleware('simulateError')
     ->get('/results', function (MismatchGetRequest $request) {
-    $user = Auth::user() ? [
-        'name' => Auth::user()->username
-    ] : null;
+        $user = Auth::user() ? [
+            'name' => Auth::user()->username
+        ] : null;
 
-    $ids = $request->input('ids');
+        $ids = $request->input('ids');
 
-    $results = Mismatch::with('importMeta.user')
-        ->whereIn('item_id', $ids)
-        ->lazy()
-        ->groupBy('item_id');
+        $results = Mismatch::with('importMeta.user')
+            ->whereIn('item_id', $ids)
+            ->lazy()
+            ->groupBy('item_id');
 
-    return inertia('Results', [
-        'user' => $user,
-        'results' => $results,
-    ]);
-})->name('results');
+        return inertia('Results', [
+            'user' => $user,
+            'results' => $results,
+        ]);
+    })->name('results');
 
 // Mismatch store manager routes, might be converted to inertia routes in the future
 Route::prefix('store')->name('store.')->group(function () {

--- a/routes/web.php
+++ b/routes/web.php
@@ -43,6 +43,7 @@ Route::middleware('simulateError')
             ->groupBy('item_id');
 
         return inertia('Results', [
+            'item_ids' => $ids,
             'user' => $user,
             'results' => $results,
         ]);

--- a/tests/Browser/ItemsFormTest.php
+++ b/tests/Browser/ItemsFormTest.php
@@ -31,7 +31,6 @@ class ItemsFormTest extends DuskTestCase
 
     public function test_can_submit_list_of_item_ids_not_present_in_db()
     {
-
         $this->browse(function (Browser $browser) {
 
             $browser->visit(new HomePage)
@@ -45,7 +44,6 @@ class ItemsFormTest extends DuskTestCase
 
     public function test_can_submit_list_of_item_ids_present_in_db()
     {
-
         $this->browse(function (Browser $browser) {
 
             $import = ImportMeta::factory()
@@ -55,20 +53,16 @@ class ItemsFormTest extends DuskTestCase
             Mismatch::factory(2)
                 ->for($import)
                 ->create();
-            
-            $mismatch = Mismatch::first();
-            $mismatch2 = Mismatch::find(2);
 
-            $item1_in_db_id =  $mismatch->item_id;
-            $item2_in_db_id =  $mismatch2->item_id;
+            $mismatches = Mismatch::all();
 
             $browser->visit(new HomePage)
-                    ->keys('@items-input', $item1_in_db_id, '{return_key}', $item2_in_db_id)
+                    ->keys('@items-input', $mismatches[0]->item_id, '{return_key}', $mismatches[1]->item_id)
                     ->press('button')
                     ->waitFor('table')
                     ->assertTitle('Mismatch Finder - Results')
-                    ->assertSee($item1_in_db_id)
-                    ->assertSee($item2_in_db_id);
+                    ->assertSee($mismatches[0]->item_id)
+                    ->assertSee($mismatches[1]->item_id);
         });
     }
 


### PR DESCRIPTION
This change updates the mismatch results route handler to provide mismatches grouped by item ID. This is required for displaying mismatches per item, and determining which items did not provide any mismatch results.

Bug: [T291569](https://phabricator.wikimedia.org/T291569)
Bug: [T289559](https://phabricator.wikimedia.org/T289559)