### PR TITLE
Copy images to public path

### DIFF
--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,4 +1,6 @@
 {
     "/js/app.js": "/js/app.js",
-    "/css/app.css": "/css/app.css"
+    "/css/app.css": "/css/app.css",
+    "/images/user.svg": "/images/user.svg",
+    "/images/wikidata-logo.svg": "/images/wikidata-logo.svg"
 }

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -14,4 +14,5 @@ const mix = require('laravel-mix');
 mix.ts('resources/js/app.ts', 'public/js')
     .vue({ version: 2 })
     .sass('resources/sass/app.scss', 'public/css')
+    .copyDirectory('resources/img', 'public/images')
     .sourceMaps(false); // False prevents source maps in production


### PR DESCRIPTION
As a followup to removing the workaround, images also need to be copied to the public path before being available to use in vue components.