### PR TITLE
Add review status column

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -23,6 +23,12 @@
     "column-property": "Property",
     "column-wikidata-value": "Value on Wikidata",
     "column-external-value": "Value on external source",
+    "column-review-status": "Status",
     "column-upload-info": "Upload Info",
-    "no-mismatches-found-message": "No mismatches have been found for:"
+    "no-mismatches-found-message": "No mismatches have been found for:",
+    "review-status-pending": "To be defined",
+    "review-status-wikidata": "Mismatch on Wikidata",
+    "review-status-external": "Mismatch on external data source",
+    "review-status-both": "Both are wrong",
+    "review-status-none": "None of the above"
 }

--- a/public/i18n/qqq.json
+++ b/public/i18n/qqq.json
@@ -20,6 +20,12 @@
     "column-property": "Property column on mismatches table",
     "column-wikidata-value": "Wikidata value column on mismatches table",
     "column-external-value": "External source column on mismatches table",
+    "column-review-status": "The mismatch review decision column on mismatches table",
     "column-upload-info": "Upload Info column on mismatches table",
-    "no-mismatches-found-message": "A message when no mismatches have been found for the provided Item Ids"
+    "no-mismatches-found-message": "A message when no mismatches have been found for the provided Item Ids",
+    "review-status-pending": "Label for pending review status. Used as placeholder in the review decision dropdown",
+    "review-status-wikidata": "Label that indicates that the data mismatch is on Wikidata. Used as an option in the review decision dropdown",
+    "review-status-external": "Label that indicates that the data mismatch is on the external database. Used as an option in the review decision dropdown",
+    "review-status-both": "Label that indicates that the data mismatch is on both sources. Used as an option in the in review decision dropdown",
+    "review-status-none": "Label that indicates that the data mismatch is not on any source. Used as an option in the in review decision dropdown"
 }

--- a/resources/js/Components/MismatchesTable.vue
+++ b/resources/js/Components/MismatchesTable.vue
@@ -5,6 +5,7 @@
                 <th>{{$i18n('column-property')}}</th>
                 <th>{{$i18n('column-wikidata-value')}}</th>
                 <th>{{$i18n('column-external-value')}}</th>
+                <th>{{$i18n('column-review-status')}}</th>
                 <th>{{$i18n('column-upload-info')}}</th>
             </tr>
         </thead>

--- a/resources/js/Components/MismatchesTable.vue
+++ b/resources/js/Components/MismatchesTable.vue
@@ -2,11 +2,11 @@
     <wikit-table>
         <thead>
             <tr>
-                <th>{{$i18n('column-property')}}</th>
-                <th>{{$i18n('column-wikidata-value')}}</th>
-                <th>{{$i18n('column-external-value')}}</th>
-                <th>{{$i18n('column-review-status')}}</th>
-                <th>{{$i18n('column-upload-info')}}</th>
+                <th class="column-property">{{$i18n('column-property')}}</th>
+                <th class="column-wikidata-value">{{$i18n('column-wikidata-value')}}</th>
+                <th class="column-external-value">{{$i18n('column-external-value')}}</th>
+                <th class="column-review-status">{{$i18n('column-review-status')}}</th>
+                <th class="column-upload-info">{{$i18n('column-upload-info')}}</th>
             </tr>
         </thead>
         <tbody>
@@ -33,3 +33,10 @@ export default Vue.extend({
     }
 });
 </script>
+
+<style lang="scss">
+    .column-review-status {
+        // Ensures that the dropdowns are evenly wide
+        min-width: 35%;
+    }
+</style>

