### PR TITLE
Fix review log message test and log more data

### DIFF
--- a/app/Http/Controllers/MismatchController.php
+++ b/app/Http/Controllers/MismatchController.php
@@ -69,8 +69,14 @@ class MismatchController extends Controller
                 [
                     "username" => $request->user()->username,
                     "mw_userid" => $request->user()->mw_userid,
-                    "old" => $old_status,
-                    "new" => $mismatch->review_status,
+                    "mismatch_id" => $mismatch->id,
+                    "item_id" => $mismatch->item_id,
+                    "property_id" => $mismatch->property_id,
+                    "statement_guid" => $mismatch->statement_guid,
+                    "wikidata_value" => $mismatch->wikidata_value,
+                    "external_value" => $mismatch->external_value,
+                    "review_status_old" => $old_status,
+                    "review_status_new" => $mismatch->review_status,
                     "time" => $mismatch->updated_at
                 ]
             );

--- a/docs/AdminGuide.md
+++ b/docs/AdminGuide.md
@@ -48,3 +48,24 @@ Example User 4
 Example User 5
 Example User 6
 ```
+
+## Log Track of Users' Review Decisions
+
+Review decisions are written to mismatch entries in the database directly, without recording an edit history. Thus, for sanity reasons, a record of review decisions is kept on the filesystem in `storage/logs/mismatch_updates.log`.
+
+Example entry:
+```
+{
+    "username": "zakary.johnson",
+    "mw_userid": 63812352,
+    "mismatch_id": 1,
+    "item_id": "Q3570615",
+    "property_id": "P5474221",
+    "statement_guid": "Q3570615$7b22f0c9-7f5b-386b-a2da-92f1dd7d01c8",
+    "wikidata_value": "404509851"
+    "external_value": "482752654",
+    "review_status_old": "pending",
+    "review_status_new": "wikidata",
+    "time": "2021-10-05 14:44:59",
+}
+```

--- a/tests/Feature/ApiMismatchRoutePutTest.php
+++ b/tests/Feature/ApiMismatchRoutePutTest.php
@@ -195,8 +195,14 @@ class ApiMismatchRoutePutTest extends TestCase
                     ($context == [
                         "username" => $reviewer->username,
                         "mw_userid" => $reviewer->mw_userid,
-                        "old" => $mismatch->review_status,
-                        "new" => 'wikidata',
+                        "mismatch_id" => $mismatch->id,
+                        "item_id" => $mismatch->item_id,
+                        "property_id" => $mismatch->property_id,
+                        "statement_guid" => $mismatch->statement_guid,
+                        "wikidata_value" => $mismatch->wikidata_value,
+                        "external_value" => $mismatch->external_value,
+                        "review_status_old" => 'pending',
+                        "review_status_new" => 'wikidata',
                         "time" => $mismatch->updated_at
                     ]);
                 return $assertMessage && $assertContext;

--- a/tests/Feature/ApiMismatchRoutePutTest.php
+++ b/tests/Feature/ApiMismatchRoutePutTest.php
@@ -185,6 +185,9 @@ class ApiMismatchRoutePutTest extends TestCase
             [ 'review_status' => 'wikidata' ]
         );
 
+        // refresh mismatch to get correct updated_at timestamp
+        $mismatch->refresh();
+
         Log::channel('mismatch_updates')
             ->assertLogged('info', function ($message, $context) use ($reviewer, $mismatch) {
                 $assertMessage = ($message == __('logging.mismatch-updated'));
@@ -210,6 +213,10 @@ class ApiMismatchRoutePutTest extends TestCase
             ->for(User::factory()->create())
             ->reviewed()
             ->for($import)
+            ->state([
+                 'review_status' => 'pending',
+                 'updated_at' => now()->subDay() // created yesterday
+                 ])
             ->create();
 
         return $mismatch;


### PR DESCRIPTION
This change modifies the test for the review log message such, that it now creates a mismatch item in the database with an old timestamp and then asserts that the new timestamp of the update is logged to correctly. Also, this adds more mismatch data to the log message.

Bug: T289134