### PR TITLE
Update decisions at the results page level

### DIFF
--- a/resources/js/Components/MismatchRow.vue
+++ b/resources/js/Components/MismatchRow.vue
@@ -18,6 +18,11 @@
                 :menuItems="Object.values(statusOptions)"
                 :placeholder="$i18n('review-status-pending')"
                 v-model="decision"
+                @input="$bubble('decision', {
+                    id: mismatch.id,
+                    item_id: mismatch.item_id,
+                    review_status: $event.value
+                })"
             />
         </td>
         <td :data-header="$i18n('column-upload-info')">

--- a/resources/js/Pages/Results.vue
+++ b/resources/js/Pages/Results.vue
@@ -115,7 +115,6 @@
                 }));
             },
             recordDecision( decision: MismatchDecision ): void {
-                console.log(decision)
                 const itemDecisions = this.decisions[decision.item_id]
                 this.decisions[decision.item_id] = {
                     ...itemDecisions,

--- a/resources/js/Pages/Results.vue
+++ b/resources/js/Pages/Results.vue
@@ -6,9 +6,9 @@
         </section>
         <section id="message-section" v-if="notFoundItemIds.length">
             <Message type="notice">
-                <span>{{ $i18n('no-mismatches-found-message') }}</span> 
+                <span>{{ $i18n('no-mismatches-found-message') }}</span>
                 <span class="message-link" v-for="item_id in notFoundItemIds" :key="item_id">
-                    <wikit-link 
+                    <wikit-link
                         :href="`http://www.wikidata.org/wiki/${item_id}`">{{labels[item_id]}} ({{item_id}})
                     </wikit-link>
                 </span>
@@ -22,7 +22,9 @@
                 <h2 class="h4">
                     <wikit-link :href="`http://www.wikidata.org/wiki/${item}`">{{labels[item]}} ({{item}})</wikit-link>
                 </h2>
-                <mismatches-table :mismatches="addLabels(mismatches)" />
+                <mismatches-table :mismatches="addLabels(mismatches)"
+                    @decision="recordDecision"
+                />
             </section>
         </section>
     </div>
@@ -31,12 +33,18 @@
 <script lang="ts">
     import { PropType } from 'vue';
     import { Head } from '@inertiajs/inertia-vue';
-    import { 
+    import {
         Link as WikitLink,
         Message } from '@wmde/wikit-vue-components';
     import MismatchesTable from '../Components/MismatchesTable.vue';
-    import Mismatch, {LabelledMismatch} from '../types/Mismatch';
+    import Mismatch, {ReviewDecision, LabelledMismatch} from '../types/Mismatch';
     import defineComponent from '../types/defineComponent';
+
+    interface MismatchDecision {
+        id: number,
+        item_id: string,
+        review_status: ReviewDecision
+    }
 
     interface Result {
         [qid: string]: Mismatch[]
@@ -48,6 +56,16 @@
 
     interface FlashMessages {
         errors : { [ key : string ] : string }
+    }
+
+    interface DecisionMap {
+        [entityId: string]: {
+            [id: number]: MismatchDecision
+        }
+    }
+
+    interface ResultsState {
+        decisions: DecisionMap
     }
 
     export default defineComponent({
@@ -72,13 +90,18 @@
             }
         },
         computed: {
-            notFoundItemIds() {   
+            notFoundItemIds() {
                 return this.item_ids.filter( id => !this.results[id] )
             },
             unexpectedError() {
                 const flashMessages = this.$page.props.flash as FlashMessages;
                 return (flashMessages.errors && flashMessages.errors.unexpected);
             },
+        },
+        data(): ResultsState {
+            return {
+                decisions: {}
+            }
         },
         methods: {
             addLabels(mismatches: Mismatch[]): LabelledMismatch[]{
@@ -91,7 +114,15 @@
                     ...mismatch
                 }));
             },
-        },
+            recordDecision( decision: MismatchDecision ): void {
+                console.log(decision)
+                const itemDecisions = this.decisions[decision.item_id]
+                this.decisions[decision.item_id] = {
+                    ...itemDecisions,
+                    [decision.id]: decision
+                };
+            }
+        }
     });
 </script>
 

--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -6,8 +6,11 @@ import { Inertia } from '@inertiajs/inertia';
 import { createInertiaApp } from '@inertiajs/inertia-vue';
 
 import i18nMessages from './lib/i18n';
+import bubble from './lib/bubble';
 import Error from './Pages/Error.vue';
 import Layout from './Pages/Layout.vue';
