### PR TITLE
Allow users to disable confirmation dialog

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -41,5 +41,6 @@
     "confirmation-dialog-message-tip-1": "If the mismatch is on Wikidata, please use the link to the statement and edit it there to correct the mismatch.",
     "confirmation-dialog-message-tip-2": "If the mismatch is on the external source, please inform the data source's maintainers of the error or correct the mismatch yourself, if possible.",
     "confirmation-dialog-message-tip-3": "If the mismatch is on both sides, please use the link to the Wikidata statement to correct it and/or inform the data source’s maintainers of the error.",
-    "confirmation-dialog-button": "Proceed"
+    "confirmation-dialog-button": "Proceed",
+    "confirmation-dialog-option-label": "Do not show again"
 }

--- a/public/i18n/qqq.json
+++ b/public/i18n/qqq.json
@@ -38,5 +38,6 @@
     "confirmation-dialog-message-tip-1": "Tip to followup on a mismatch that was discovered in wikidata",
     "confirmation-dialog-message-tip-2": "Tip to followup on a mismatch that was discovered in the external source",
     "confirmation-dialog-message-tip-3": "Tip to followup on a mismatch that was discovered in both wikidata and the external source",
-    "confirmation-dialog-button": "A button to confirm that the confirmation dialog was seen"
+    "confirmation-dialog-button": "A button to confirm that the confirmation dialog was seen",
+    "confirmation-dialog-option-label": "Checkbox label to determine whether to disable the confirmation dialog in the future"
 }

--- a/resources/js/Components/Dialog.vue
+++ b/resources/js/Components/Dialog.vue
@@ -16,7 +16,7 @@
             aria-modal="true"
             :aria-labelledby="`dialog-title-${uid}`"
         >
-            <div class="wikit-Dialog__overlay" @click="hide"></div>
+            <div class="wikit-Dialog__overlay" @click="dismiss"></div>
             <div class="wikit-Dialog__modal">
                 <header class="wikit-Dialog__header">
                     <span :id="`dialog-title-${uid}`" class="wikit-Dialog__title">{{title}}</span>
@@ -27,7 +27,7 @@
                         type="neutral"
                         aria-label="close"
                         icon-only
-                        @click.native="hide"
+                        @click.native="dismiss"
                     >
                         <icon type="close" size="medium" />
                     </wikit-button>
@@ -173,13 +173,17 @@ export default defineComponent({
 
             this.$nextTick(this._resetScroll);
         },
+        dismiss(){
+            this.$emit('dismissed');
+            this.hide();
+        },
         _dispatch(namespace: string){
             this.$emit('action', namespace, this)
         },
         _handleKeydown(event : KeyboardEvent){
             switch (event.key) {
                 case 'Escape':
-                    this.hide();
+                    this.dismiss();
                     break;
                 case 'Tab':
                     this._cycleFocus(event.shiftKey)

--- a/resources/js/Pages/Results.vue
+++ b/resources/js/Pages/Results.vue
@@ -55,7 +55,7 @@
                 namespace: 'next-steps-confirm'
             }]"
             @action="_handleConfirmation"
-            @update:visible="_handleVisibility"
+            @dismissed="disableConfirmation = false"
             dismiss-button
         >
             <p>{{ $i18n('confirmation-dialog-message-intro') }}</p>
@@ -234,12 +234,6 @@
                 }
 
                 dialog.hide();
-            },
-            // Reset disable confirmation on dialog dismissal
-            _handleVisibility(showing: boolean){
-                if (!showing){
-                    this.disableConfirmation = false;
-                }
             }
         }
     });

--- a/resources/js/Pages/Results.vue
+++ b/resources/js/Pages/Results.vue
@@ -55,6 +55,7 @@
                 namespace: 'next-steps-confirm'
             }]"
             @action="_handleConfirmation"
+            @update:visible="_handleVisibility"
             dismiss-button
         >
             <p>{{ $i18n('confirmation-dialog-message-intro') }}</p>
@@ -235,6 +236,11 @@
                 dialog.hide();
             },
             // Reset disable confirmation on dialog dismissal
