### PR TITLE
Confirmation Dialog

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -35,5 +35,11 @@
     "result-form-submit": "Apply changes",
     "log-in-message": "Please <a href=\"$1\">log in</a> to be able to make any changes.",
     "results-page-description": "You can fix them! The table below presents you with links to the statement on Wikidata and to the entry on the external source. You can compare the values and manually fix the mismatch, editing Wikidata or the external data source. After investigating and fixing the mismatch, you can indicate their status using the options from the drop-down.",
-    "results-page-title": "What should I do with the mismatches?"
+    "results-page-title": "What should I do with the mismatches?",
+    "confirmation-dialog-title": "Next steps",
+    "confirmation-dialog-message-intro": "Now that the changes are submitted successfully, remember:",
+    "confirmation-dialog-message-tip-1": "If the mismatch is on Wikidata, please use the link to the statement and edit it there to correct the mismatch.",
+    "confirmation-dialog-message-tip-2": "If the mismatch is on the external source, please inform the data source's maintainers of the error or correct the mismatch yourself, if possible.",
+    "confirmation-dialog-message-tip-3": "If the mismatch is on both sides, please use the link to the Wikidata statement to correct it and/or inform the data source’s maintainers of the error.",
+    "confirmation-dialog-button": "Proceed"
 }

--- a/public/i18n/qqq.json
+++ b/public/i18n/qqq.json
@@ -32,5 +32,11 @@
     "result-form-submit": "The call to action on the Results Item Mismatches Table button",
     "log-in-message": "A message to notify users to log in to make any changes",
     "results-page-description": "The description of the Results page",
-    "results-page-title": "The title of the Results page"
+    "results-page-title": "The title of the Results page",
+    "confirmation-dialog-title": "A title for the dialog that appears after changed have been successfully submitted",
+    "confirmation-dialog-message-intro": "Short test to segue into possible followup actions to submitting a review decision",
+    "confirmation-dialog-message-tip-1": "Tip to followup on a mismatch that was discovered in wikidata",
+    "confirmation-dialog-message-tip-2": "Tip to followup on a mismatch that was discovered in the external source",
+    "confirmation-dialog-message-tip-3": "Tip to followup on a mismatch that was discovered in both wikidata and the external source",
+    "confirmation-dialog-button": "A button to confirm that the confirmation dialog was seen"
 }

--- a/resources/js/Pages/Results.vue
+++ b/resources/js/Pages/Results.vue
@@ -55,7 +55,7 @@
                 namespace: 'next-steps-confirm'
             }]"
             @action="(_, dialog) => dialog.hide()"
-            dismissible
+            dismiss-button
         >
             <p>{{ $i18n('confirmation-dialog-message-intro') }}</p>
             <ul>

--- a/resources/js/Pages/Results.vue
+++ b/resources/js/Pages/Results.vue
@@ -47,6 +47,23 @@
                 </form>
             </section>
         </section>
+        <wikit-dialog class="confirmation-dialog"
+            :title="$i18n('confirmation-dialog-title')"
+            ref="confirmation"
+            :actions="[{
+                label: $i18n('confirmation-dialog-button'),
+                namespace: 'next-steps-confirm'
+            }]"
+            @action="(_, dialog) => dialog.hide()"
+            dismissible
+        >
+            <p>{{ $i18n('confirmation-dialog-message-intro') }}</p>
+            <ul>
+                <li>{{ $i18n('confirmation-dialog-message-tip-1') }}</li>
+                <li>{{ $i18n('confirmation-dialog-message-tip-2') }}</li>
+                <li>{{ $i18n('confirmation-dialog-message-tip-3') }}</li>
+            </ul>
+        </wikit-dialog>
     </div>
 </template>
 
@@ -57,6 +74,7 @@
         Link as WikitLink,
         Button as WikitButton,
         Message } from '@wmde/wikit-vue-components';
+    import WikitDialog from '../Components/Dialog.vue';
     import MismatchesTable from '../Components/MismatchesTable.vue';
     import Mismatch, {ReviewDecision, LabelledMismatch} from '../types/Mismatch';
     import User from '../types/User';
