### PR TITLE
Change width of review-status column to 25%

### DIFF
--- a/resources/js/Components/MismatchesTable.vue
+++ b/resources/js/Components/MismatchesTable.vue
@@ -47,6 +47,6 @@ export default Vue.extend({
 <style lang="scss">
     .column-review-status {
         // Ensures that the dropdowns are evenly wide
-        width: 35%;
+        width: 25%;
     }
 </style>


### PR DESCRIPTION
**NOTE: This PR is based on PR #85, which should be merged first.**

The review status column should be 280px at an overall table width of
1120px, which is 25%.

Bug: [T294577](https://phabricator.wikimedia.org/T294577)