+            _handleVisibility(showing: boolean){
+                if (!showing){
+                    this.disableConfirmation = false;
+                }
+            }
         }
     });
 </script>

--- a/tests/Browser/Pages/ResultsPage.php
+++ b/tests/Browser/Pages/ResultsPage.php
@@ -47,7 +47,8 @@ class ResultsPage extends Page
     {
         return [
             '@confirmation-dialog' => '.confirmation-dialog',
-            '@disable-confirmation' => '.disable-confirmation'
+            '@disable-confirmation' => '.disable-confirmation',
+            '@disable-confirmation-label' => '.disable-confirmation>.wikit-checkbox__label'
         ];
     }
 

--- a/tests/Browser/Pages/ResultsPage.php
+++ b/tests/Browser/Pages/ResultsPage.php
@@ -4,6 +4,8 @@ namespace Tests\Browser\Pages;
 
 use Laravel\Dusk\Browser;
 use Laravel\Dusk\Page;
+use Tests\Browser\Components\DecisionDropdown;
+use App\Models\Mismatch;
 
 class ResultsPage extends Page
 {
@@ -39,5 +41,27 @@ class ResultsPage extends Page
         $browser
             ->assertPathIs('/results')
             ->assertPresent('header');
+    }
+
+    public function elements()
+    {
+        return [
+            '@confirmation-dialog' => '.confirmation-dialog',
+            '@disable-confirmation' => '.disable-confirmation'
+        ];
+    }
+
+    public function decideAndApply(Browser $browser, Mismatch $mismatch, array $decision)
+    {
+        $dropdownComponent = new DecisionDropdown($mismatch->id);
+
+        $browser->within($dropdownComponent, function ($dropdown) use ($decision) {
+           // select and assert option
+            $dropdown->selectPosition($decision['option'], $decision['label']);
+        })
+        // ensure the correct apply button is pressed
+        ->within("#item-mismatches-$mismatch->item_id", function ($section) {
+            $section->press('Apply changes');
+        });
     }
 }

--- a/tests/Browser/ResultsTest.php
+++ b/tests/Browser/ResultsTest.php
@@ -146,20 +146,12 @@ class ResultsTest extends DuskTestCase
             ->create();
 
         $this->browse(function (Browser $browser) use ($mismatch) {
-            $dropdownComponent = new DecisionDropdown($mismatch->id);
-
             $browser->loginAs(User::factory()->create())
                 ->visit(new ResultsPage($mismatch->item_id))
-                ->within($dropdownComponent, function ($dropdown) {
-                    // make sure the item's initial review_status is 'pending'
-                    $dropdown->assertVue('value', null)
-                        // select and assert option
-                        ->selectPosition(2, 'Mismatch on external data source');
-                })
-                // ensure the correct apply button is pressed
-                ->within("#item-mismatches-$mismatch->item_id", function ($section) {
-                    $section->press('Apply changes');
-                })
+                ->decideAndApply($mismatch, [
+                    'option' => 2,
+                    'label' => 'Mismatch on external data source'
+                ])
                 //load the page again
                 ->refresh()
                 // a 'notice' message indicates that the review status has been submitted
@@ -180,25 +172,18 @@ class ResultsTest extends DuskTestCase
             ->create();
 
         $this->browse(function (Browser $browser) use ($mismatch) {
-            $dropdownComponent = new DecisionDropdown($mismatch->id);
-
             $browser->loginAs(User::factory()->create())
                 ->visit(new ResultsPage($mismatch->item_id))
-                ->within($dropdownComponent, function ($dropdown) {
-                    // make sure the item's initial review_status is 'pending'
-                    $dropdown->assertVue('value', null)
-                        // select and assert option
-                        ->selectPosition(2, 'Mismatch on external data source');
-                })
-                // ensure the correct apply button is pressed
-                ->within("#item-mismatches-$mismatch->item_id", function ($section) {
-                    $section->press('Apply changes');
-                })
-                ->waitFor('.confirmation-dialog', 1)
+                ->decideAndApply($mismatch, [
+                    'option' => 2,
+                    'label' => 'Mismatch on external data source'
+                ])
+                ->waitFor('@confirmation-dialog', 1)
                 ->assertSee('Next steps')
                 ->press('Proceed')
-                ->waitUntilMissing('.confirmation-dialog')
+                ->waitUntilMissing('@confirmation-dialog')
                 ->assertDontSee('Next Steps');
         });
     }
+
 }

