### PR TITLE
Make image path absolute

### DIFF
--- a/resources/js/Pages/Layout.vue
+++ b/resources/js/Pages/Layout.vue
@@ -1,7 +1,7 @@
 <template>
   <main class="website">
     <header>
-      <img src="images/wikidata-logo.svg" class="wikidata-logo" alt="Wikidata-logo" width="160" />
+      <img src="/images/wikidata-logo.svg" class="wikidata-logo" alt="Wikidata-logo" width="160" />
       <div class="auth-widget">
         <AuthWidget :user="user" />
       </div>


### PR DESCRIPTION
This change introduces a small fix to the image path, to allow the logo image to render from any path the layout component renders from.