### PR TITLE
Generate app key on each test run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,6 @@
 name: Test
 
 on: [push]
-env:
-  APP_KEY: ${{ secrets.TESTING_KEY }}
 
 jobs:
   feature-test:
@@ -11,6 +9,11 @@ jobs:
         - uses: actions/checkout@v2
         - name: Install Composer Dependencies
           run: composer install --no-progress --prefer-dist --optimize-autoloader
+        - name: Prepare The Environment
+          run: cp .env.example .env
+        - name: Generate Application Key
+          run: |
+            php artisan key:generate
         - name: phpunit
           uses: php-actions/phpunit@v3
           with:


### PR DESCRIPTION
This change generates the application key for tests on each test run. This is to ensure that Dependabot branches and forks will be able to run tests without requiring access to any repository secrets.