+
+Vue.use(bubble);
 
 // Retrieve i18n messages and setup the Vue instance to handle them.
 async function setupI18n(locale: string): Promise<void>{
@@ -55,6 +58,8 @@ function createStore(): Store<{loading: boolean}>{
 
     return store;
 }
+
+
 
 // Only bootstrap inertia if setup is successful. Display generic error
 // component otherwise

--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -59,8 +59,6 @@ function createStore(): Store<{loading: boolean}>{
     return store;
 }
 
-
-
 // Only bootstrap inertia if setup is successful. Display generic error
 // component otherwise
 (async () => {

--- a/resources/js/lib/bubble.ts
+++ b/resources/js/lib/bubble.ts
@@ -1,0 +1,14 @@
+import { VueConstructor } from "vue";
+
+// Bubble custom events to their parent components, to ease data flow from
+// nested child components upwards. See: https://stackoverflow.com/a/54940012
+export default function (Vue: VueConstructor<Vue>): void {
+    Vue.prototype.$bubble = function $bubble(eventName: string, ...args: any) {
+        // Emit the event on all parent components
+        let component = this;
+        do {
+            component.$emit(eventName, ...args);
+            component = component.$parent;
+        } while (component);
+    };
+}

--- a/tests/Vue/Components/MismatchRow.spec.js
+++ b/tests/Vue/Components/MismatchRow.spec.js
@@ -96,7 +96,7 @@ describe('MismatchesRow.vue', () => {
         });
     });
 
-    it('bubbles a decision event on dropdown input', async () => {
+    it('bubbles a decision event on dropdown input', () => {
         const mismatch = {
             id: 123,
             item_id: 'Q123',
@@ -128,9 +128,6 @@ describe('MismatchesRow.vue', () => {
         dropdown.vm.$emit('input', {
             value: ReviewDecision.Wikidata
         });
-
-        // Wait for the event queue to be processed.
-        await wrapper.vm.$nextTick();
 
         expect(bubbleStub).toHaveBeenCalledTimes(1);
         expect(bubbleStub).toHaveBeenCalledWith('decision', {

--- a/tests/Vue/Components/MismatchRow.spec.js
+++ b/tests/Vue/Components/MismatchRow.spec.js
@@ -95,4 +95,48 @@ describe('MismatchesRow.vue', () => {
             value: currentStatus
         });
     });
+
+    it('bubbles a decision event on dropdown input', async () => {
+        const mismatch = {
+            id: 123,
+            item_id: 'Q123',
+            property_label: 'Hey hey',
+            wikidata_value: 'Some value',
+            external_value: 'Another Value',
+            review_status: 'pending',
+            import_meta: {
+                user: {
+                    username: 'some_user_name'
+                },
+                created_at: '2021-09-23'
+            },
+        };
+
+        const bubbleStub = jest.fn();
+
+        const wrapper = mount(MismatchRow, {
+            propsData: { mismatch },
+            mocks: {
+                // Mock the banana-i18n plugin dependency
+                $i18n: key => `${key}`,
+                $bubble: bubbleStub
+            }
+        });
+
+        const dropdown = wrapper.findComponent(Dropdown);
+
+        dropdown.vm.$emit('input', {
+            value: ReviewDecision.Wikidata
+        });
+
+        // Wait for the event queue to be processed.
+        await wrapper.vm.$nextTick();
+
+        expect(bubbleStub).toHaveBeenCalledTimes(1);
+        expect(bubbleStub).toHaveBeenCalledWith('decision', {
+            id: mismatch.id,
+            item_id: mismatch.item_id,
+            review_status: ReviewDecision.Wikidata
+        });
+    });
 })

--- a/tests/Vue/Pages/Results.spec.js
+++ b/tests/Vue/Pages/Results.spec.js
@@ -113,7 +113,7 @@ describe('Results.vue', () => {
         Object.values(labels).forEach(label => expect(wrapper.text()).toContain(label));
     });
 
-    it('Updates decisions mismatches on emitted decision events', async () => {
+    it('Updates decisions mismatches on emitted decision events', () => {
         const results = {
             'Q321': [{
                 id: 123,
@@ -133,9 +133,7 @@ describe('Results.vue', () => {
 
         const wrapper = mount(Results, {
             propsData: { results },
-            mocks: {
-                $i18n: key => key
-            }
+            mocks
         });
 
         const tables = wrapper.findAllComponents(MismatchesTable);
@@ -146,9 +144,6 @@ describe('Results.vue', () => {
         };
 
         tables.at(0).vm.$emit('decision', emitted);
-
-        // Wait for the event queue to be processed.
-        await wrapper.vm.$nextTick();
 
         expect(wrapper.vm.decisions['Q321'][123]).toEqual(emitted)
     });

--- a/tests/Vue/lib/bubble.spec.js
+++ b/tests/Vue/lib/bubble.spec.js
@@ -1,0 +1,52 @@
+import bubble from '@/lib/bubble.ts';
+
+describe('bubble plugin', () => {
+    it('mutates passed constructor to add the `$bubble` property', () => {
+        class MockVue {};
+
+        bubble(MockVue);
+
+        expect(MockVue.prototype.$bubble).toBeTruthy();
+    });
+
+    describe('$bubble()', () => {
+        it('calls $emit on instance of passed constructor', () => {
+            class MockVue {};
+            MockVue.prototype.$emit = jest.fn();
+
+            bubble(MockVue);
+
+            const instance = new MockVue();
+            const args = ['test', [1,2,3]]
+
+            instance.$bubble(...args);
+
+            expect(instance.$emit).toHaveBeenCalledTimes(1);
+            expect(instance.$emit).toHaveBeenCalledWith(...args);
+        });
+
+        it('calls $emit on instance of parent of passed constructor', () => {
+            class MockVue {
+                constructor(emit, parent){
+                    this.$parent = parent;
+                    this.$emit = emit;
+                }
+            };
+
+            bubble(MockVue);
+
+            const grandparent = new MockVue(jest.fn());
+            const parent = new MockVue(jest.fn(), grandparent);
+            const instance = new MockVue(jest.fn(), parent);
+            const args = ['test', [1,2,3]]
+
+            instance.$bubble(...args);
+
+            expect(parent.$emit).toHaveBeenCalledTimes(1);
+            expect(parent.$emit).toHaveBeenCalledWith(...args);
+
+            expect(grandparent.$emit).toHaveBeenCalledTimes(1);
+            expect(grandparent.$emit).toHaveBeenCalledWith(...args);
+        });
+    });
+});


### PR DESCRIPTION
_**Note:** This change depends on #118_

This change ensures that user decisions regarding each mismatch are recorded at the result's page model. In order to skip a convoluted event trigger chain, an additional plugin was created to bubble events up from child to parent component.

[T289557](https://phabricator.wikimedia.org/T289557)