### PR TITLE
Fix width of error message box on home page

### DIFF
--- a/resources/js/Pages/Home.vue
+++ b/resources/js/Pages/Home.vue
@@ -135,16 +135,13 @@
 <style lang="scss">
 @import '~@wmde/wikit-tokens/dist/_variables.scss';
 
-#about-description {
+#intro-section,
+#message-section {
     max-width: 705px;
 }
 
-#message-section {
-    max-width: 675px;
-
-    .wikit-Message {
-        border-radius: $border-radius-base;
-    }
+#message-section .wikit-Message {
+    border-radius: $border-radius-base;
 }
 
 #items-form {


### PR DESCRIPTION
This adjusts a possible error message box on the home page to have
the same width as the intro text above. The layout change now also
justifies moving the error message into the intro section, rather than
creating a second section with the same hard coded px size.

Bug: [T289344](https://phabricator.wikimedia.org/T289344)