### PR TITLE
Add labels and links

### DIFF
--- a/app/Http/Controllers/ResultsController.php
+++ b/app/Http/Controllers/ResultsController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\MismatchGetRequest;
+use App\Services\WikibaseAPIClient;
+use Illuminate\Support\Facades\Auth;
+use App\Models\Mismatch;
+use Illuminate\Support\Facades\App;
+use Inertia\Response;
+use Illuminate\Support\LazyCollection;
+
+class ResultsController extends Controller
+{
+    public function index(MismatchGetRequest $request, WikibaseAPIClient $wikidata): Response
+    {
+        $user = Auth::user() ? [
+            'name' => Auth::user()->username
+        ] : null;
+
+        $itemIds = $request->input('ids');
+
+        $mismatches = Mismatch::with('importMeta.user')
+            ->whereIn('item_id', $itemIds)
+            ->lazy();
+
+        $entityIds = $this->extractEntityIds($mismatches, $itemIds);
+
+        return inertia('Results', [
+            'user' => $user,
+            'item_ids' => $itemIds,
+            'results' => $mismatches->groupBy('item_id'),
+            // Use wikidata to fetch labels for found entity ids
+            'labels' => $wikidata->getLabels($entityIds, App::getLocale())
+        ]);
+    }
+
+    private function extractEntityIds(LazyCollection $mismatches, array $initialIds): array
+    {
+        $entityIdExtractor = function (array $ids, Mismatch $mismatch): array {
+            $wikidataValue = $mismatch->wikidata_value;
+            $entityValue = preg_match(config('mismatches.validation.item_id.format'), $wikidataValue);
+
+            // Add any new property id to the array of ids.
+            if (!in_array($mismatch->property_id, $ids)) {
+                $ids[] = $mismatch->property_id;
+            }
+
+            // If they wikidata value is an item id, add it to the array of ids if
+            // it is not there yet.
+            if ($entityValue && !in_array($wikidataValue, $ids)) {
+                $ids[] = $wikidataValue;
+            }
+
+            return $ids;
+        };
+
+        // Extract all entity ids encountered in mismatch data, and add them
+        // into an array of initial entity ids.
+        return $mismatches->reduce($entityIdExtractor, $initialIds);
+    }
+}

--- a/app/Http/Controllers/ResultsController.php
+++ b/app/Http/Controllers/ResultsController.php
@@ -46,7 +46,7 @@ class ResultsController extends Controller
                 $ids[] = $mismatch->property_id;
             }
 
-            // If they wikidata value is an item id, add it to the array of ids if
+            // If the wikidata value is an item id, add it to the array of ids if
             // it is not there yet.
             if ($entityValue && !in_array($wikidataValue, $ids)) {
                 $ids[] = $wikidataValue;

--- a/app/Models/Mismatch.php
+++ b/app/Models/Mismatch.php
@@ -51,6 +51,6 @@ class Mismatch extends Model
     public function setStatementGuidAttribute($value)
     {
         $this->attributes['statement_guid'] = $value;
-        $this->attributes['item_id'] = explode('$', $value, 2)[0];
+        $this->attributes['item_id'] = strtoupper(explode('$', $value, 2)[0]);
     }
 }

--- a/resources/js/Components/MismatchRow.vue
+++ b/resources/js/Components/MismatchRow.vue
@@ -5,7 +5,11 @@
                 {{mismatch.property_label}}
             </wikit-link>
         </td>
-        <td :data-header="$i18n('column-wikidata-value')">{{mismatch.value_label || mismatch.wikidata_value}}</td>
+        <td :data-header="$i18n('column-wikidata-value')">
+            <wikit-link :href="statementUrl">
+                {{mismatch.value_label || mismatch.wikidata_value}}
+            </wikit-link>
+        </td>
         <td :data-header="$i18n('column-external-value')">{{mismatch.external_value}}</td>
         <td :data-header="$i18n('column-upload-info')">
             <div class="upload-details">
@@ -40,6 +44,9 @@ export default Vue.extend({
             return formatISO(new Date(this.mismatch.import_meta.created_at), {
                 representation: 'date'
             });
+        },
+        statementUrl(): string {
+            return `https://www.wikidata.org/wiki/${this.mismatch.item_id}#${this.mismatch.statement_guid}`
         }
     }
 });

--- a/resources/js/Components/MismatchRow.vue
+++ b/resources/js/Components/MismatchRow.vue
@@ -1,7 +1,11 @@
 <template>
     <tr>
-        <td :data-header="$i18n('column-property')">{{mismatch.property_id}}</td>
-        <td :data-header="$i18n('column-wikidata-value')">{{mismatch.wikidata_value}}</td>
+        <td :data-header="$i18n('column-property')">
+            <wikit-link :href="`https://www.wikidata.org/wiki/Property:${mismatch.property_id}`">
+                {{mismatch.property_label}}
+            </wikit-link>
+        </td>
+        <td :data-header="$i18n('column-wikidata-value')">{{mismatch.value_label || mismatch.wikidata_value}}</td>
         <td :data-header="$i18n('column-external-value')">{{mismatch.external_value}}</td>
         <td :data-header="$i18n('column-upload-info')">
             <div class="upload-details">