--- a/tests/Vue/Components/Dialog.spec.js
+++ b/tests/Vue/Components/Dialog.spec.js
@@ -115,6 +115,19 @@ describe('Dialog.vue', () => {
         expect(content.isVisible()).toBe(false);
     });
 
+    it('closes when calling the dismiss method', async () => {
+        const wrapper = mount(Dialog, {
+            propsData: { visible: true }
+        });
+
+        const content = wrapper.find('.wikit-Dialog');
+
+        wrapper.vm.dismiss();
+        await wrapper.vm.$nextTick();
+
+        expect(content.isVisible()).toBe(false);
+    });
+
     // Events
     it('emits update:visible event when hiding dialog', () => {
         const wrapper = mount(Dialog);
@@ -132,6 +145,14 @@ describe('Dialog.vue', () => {
 
         expect(wrapper.emitted()['update:visible']).toBeTruthy();
         expect(wrapper.emitted()['update:visible'][0]).toEqual([true]);
+    });
+
+    it('emits dismissed event when dismissed', () => {
+        const wrapper = mount(Dialog);
+
+        wrapper.vm.dismiss();
+
+        expect(wrapper.emitted()['dismissed']).toBeTruthy();
     });
 
     it('emits action event when pressing an action button', () => {
@@ -172,7 +193,7 @@ describe('Dialog.vue', () => {
         expect(content.isVisible()).toBe(false);
     });
 
-    it('closes when pressing the close button', async () => {
+    it('dismisses when pressing the close button', async () => {
         const wrapper = mount(Dialog, {
             propsData: {
                 visible: true,
@@ -186,10 +207,11 @@ describe('Dialog.vue', () => {
         button.trigger('click');
 
         await wrapper.vm.$nextTick();
+        expect(wrapper.emitted()['dismissed']).toBeTruthy();
         expect(content.isVisible()).toBe(false);
     });
 
-    it('closes when pressing the overlay', async () => {
+    it('dismisses when pressing the overlay', async () => {
         const wrapper = mount(Dialog, {
             propsData: { visible: true }
         });
@@ -200,10 +222,11 @@ describe('Dialog.vue', () => {
         overlay.trigger('click');
 
         await wrapper.vm.$nextTick();
+        expect(wrapper.emitted()['dismissed']).toBeTruthy();
         expect(content.isVisible()).toBe(false);
     });
 
-    it('closes when pressing the esc key', async () => {
+    it('dismisses when pressing the esc key', async () => {
         const wrapper = mount(Dialog, {
             propsData: { visible: true },
             attachTo: document.body
@@ -215,6 +238,7 @@ describe('Dialog.vue', () => {
         });
 
         await wrapper.vm.$nextTick();
+        expect(wrapper.emitted()['dismissed']).toBeTruthy();
         expect(content.isVisible()).toBe(false);
     });
 

--- a/tests/Vue/Components/Dialog.spec.js
+++ b/tests/Vue/Components/Dialog.spec.js
@@ -91,7 +91,7 @@ describe('Dialog.vue', () => {
     // Methods
     it('opens when calling the show method', async () => {
         const wrapper = mount(Dialog, {
-            visible: false
+            propsData: { visible: false }
         });
 
         const content = wrapper.find('.wikit-Dialog');
@@ -104,7 +104,7 @@ describe('Dialog.vue', () => {
 
     it('closes when calling the hide method', async () => {
         const wrapper = mount(Dialog, {
-            visible: true
+            propsData: { visible: true }
         });
 
         const content = wrapper.find('.wikit-Dialog');


### PR DESCRIPTION
_**Note:** This PR depends on #178_

This change allows the user to disable the confirmation dialog that appear when submitting decisions, and persists that state into the browser's local storage.

Additionally, some convenience methods were added to the results page testing object to apply and submit review decisions more easily within the browser tests.

Bug: [T290953](https://phabricator.wikimedia.org/T290953)