@@ -97,6 +115,7 @@
             MismatchesTable,
             WikitLink,
             WikitButton,
+            WikitDialog,
             Message
         },
         props: {
@@ -150,6 +169,13 @@
                 };
             },
             async send( item: string ): Promise<void> {
+                // Casting to `any` since TS cannot understand $refs as
+                // component instances and complains about the usage of `show`
+                // See: https://github.com/vuejs/vue-class-component/issues/94
+                // Defaulting to any, as the alternative presents us with
+                // convoluted and unnecessary syntax.
+                const confirmationDialog = this.$refs.confirmation! as any;
+
                 if(this.decisions[item]){
                     // use axios in order to preserve saved mismatches
                     try {
@@ -158,6 +184,8 @@
                         // remove decision from this.decisions after it has been
                         // sent to the server successfully, to avoid sending them twice
                         delete this.decisions[item];
+
+                        confirmationDialog.show();
                     } catch(e) {
                         console.error("saving review decisions has failed", e);
                     }

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -79,6 +79,18 @@ li {
     }
 }
 
+.wikit.wikit-Dialog {
+    // Override global styles from media query below
+    header {
+        flex-direction: row;
+    }
+
+    // Ensure dialog is wider than 75% default
+    .wikit-Dialog__modal {
+        max-width: 90%;
+    }
+}
+
 .wikit.wikit-Message {
     border-radius: $border-radius-base;
 }

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -55,6 +55,30 @@ a {
     @include link;
 }
 
+p, ul, ol {
+    margin-block-end: 1rem;
+
+    .wikit-Dialog & {
+        margin-block-end: 1rem;
+    }
+}
+
+li + li {
+    margin-block-start: 1rem;
+
+    .wikit-Dialog & {
+        margin-block-start: 1rem;
+    }
+}
+
+li {
+    margin-inline-start: 1rem;
+
+    .wikit-Dialog & {
+        margin-inline-start: 1rem;
+    }
+}
+
 .wikit.wikit-Message {
     border-radius: $border-radius-base;
 }

--- a/tests/Vue/Pages/Results.spec.js
+++ b/tests/Vue/Pages/Results.spec.js
@@ -231,4 +231,46 @@ describe('Results.vue', () => {
         //the decisions object will be untouched
         expect(wrapper.vm.decisions).toEqual({ [item_id]:{1:{id:1, item_id ,review_status: ReviewDecision.Wikidata}}});
     });
+
+    it('Shows confirmation dialog after successful put requests', async () => {
+        // Ensure a successful response (axios throws on any failed response from 400 up)
+        axios.put.mockImplementationOnce(() => true);
+
+        const item_id = 'Q321';
+        const decisions = { [item_id]:{1:{id:1, item_id ,review_status: ReviewDecision.Wikidata}}};
+        const wrapper = mount(Results, {
+            mocks,
+            data() {
+                return {
+                    decisions
+                }
+            }
+        });
+        const dialog = wrapper.find('.confirmation-dialog .wikit-Dialog');
+
+        await wrapper.vm.send(item_id);
+
+        expect(dialog.isVisible()).toBe(true);
+    });
+
+    it('Doesn\'t show confirmation dialog after failed put requests', async () => {
+        // Ensure a failed response (axios throws on any failed response from 400 up)
+        axios.put.mockImplementationOnce(() => { throw new Error() });
+
+        const item_id = 'Q321';
+        const decisions = { [item_id]:{1:{id:1, item_id ,review_status: ReviewDecision.Wikidata}}};
+        const wrapper = mount(Results, {
+            mocks,
+            data() {
+                return {
+                    decisions
+                }
+            }
+        });
+        const dialog = wrapper.find('.confirmation-dialog .wikit-Dialog');
+
+        await wrapper.vm.send(item_id);
+
+        expect(dialog.isVisible()).toBe(false);
+    });
 })


### PR DESCRIPTION
This change implements the confirmation dialog that appears upon successful submission of review decisions. This does not yet include the option to ignore the dialog in the future, which will be addressed in a followup.

Bug: [T290953](https://phabricator.wikimedia.org/T290953)