--- a/resources/js/Components/MismatchesTable.vue
+++ b/resources/js/Components/MismatchesTable.vue
@@ -37,6 +37,6 @@ export default Vue.extend({
 <style lang="scss">
     .column-review-status {
         // Ensures that the dropdowns are evenly wide
-        min-width: 35%;
+        width: 35%;
     }
 </style>

--- a/resources/js/Pages/Results.vue
+++ b/resources/js/Pages/Results.vue
@@ -55,9 +55,18 @@
             Message
         },
         props: {
-            item_ids: Array as PropType<string[]>,
-            results: Object as PropType<Result>,
-            labels: Object as PropType<LabelMap>
+            item_ids: {
+                type: Array as PropType<string[]>,
+                default: () => []
+            },
+            results: {
+                type: Object as PropType<Result>,
+                default: () => ({})
+            },
+            labels: {
+                type: Object as PropType<LabelMap>,
+                default: () => ({})
+            }
         },
         computed: {
             notFoundItemIds() {   

--- a/resources/js/Pages/Results.vue
+++ b/resources/js/Pages/Results.vue
@@ -15,7 +15,10 @@
             </Message>
         </section>
         <section id="results" v-if="Object.keys(results).length">
-            <section class="item-mismatches" v-for="(mismatches, item, idx) in results" :key="idx">
+            <section class="item-mismatches"
+                v-for="(mismatches, item, idx) in results"
+                :id="`item-mismatches-${item}`"
+                :key="idx">
                 <h2 class="h4">
                     <wikit-link :href="`http://www.wikidata.org/wiki/${item}`">{{labels[item]}} ({{item}})</wikit-link>
                 </h2>

--- a/resources/js/types/Mismatch.ts
+++ b/resources/js/types/Mismatch.ts
@@ -1,3 +1,11 @@
+export enum ReviewStatus {
+    Pending = 'pending',
+    Wikidata = 'wikidata',
+    External = 'external',
+    Both = 'both',
+    None = 'none'
+}
+
 interface Mismatch {
     id: number,
     item_id: string,
@@ -5,6 +13,7 @@ interface Mismatch {
     property_id: string,
     wikidata_value: string,
     external_value: string,
+    review_status: ReviewStatus,
     import_meta: {
         user: {
             username: string

--- a/resources/js/types/Mismatch.ts
+++ b/resources/js/types/Mismatch.ts
@@ -1,10 +1,12 @@
-export enum ReviewStatus {
-    Pending = 'pending',
+export enum ReviewDecision {
     Wikidata = 'wikidata',
     External = 'external',
     Both = 'both',
     None = 'none'
 }
+
+
+type ReviewStatus = ReviewDecision | 'pending';
 
 interface Mismatch {
     id: number,

--- a/tests/Feature/WebRouteTest.php
+++ b/tests/Feature/WebRouteTest.php
@@ -109,6 +109,7 @@ class WebRouteTest extends TestCase
                 'property_id' => (string) $mismatch->property_id,
                 'wikidata_value' => (string) $mismatch->wikidata_value,
                 'external_value' => (string) $mismatch->external_value,
+                'review_status' => (string) $mismatch->review_status,
                 'import_meta.user.username' => (string) $import->user->username,
                 'import_meta.created_at' => $import->created_at->toISOString()
             ])->etc();

--- a/tests/Vue/Components/MismatchRow.spec.js
+++ b/tests/Vue/Components/MismatchRow.spec.js
@@ -1,4 +1,8 @@
 import { mount } from '@vue/test-utils';
+import { Dropdown } from '@wmde/wikit-vue-components';
+
+import { ReviewDecision } from '@/types/Mismatch.ts';
+
 import MismatchRow from '@/Components/MismatchRow.vue';
 
 describe('MismatchesRow.vue', () => {
@@ -7,6 +11,7 @@ describe('MismatchesRow.vue', () => {
             property_label: 'Hey hey',
             wikidata_value: 'Some value',
             external_value: 'Another Value',
+            review_status: 'pending',
             import_meta: {
                 user: {
                     username: 'some_user_name'
@@ -22,16 +27,18 @@ describe('MismatchesRow.vue', () => {
                 $i18n: key => key
             }
         });
+        const rowText = wrapper.find( 'tr' ).text();
 
         expect( wrapper.props().mismatch ).toBe( mismatch );
 
-        expect( wrapper.find( 'tr' ).text() ).toContain(
+        [
             mismatch.property_label,
             mismatch.wikidata_value,
             mismatch.external_value,
+            `review-status-${mismatch.review_status}`,
             mismatch.import_meta.user.username,
             mismatch.import_meta.created_at
-        );
+        ].forEach(value => expect(rowText).toContain(value));
     });
 
     it('shows wikidata label over value when available', () => {
@@ -56,5 +63,36 @@ describe('MismatchesRow.vue', () => {
 
         expect( wrapper.props().mismatch ).toBe( mismatch );
         expect( wrapper.find( 'tr' ).text() ).toContain(mismatch.value_label);
+    });
+
+    test.each(Object.values(ReviewDecision))
+    ('shows a dropdown with the %s option', (currentStatus) => {
+        const mismatch = {
+            property_label: 'Hey hey',
+            wikidata_value: 'Some value',
+            external_value: 'Another Value',
+            review_status: currentStatus,
+            import_meta: {
+                user: {
+                    username: 'some_user_name'
+                },
+                created_at: '2021-09-23'
+            },
+        };
+
+        const wrapper = mount(MismatchRow, {
+            propsData: { mismatch },
+            mocks: {
+                // Mock the banana-i18n plugin dependency
+                $i18n: key => `${key}`
+            }
+        });
+
+        const dropdown = wrapper.findComponent(Dropdown);
+
+        expect(dropdown.props().value).toMatchObject({
+            label: `review-status-${currentStatus}`, // Match the i18n key, as the i18n plugin is mocked
+            value: currentStatus
+        });
     });
 })

--- a/tests/Vue/Pages/Results.spec.js
+++ b/tests/Vue/Pages/Results.spec.js
@@ -1,17 +1,108 @@
 import { mount } from '@vue/test-utils';
 import Results from '@/Pages/Results.vue';
-import Home from '@/Pages/Home.vue';
+import MismatchesTable from '@/Components/MismatchesTable.vue';
 
 // Stub the inertia vue components module entirely so that we don't run into
 // issues with the Head component.
 jest.mock('@inertiajs/inertia-vue', () => ({}));
 
 describe('Results.vue', () => {
-    it('mounts', () => {
+    it('accepts and renders item ids', () => {
+        const item_ids =  ['Q1', 'Q2']
         const wrapper = mount(Results, {
-            propsData: {}
+            propsData: { item_ids }
         });
 
-        expect(true).toBe(true);
+        expect(wrapper.props().item_ids).toBe(item_ids);
+        item_ids.forEach(id => expect(wrapper.text()).toContain(id));
+    });
+
+    it('accepts and renders results', () => {
+        const results = {
+            'Q321': [{
+                id: 123,
+                item_id: 'Q321',
+                property_id: 'P123',
+                property_label: 'some property',
+                wikidata_value: 'Some value',
+                value_label: null,
+                external_value: 'Another Value',
+                import_meta: {
+                    user: {
+                        username: 'some_user_name'
+                    },
+                    created_at: '2021-09-23'
+                },
+            }],
+            'Q987': [{
+                id: 654,
+                item_id: 'Q987',
+                property_id: 'p789',
+                property_label: 'some property',
+                wikidata_value: 'Some value',
+                value_label: null,
+                external_value: 'Another Value',
+                import_meta: {
+                    user: {
+                        username: 'some_user_name'
+                    },
+                    created_at: '2021-09-23'
+                },
+            }]
+        };
+
+        const wrapper = mount(Results, {
+            propsData: { results },
+            mocks: {
+                $i18n: key => key
+            }
+        });
+
+        const tables = wrapper.findAllComponents(MismatchesTable);
+
+        expect(wrapper.props().results).toBe(results);
+
+        Object.keys(results).forEach((itemId, i) => {
+            const section = wrapper.find(`#item-mismatches-${itemId}`);
+            const table = tables.at(i);
+
+            expect(section.text()).toContain(itemId);
+            expect(table.props().mismatches).toEqual(results[itemId]);
+        });
+    });
+
+    it('accepts and renders labels', () => {
+        const results = {
+            'Q321': [{
+                id: 123,
+                item_id: 'Q321',
+                property_id: 'P123',
+                wikidata_value: 'Q1986',
+                external_value: 'Another Value',
+                import_meta: {
+                    user: {
+                        username: 'some_user_name'
+                    },
+                    created_at: '2021-09-23'
+                },
+            }]
+        };
+
+        const labels = {
+            'Q321': 'Some Item',
+            'P123': 'Some Property',
+            'Q1986': 'Some Value'
+        }
+
+        const wrapper = mount(Results, {
+            propsData: { results, labels },
+            mocks: {
+                $i18n: key => key
+            }
+        });
+
+        expect(wrapper.props().labels).toBe(labels);
+
+        Object.values(labels).forEach(label => expect(wrapper.text()).toContain(label));
     });
 })

--- a/tests/Vue/Pages/Results.spec.js
+++ b/tests/Vue/Pages/Results.spec.js
@@ -1,0 +1,17 @@
+import { mount } from '@vue/test-utils';
+import Results from '@/Pages/Results.vue';
+import Home from '@/Pages/Home.vue';
+
+// Stub the inertia vue components module entirely so that we don't run into
+// issues with the Head component.
+jest.mock('@inertiajs/inertia-vue', () => ({}));
+
+describe('Results.vue', () => {
+    it('mounts', () => {
+        const wrapper = mount(Results, {
+            propsData: {}
+        });
+
+        expect(true).toBe(true);
+    });
+})

--- a/tests/Vue/Pages/Results.spec.js
+++ b/tests/Vue/Pages/Results.spec.js
@@ -7,10 +7,19 @@ import MismatchesTable from '@/Components/MismatchesTable.vue';
 jest.mock('@inertiajs/inertia-vue', () => ({}));
 
 describe('Results.vue', () => {
+
+    const mocks = {
+        $i18n: key => key,
+        $page: {
+            props: { flash: {} }
+        },
+    }
+
     it('accepts and renders item ids', () => {
         const item_ids =  ['Q1', 'Q2']
         const wrapper = mount(Results, {
-            propsData: { item_ids }
+            propsData: { item_ids },
+            mocks
         });
 
         expect(wrapper.props().item_ids).toBe(item_ids);
@@ -53,9 +62,7 @@ describe('Results.vue', () => {
 
         const wrapper = mount(Results, {
             propsData: { results },
-            mocks: {
-                $i18n: key => key
-            }
+            mocks
         });
 
         const tables = wrapper.findAllComponents(MismatchesTable);
@@ -96,9 +103,7 @@ describe('Results.vue', () => {
 
         const wrapper = mount(Results, {
             propsData: { results, labels },
-            mocks: {
-                $i18n: key => key
-            }
+            mocks
         });
 
         expect(wrapper.props().labels).toBe(labels);


### PR DESCRIPTION
This change adds a column to each item's mismatches table, to indicate the review status of the mismatches. Additionally, since there were no tests enabled for the results page, this change adds some missing tests, in preparation for adding more tests in a followup to this PR.

This change does not yet include data binding between the status of the mismatches in the table, and the mismatches in the results pages' model after a new status is selected. These changes will  be included in a followup.

Bug: [T289557](https://phabricator.wikimedia.org/T289557)