### PR TITLE
Avoid empty results Array in case of no mismatches

### DIFF
--- a/app/Http/Controllers/ResultsController.php
+++ b/app/Http/Controllers/ResultsController.php
@@ -44,13 +44,18 @@ class ResultsController extends Controller
 
         $entityIds = $this->extractEntityIds($mismatches, $itemIds);
 
-        return inertia('Results', [
-            'user' => $user,
-            'item_ids' => $itemIds,
-            'results' => $mismatches->groupBy('item_id'),
-            // Use wikidata to fetch labels for found entity ids
-            'labels' => $wikidata->getLabels($entityIds, App::getLocale())
-        ]);
+        $props = array_merge(
+            [
+                'user' => $user,
+                'item_ids' => $itemIds,
+                // Use wikidata to fetch labels for found entity ids
+                'labels' => $wikidata->getLabels($entityIds, App::getLocale())
+            ],
+            // only add 'results' prop if mismatches have been found
+            $mismatches->isNotEmpty() ? [ 'results' => $mismatches->groupBy('item_id') ] : []
+        );
+
+        return inertia('Results', $props);
     }
 
     private function extractEntityIds(LazyCollection $mismatches, array $initialIds): array

--- a/tests/Feature/WebResultsRouteTest.php
+++ b/tests/Feature/WebResultsRouteTest.php
@@ -104,12 +104,13 @@ class WebResultsRouteTest extends TestCase
             ])
             ->create();
 
-        $response = $this->get(route('results', [ 'ids' => $mismatch->item_id ]));
-        $response->assertSuccessful();
-        $response->assertViewIs('app')->assertInertia(function (Assert $page) {
-            $page->component('Results')
-                ->where('results', [ ]);
-        });
+        $this->get(route('results', [ 'ids' => $mismatch->item_id ]))
+            ->assertSuccessful()
+            ->assertViewIs('app')
+            ->assertInertia(function (Assert $page) {
+                $page->component('Results')
+                    ->missing('results');
+            });
     }
 
     /**
@@ -131,12 +132,13 @@ class WebResultsRouteTest extends TestCase
             ])
             ->create();
 
-        $response = $this->get(route('results', [ 'ids' => $mismatch->item_id ]));
-        $response->assertSuccessful();
-        $response->assertViewIs('app')->assertInertia(function (Assert $page) {
-            $page->component('Results')
-                ->where('results', [ ]);
-        });
+        $this->get(route('results', [ 'ids' => $mismatch->item_id ]))
+            ->assertSuccessful()
+            ->assertViewIs('app')
+            ->assertInertia(function (Assert $page) {
+                $page->component('Results')
+                    ->missing('results');
+            });
     }
 
     /**


### PR DESCRIPTION
This change makes sure that instead of sending an empty array in the
Inertia response, no results field is passed to Results.vue, when no
mismatches have been found. This way the results prop's default
function will be executed to create an empty object, which prevents an
'Invalid prop' error message, previously caused by the empty array.

Bug: [T294303](https://phabricator.wikimedia.org/T294303)