@@ -22,14 +26,14 @@ import { formatISO } from 'date-fns';
 import Vue, { PropType } from 'vue';
 import { Link as WikitLink } from '@wmde/wikit-vue-components';
 
-import Mismatch from '../types/Mismatch';
+import { LabelledMismatch } from '../types/Mismatch';
 
 export default Vue.extend({
     components: {
         WikitLink
     },
     props: {
-        mismatch: Object as PropType<Mismatch>
+        mismatch: Object as PropType<LabelledMismatch>
     },
     computed: {
         uploadDate(): string {

--- a/resources/js/Components/MismatchesTable.vue
+++ b/resources/js/Components/MismatchesTable.vue
@@ -19,7 +19,7 @@ import Vue, { PropType } from 'vue';
 import MismatchRow from './MismatchRow.vue';
 import WikitTable from './Table.vue';
 
-import Mismatch from '../types/Mismatch';
+import { LabelledMismatch } from '../types/Mismatch';
 
 export default Vue.extend({
     components: {
@@ -27,7 +27,7 @@ export default Vue.extend({
         WikitTable,
     },
     props: {
-        mismatches: Array as PropType<Mismatch[]>
+        mismatches: Array as PropType<LabelledMismatch[]>
     }
 });
 </script>

--- a/resources/js/Pages/Results.vue
+++ b/resources/js/Pages/Results.vue
@@ -3,7 +3,9 @@
         <Head title="Mismatch Finder - Results" />
         <section id="results" v-if="Object.keys(results).length">
             <section class="item-mismatches" v-for="(mismatches, item, idx) in results" :key="idx">
-                <h2 class="h4">{{item}}</h2>
+                <h2 class="h4">
+                    <wikit-link :href="`http://www.wikidata.org/wiki/${item}`">{{labels[item]}} ({{item}})</wikit-link>
+                </h2>
                 <mismatches-table :mismatches="mapLabels(mismatches)" />
             </section>
         </section>
@@ -19,26 +21,47 @@
     import { PropType } from 'vue';
 
     import { Head } from '@inertiajs/inertia-vue';
+    import { Link as WikitLink } from '@wmde/wikit-vue-components';
 
     import MismatchesTable from '../Components/MismatchesTable.vue';
-    import Mismatch from '../types/Mismatch';
+    import Mismatch, {LabelledMismatch} from '../types/Mismatch';
     import defineComponent from '../types/defineComponent';
 
     interface Result {
         [qid: string]: Mismatch[]
     }
 
+    interface LabelMap {
+        [entityId: string]: string
+    }
+
     export default defineComponent({
         components: {
             Head,
-            MismatchesTable
+            MismatchesTable,
+            WikitLink
         },
         props: {
             item_ids: Array as PropType<string[]>,
-            results: Object as PropType<Result>
+            results: Object as PropType<Result>,
+            labels: Object as PropType<LabelMap>
+        },
+        methods: {
+            mapLabels(mismatches: Mismatch[]): LabelledMismatch[]{
+                return mismatches.map(mismatch => ({
+                    property_label: this.labels[mismatch.property_id],
+                    value_label: this.labels[mismatch.wikidata_value] || null,
+                    ...mismatch
+                }));
+            }
         }
     });
 </script>
 
 <style lang="scss">
+    h2 {
+        .wikit-Link.wikit {
+            font-weight: bold;
+        }
+    }
 </style>

--- a/resources/js/Pages/Results.vue
+++ b/resources/js/Pages/Results.vue
@@ -6,7 +6,7 @@
                 <h2 class="h4">
                     <wikit-link :href="`http://www.wikidata.org/wiki/${item}`">{{labels[item]}} ({{item}})</wikit-link>
                 </h2>
-                <mismatches-table :mismatches="mapLabels(mismatches)" />
+                <mismatches-table :mismatches="addLabels(mismatches)" />
             </section>
         </section>
         <p v-else class="not-found">
@@ -47,7 +47,10 @@
             labels: Object as PropType<LabelMap>
         },
         methods: {
-            mapLabels(mismatches: Mismatch[]): LabelledMismatch[]{
+            addLabels(mismatches: Mismatch[]): LabelledMismatch[]{
+                // The following callback maps existing mismatches to extended
+                // mismatch objects which include labels, by looking up any
+                // potential entity ids within the labels object.
                 return mismatches.map(mismatch => ({
                     property_label: this.labels[mismatch.property_id],
                     value_label: this.labels[mismatch.wikidata_value] || null,

--- a/resources/js/Pages/Results.vue
+++ b/resources/js/Pages/Results.vue
@@ -4,7 +4,7 @@
         <section id="results" v-if="Object.keys(results).length">
             <section class="item-mismatches" v-for="(mismatches, item, idx) in results" :key="idx">
                 <h2 class="h4">{{item}}</h2>
-                <mismatches-table :mismatches="mismatches" />
+                <mismatches-table :mismatches="mapLabels(mismatches)" />
             </section>
         </section>
         <p v-else class="not-found">

--- a/resources/js/types/Mismatch.ts
+++ b/resources/js/types/Mismatch.ts
@@ -1,5 +1,7 @@
 interface Mismatch {
     id: number,
+    item_id: string,
+    statement_guid: string,
     property_id: string,
     wikidata_value: string,
     external_value: string,

--- a/resources/js/types/Mismatch.ts
+++ b/resources/js/types/Mismatch.ts
@@ -1,4 +1,4 @@
-export default interface Mismatch {
+interface Mismatch {
     id: number,
     property_id: string,
     wikidata_value: string,
@@ -10,3 +10,10 @@ export default interface Mismatch {
         created_at: string
     }
 }
+
+export interface LabelledMismatch extends Mismatch {
+    property_label: string,
+    value_label: string|null
+}
+
+export default Mismatch;

--- a/tests/Feature/WebRouteTest.php
+++ b/tests/Feature/WebRouteTest.php
@@ -9,6 +9,7 @@ use Tests\TestCase;
 use Inertia\Testing\Assert;
 use App\Models\User;
 use Illuminate\Support\Facades\App;
+use Illuminate\Support\Collection;
 
 class WebRouteTest extends TestCase
 {
@@ -113,8 +114,16 @@ class WebRouteTest extends TestCase
             ])->etc();
         };
 
-        $withResultsPage = function (Assert $page) use ($qid, $isMismatch) {
-            $page->component('Results')->has("results.$qid.0", $isMismatch);
+        $assertLabels = function (Collection $labels) use ($mismatch) {
+            // Labels should at least have the item id and property id
+            // of a mismatch
+            return $labels->has([$mismatch->item_id, $mismatch->property_id]);
+        };
+
+        $withResultsPage = function (Assert $page) use ($qid, $isMismatch, $assertLabels) {
+            $page->component('Results')
+                ->has("results.$qid.0", $isMismatch)
+                ->where("labels", $assertLabels);
         };
 
         $response = $this->get(route('results', [

--- a/tests/Feature/WebRouteTest.php
+++ b/tests/Feature/WebRouteTest.php
@@ -103,6 +103,8 @@ class WebRouteTest extends TestCase
                 'id' => $mismatch->id,
                 // Casting values to string, as it seems that the inertia
                 // testing helper also converts all values to strings
+                'item_id' => (string) $mismatch->item_id,
+                'statement_guid' => (string) $mismatch->statement_guid,
                 'property_id' => (string) $mismatch->property_id,
                 'wikidata_value' => (string) $mismatch->wikidata_value,
                 'external_value' => (string) $mismatch->external_value,

--- a/tests/Vue/Components/MismatchRow.spec.js
+++ b/tests/Vue/Components/MismatchRow.spec.js
@@ -6,6 +6,7 @@ describe('MismatchesRow.vue', () => {
         const mismatch = {
             id: 123,
             property_id: 'P123',
+            property_label: 'Hey hey',
             wikidata_value: 'Some value',
             external_value: 'Another Value',
             import_meta: {
@@ -27,7 +28,7 @@ describe('MismatchesRow.vue', () => {
         expect( wrapper.props().mismatch ).toBe( mismatch );
 
         expect( wrapper.find( 'tr' ).text() ).toContain(
-            mismatch.property_id,
+            mismatch.property_label,
             mismatch.wikidata_value,
             mismatch.external_value,
             mismatch.import_meta.user.username,

--- a/tests/Vue/Components/MismatchRow.spec.js
+++ b/tests/Vue/Components/MismatchRow.spec.js
@@ -4,8 +4,6 @@ import MismatchRow from '@/Components/MismatchRow.vue';
 describe('MismatchesRow.vue', () => {
     it('accepts a mismatch property', () => {
         const mismatch = {
-            id: 123,
-            property_id: 'P123',
             property_label: 'Hey hey',
             wikidata_value: 'Some value',
             external_value: 'Another Value',
@@ -34,5 +32,29 @@ describe('MismatchesRow.vue', () => {
             mismatch.import_meta.user.username,
             mismatch.import_meta.created_at
         );
+    });
+
+    it('shows wikidata label over value when available', () => {
+        const mismatch = {
+            wikidata_value: 'Some value',
+            value_label: 'Some label',
+            import_meta: {
+                user: {
+                    username: 'some_user_name'
+                },
+                created_at: '2021-09-23'
+            },
+        };
+
+        const wrapper = mount(MismatchRow, {
+            propsData: { mismatch },
+            mocks: {
+                // Mock the banana-i18n plugin dependency
+                $i18n: key => key
+            }
+        });
+
+        expect( wrapper.props().mismatch ).toBe( mismatch );
+        expect( wrapper.find( 'tr' ).text() ).toContain(mismatch.value_label);
     });
 })


### PR DESCRIPTION
_**Note:** This change depends on #113_

This change adds an entity ID to Wikidata label map to the results page. This map is then used to display labels for various entity IDs displayed on the page.

Bug: [T291569](https://phabricator.wikimedia.org/T291569)