### PR TITLE
Hotfix: Use image urls from public path

### DIFF
--- a/resources/js/Components/AuthWidget.vue
+++ b/resources/js/Components/AuthWidget.vue
@@ -1,9 +1,9 @@
 <template>
     <div v-if="user">
         <Link :href="`https://www.wikidata.org/wiki/User:${user.name}`">
-            <img src="../../img/user.svg" class="icon-user" /><span class="username">{{ user.name }}</span>
+            <img src="images/user.svg" class="icon-user" /><span class="username">{{ user.name }}</span>
         </Link>
-        <Link href="/auth/logout">{{ $i18n('log-out') }}</Link>      
+        <Link href="/auth/logout">{{ $i18n('log-out') }}</Link>
     </div>
     <Link v-else href="/auth/login">{{ $i18n('log-in') }}</Link>
 </template>

--- a/resources/js/Pages/Layout.vue
+++ b/resources/js/Pages/Layout.vue
@@ -1,7 +1,7 @@
 <template>
   <main class="website">
     <header>
-      <img src="../../img/wikidata-logo.svg" class="wikidata-logo" alt="Wikidata-logo" width="160" />
+      <img src="images/wikidata-logo.svg" class="wikidata-logo" alt="Wikidata-logo" width="160" />
       <div class="auth-widget">
         <AuthWidget :user="user" />
       </div>

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -15,22 +15,3 @@ mix.ts('resources/js/app.ts', 'public/js')
     .vue({ version: 2 })
     .sass('resources/sass/app.scss', 'public/css')
     .sourceMaps(false); // False prevents source maps in production
-
-mix.override(webpackConfig => {
-    // BUG: vue-loader doesn't handle file-loader's default esModule:true setting properly causing
-    // <img src="[object module]" /> to be output from vue templates.
-    // WORKAROUND: Override mixs and turn off esModule support on images.
-    // FIX: When vue-loader fixes their bug AND laravel-mix updates to the fixed version
-    // this can be removed
-    webpackConfig.module.rules.forEach(rule => {
-        if (rule.test.toString() === '/(\\.(png|jpe?g|gif|webp)$|^((?!font).)*\\.svg$)/') {
-        if (Array.isArray(rule.use)) {
-            rule.use.forEach(ruleUse => {
-            if (ruleUse.loader === 'file-loader') {
-                ruleUse.options.esModule = false;
-            }
-            });
-        }
-        }
-    });
-    });


### PR DESCRIPTION
After updating Laravel mix to the most recent version, a former workaround to generate public path URLs from their  relative path counterparts stopped working, leading to images not appearing in the staging environment. This change removes the non-working workaround, and revert the image URLs to the explicit public path URLs.