### PR TITLE
Add dialog with instructions to results intro text

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -36,7 +36,7 @@
     "log-in-message": "Please <a href=\"$1\">log in</a> to be able to make any changes.",
     "results-page-description": "You can fix them! The table below presents you with links to the statement on Wikidata and to the entry on the external source. You can compare the values and manually fix the mismatch, editing Wikidata or the external data source. After investigating and fixing the mismatch, you can indicate their status using the options from the drop-down.",
     "results-page-title": "What should I do with the mismatches?",
-    "results-consult-instructions-link": "Consult the instructions",
+    "results-instructions-button": "Instructions",
     "confirmation-dialog-title": "Next steps",
     "results-read-full-description-link": "read the full description",
     "confirmation-dialog-message-intro": "Now that the changes are submitted successfully, remember:",

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -36,7 +36,7 @@
     "log-in-message": "Please <a href=\"$1\">log in</a> to be able to make any changes.",
     "results-page-description": "You can fix them! The table below presents you with links to the statement on Wikidata and to the entry on the external source. You can compare the values and manually fix the mismatch, editing Wikidata or the external data source. After investigating and fixing the mismatch, you can indicate their status using the options from the drop-down.",
     "results-page-title": "What should I do with the mismatches?",
-    "results-instructions-button": "Instructions",
+    "results-instructions-button": "Instruction",
     "confirmation-dialog-title": "Next steps",
     "results-read-full-description-link": "read the full description",
     "confirmation-dialog-message-intro": "Now that the changes are submitted successfully, remember:",

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -36,6 +36,7 @@
     "log-in-message": "Please <a href=\"$1\">log in</a> to be able to make any changes.",
     "results-page-description": "You can fix them! The table below presents you with links to the statement on Wikidata and to the entry on the external source. You can compare the values and manually fix the mismatch, editing Wikidata or the external data source. After investigating and fixing the mismatch, you can indicate their status using the options from the drop-down.",
     "results-page-title": "What should I do with the mismatches?",
+    "results-consult-instructions-link": "Consult the instructions",
     "confirmation-dialog-title": "Next steps",
     "results-read-full-description-link": "read the full description",
     "confirmation-dialog-message-intro": "Now that the changes are submitted successfully, remember:",
@@ -44,5 +45,13 @@
     "confirmation-dialog-message-tip-3": "If the mismatch is on both sides, please use the link to the Wikidata statement to correct it and/or inform the data source’s maintainers of the error.",
     "confirmation-dialog-button": "Proceed",
     "confirmation-dialog-option-label": "Do not show again",
-    "confirm-dialog-button": "Confirm"
+    "confirm-dialog-button": "Confirm",
+    "instructions-dialog-title": "Instruction on mismatches",
+    "instructions-dialog-message-upload-info-description": "In the “Upload Info” column, you can find additional information for each upload that might be valuable when investigating the mismatches. This includes the username of the person who uploaded the mismatch, the date of the upload and a short description of it.",
+    "instructions-dialog-message-intro": "After investigating the mismatches, please choose one of the following status from the the drop-down:",
+    "instructions-dialog-message-instruction-wikidata": "Mismatch on Wikidata: use this option if Wikidata's data is inaccurate. Please use the link to the Wikidata statement and edit it there to correct the mismatch.",
+    "instructions-dialog-message-instruction-external": "Mismatch on external data source: use this option if the error lies in the external data source. When possible, please inform the data source's maintainers of the error or correct the mismatch yourself.",
+    "instructions-dialog-message-instruction-both": "Both are wrong: use this option if you find there are errors on both sides. When possible, please use the link to the Wikidata statement to correct the mismatch and/or inform the data source’s maintainers of the error.",
+    "instructions-dialog-message-instruction-none": "None of the above: use this option if none of the other options are applicable. This might for example be the case if the mismatch has already been resolved by someone else."
+
 }

--- a/public/i18n/qqq.json
+++ b/public/i18n/qqq.json
@@ -33,7 +33,7 @@
     "log-in-message": "A message to notify users to log in to make any changes",
     "results-page-description": "The description of the Results page",
     "results-page-title": "The title of the Results page",
-    "results-consult-instructions-link": "The link in the Intro text to consult further instructions",
+    "results-instructions-button": "The quiet button in the intro section to consult further instructions",
     "results-read-full-description-link": "The link in the Upload info column to see a full description",
     "confirmation-dialog-title": "A title for the dialog that appears after changed have been successfully submitted",
     "confirmation-dialog-message-intro": "Short text to segue into possible followup actions to submitting a review decision",

--- a/public/i18n/qqq.json
+++ b/public/i18n/qqq.json
@@ -33,6 +33,7 @@
     "log-in-message": "A message to notify users to log in to make any changes",
     "results-page-description": "The description of the Results page",
     "results-page-title": "The title of the Results page",
+    "results-consult-instructions-link": "The link in the Intro text to consult further instructions",
     "results-read-full-description-link": "The link in the Upload info column to see a full description",
     "confirmation-dialog-title": "A title for the dialog that appears after changed have been successfully submitted",
     "confirmation-dialog-message-intro": "Short test to segue into possible followup actions to submitting a review decision",
@@ -41,5 +42,12 @@
     "confirmation-dialog-message-tip-3": "Tip to followup on a mismatch that was discovered in both wikidata and the external source",
     "confirmation-dialog-button": "A button to confirm that the confirmation dialog was seen",
     "confirmation-dialog-option-label": "Checkbox label to determine whether to disable the confirmation dialog in the future",
-    "confirm-dialog-button": "A button to confirm that the upload info description dialog was seen"
+    "confirm-dialog-button": "A button to confirm that the upload info description dialog was seen",
+    "instructions-dialog-title": "The title of the instructions dialog",
+    "instructions-dialog-message-upload-info-description": "Short description of the 'Upload Info' column",
+    "instructions-dialog-message-intro": "Short text to segue into the instructions",
+    "instructions-dialog-message-instruction-wikidata": "Instruction when to choose the review status 'wikidata'",
+    "instructions-dialog-message-instruction-external": "Instruction when to choose the review status 'external source'",
+    "instructions-dialog-message-instruction-both": "Instruction when to choose the review status 'both'",
+    "instructions-dialog-message-instruction-none": "Instruction when to choose the review status 'none'"
 }

--- a/public/i18n/qqq.json
+++ b/public/i18n/qqq.json
@@ -36,7 +36,7 @@
     "results-consult-instructions-link": "The link in the Intro text to consult further instructions",
     "results-read-full-description-link": "The link in the Upload info column to see a full description",
     "confirmation-dialog-title": "A title for the dialog that appears after changed have been successfully submitted",
-    "confirmation-dialog-message-intro": "Short test to segue into possible followup actions to submitting a review decision",
+    "confirmation-dialog-message-intro": "Short text to segue into possible followup actions to submitting a review decision",
     "confirmation-dialog-message-tip-1": "Tip to followup on a mismatch that was discovered in wikidata",
     "confirmation-dialog-message-tip-2": "Tip to followup on a mismatch that was discovered in the external source",
     "confirmation-dialog-message-tip-3": "Tip to followup on a mismatch that was discovered in both wikidata and the external source",

--- a/resources/js/Components/Dialog.vue
+++ b/resources/js/Components/Dialog.vue
@@ -310,6 +310,7 @@ export default defineComponent({
         right: 0;
         bottom: 0;
         left: 0;
+        z-index: 1;
     }
 
     #{$base}__overlay {

--- a/resources/js/Pages/Results.vue
+++ b/resources/js/Pages/Results.vue
@@ -2,32 +2,42 @@
     <div class="page-container results-page">
         <Head title="Mismatch Finder - Results" />
         <section id="description-section">
-            <h2 class="h4">{{ $i18n('results-page-title') }}</h2>
+            <div class="description-header">
+                <h2 class="h4">{{ $i18n('results-page-title') }}</h2>
+                <wikit-button
+                    class="instructions-button"
+                    variant="quiet"
+                    type="progressive"
+                    @click.native="showInstructionsDialog"
+                >
+                    <template #prefix>
+                        <icon type="info-outlined" size="medium" color="inherit"/>
+                    </template>
+                    {{$i18n('results-instructions-button')}}
+                </wikit-button>
+            </div>
+
+            <wikit-dialog class="instructions-dialog"
+                :title="$i18n('instructions-dialog-title')"
+                ref="inctructionsDialog"
+                :actions="[{
+                    label: $i18n('confirm-dialog-button'),
+                    namespace: 'instructions-confirm'
+                }]"
+                @action="(_, dialog) => dialog.hide()"
+                dismiss-button
+            >
+                <p>{{ $i18n('instructions-dialog-message-upload-info-description') }}</p>
+                <p class="list-intro">{{ $i18n('instructions-dialog-message-intro') }}</p>
+                <ul>
+                    <li>{{ $i18n('instructions-dialog-message-instruction-wikidata') }}</li>
+                    <li>{{ $i18n('instructions-dialog-message-instruction-external') }}</li>
+                    <li>{{ $i18n('instructions-dialog-message-instruction-both') }}</li>
+                    <li>{{ $i18n('instructions-dialog-message-instruction-none') }}</li>
+                </ul>
+            </wikit-dialog>
             <p id="about-description" >
                 {{ $i18n('results-page-description') }}
-                <wikit-link class="consult-instructions-link" href="#" @click.native="showInstructionsDialog">
-                    {{$i18n('results-consult-instructions-link')}}
-                </wikit-link>
-
-                <wikit-dialog class="instructions-dialog"
-                    :title="$i18n('instructions-dialog-title')"
-                    ref="inctructionsDialog"
-                    :actions="[{
-                        label: $i18n('confirm-dialog-button'),
-                        namespace: 'instructions-confirm'
-                    }]"
-                    @action="(_, dialog) => dialog.hide()"
-                    dismiss-button
-                >
-                    <p>{{ $i18n('instructions-dialog-message-upload-info-description') }}</p>
-                    <p class="list-intro">{{ $i18n('instructions-dialog-message-intro') }}</p>
-                    <ul>
-                        <li>{{ $i18n('instructions-dialog-message-instruction-wikidata') }}</li>
-                        <li>{{ $i18n('instructions-dialog-message-instruction-external') }}</li>
-                        <li>{{ $i18n('instructions-dialog-message-instruction-both') }}</li>
-                        <li>{{ $i18n('instructions-dialog-message-instruction-none') }}</li>
-                    </ul>
-                </wikit-dialog>
             </p>
         </section>
         <section id="error-section" v-if="unexpectedError">
@@ -104,6 +114,7 @@
         Link as WikitLink,
         Button as WikitButton,
         Checkbox,
+        Icon,
         Message } from '@wmde/wikit-vue-components';
     import WikitDialog from '../Components/Dialog.vue';
     import MismatchesTable from '../Components/MismatchesTable.vue';
@@ -144,6 +155,7 @@
     export default defineComponent({
         components: {
             Head,
+            Icon,
             MismatchesTable,
             WikitLink,
             WikitButton,
@@ -298,11 +310,25 @@ h2 {
     margin-top: $dimension-layout-xsmall;
 }
 
-.wikit-Link.consult-instructions-link {
-    display: inline;
-}
-
 p.list-intro {
     margin-bottom: 0
+}
+
+#description-section {
+    position:relative;
+
+    .description-header {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+
+        h2 {
+            width: 100%;
+        }
+
+        .instructions-button {
+            padding: 6px 13px;
+        }
+    }
 }
 </style>

--- a/resources/js/Pages/Results.vue
+++ b/resources/js/Pages/Results.vue
@@ -3,7 +3,32 @@
         <Head title="Mismatch Finder - Results" />
         <section id="description-section">
             <h2 class="h4">{{ $i18n('results-page-title') }}</h2>
-            <p id="about-description" >{{ $i18n('results-page-description') }}</p>
+            <p id="about-description" >
+                {{ $i18n('results-page-description') }}
+                <wikit-link class="consult-instructions-link" href="#" @click.native="showInstructionsDialog">
+                    {{$i18n('results-consult-instructions-link')}}
+                </wikit-link>
+
+                <wikit-dialog class="instructions-dialog"
+                    :title="$i18n('instructions-dialog-title')"
+                    ref="inctructionsDialog"
+                    :actions="[{
+                        label: $i18n('confirm-dialog-button'),
+                        namespace: 'instructions-confirm'
+                    }]"
+                    @action="(_, dialog) => dialog.hide()"
+                    dismiss-button
+                >
+                    <p>{{ $i18n('instructions-dialog-message-upload-info-description') }}</p>
+                    <p class="list-intro">{{ $i18n('instructions-dialog-message-intro') }}</p>
+                    <ul>
+                        <li>{{ $i18n('instructions-dialog-message-instruction-wikidata') }}</li>
+                        <li>{{ $i18n('instructions-dialog-message-instruction-external') }}</li>
+                        <li>{{ $i18n('instructions-dialog-message-instruction-both') }}</li>
+                        <li>{{ $i18n('instructions-dialog-message-instruction-none') }}</li>
+                    </ul>
+                </wikit-dialog>
+            </p>
         </section>
         <section id="error-section" v-if="unexpectedError">
             <Message type="error">{{ $i18n('server-error') }}</Message>
@@ -177,6 +202,12 @@
             }
         },
         methods: {
+            showInstructionsDialog(e: Event) {
+                e.preventDefault();
+                /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+                const dialog = this.$refs.inctructionsDialog as any;
+                dialog.show();
+            },
             addLabels(mismatches: Mismatch[]): LabelledMismatch[]{
                 // The following callback maps existing mismatches to extended
                 // mismatch objects which include labels, by looking up any
@@ -267,4 +298,11 @@ h2 {
     margin-top: $dimension-layout-xsmall;
 }
 
+.wikit-Link.consult-instructions-link {
+    display: inline;
+}
+
+p.list-intro {
+    margin-bottom: 0
+}
 </style>

--- a/resources/js/Pages/Results.vue
+++ b/resources/js/Pages/Results.vue
@@ -83,7 +83,7 @@
             @dismissed="disableConfirmation = false"
             dismiss-button
         >
-            <p>{{ $i18n('confirmation-dialog-message-intro') }}</p>
+            <p class="list-intro">{{ $i18n('confirmation-dialog-message-intro') }}</p>
             <ul>
                 <li>{{ $i18n('confirmation-dialog-message-tip-1') }}</li>
                 <li>{{ $i18n('confirmation-dialog-message-tip-2') }}</li>

--- a/resources/js/Pages/Results.vue
+++ b/resources/js/Pages/Results.vue
@@ -214,8 +214,7 @@
             }
         },
         methods: {
-            showInstructionsDialog(e: Event) {
-                e.preventDefault();
+            showInstructionsDialog() {
                 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
                 const dialog = this.$refs.inctructionsDialog as any;
                 dialog.show();
@@ -315,20 +314,12 @@ p.list-intro {
 }
 
 #description-section {
-    position:relative;
 
     .description-header {
         display: flex;
         flex-direction: row;
         align-items: center;
-
-        h2 {
-            width: 100%;
-        }
-
-        .instructions-button {
-            padding: 6px 13px;
-        }
+        justify-content: space-between;
     }
 }
 </style>

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -102,7 +102,7 @@ li {
 #intro-section,
 #error-section,
 #message-section,
-#about-description {
+#description-section {
     max-width: 705px;
 }
 

--- a/tests/Vue/Pages/Results.spec.js
+++ b/tests/Vue/Pages/Results.spec.js
@@ -22,19 +22,20 @@ describe('Results.vue', () => {
         },
     }
 
-    it('displays intro text with instructions link', () => {
+    it('displays intro text and instructions button', () => {
         const wrapper = mount(Results, { mocks });
 
         const intro = wrapper.find('#about-description');
         expect(intro.isVisible()).toBe(true);
 
-        const instructionsLink = intro.find('.consult-instructions-link');
-        expect(instructionsLink.isVisible()).toBe(true);
+        const instructionsButton = wrapper.find('.instructions-button');
+        expect(instructionsButton.isVisible()).toBe(true);
+
     });
 
-    it('Shows dialog after clicking "consult instructions" in intro text', async () => {
+    it('shows dialog after clicking the instructions button', async () => {
         const wrapper = mount(Results, { mocks });
-        await wrapper.find('.consult-instructions-link').trigger('click');
+        await wrapper.find('.instructions-button').trigger('click');
 
         const dialog = wrapper.find('.instructions-dialog .wikit-Dialog');
         expect(dialog.isVisible()).toBe(true);

--- a/tests/Vue/Pages/Results.spec.js
+++ b/tests/Vue/Pages/Results.spec.js
@@ -22,6 +22,24 @@ describe('Results.vue', () => {
         },
     }
 
+    it('displays intro text with instructions link', () => {
+        const wrapper = mount(Results, { mocks });
+
+        const intro = wrapper.find('#about-description');
+        expect(intro.isVisible()).toBe(true);
+
+        const instructionsLink = intro.find('.consult-instructions-link');
+        expect(instructionsLink.isVisible()).toBe(true);
+    });
+
+    it('Shows dialog after clicking "consult instructions" in intro text', async () => {
+        const wrapper = mount(Results, { mocks });
+        await wrapper.find('.consult-instructions-link').trigger('click');
+
+        const dialog = wrapper.find('.instructions-dialog .wikit-Dialog');
+        expect(dialog.isVisible()).toBe(true);
+    });
+
     it('accepts and renders item ids', () => {
         const item_ids =  ['Q1', 'Q2']
         const wrapper = mount(Results, {

--- a/tests/Vue/Pages/Results.spec.js
+++ b/tests/Vue/Pages/Results.spec.js
@@ -251,27 +251,6 @@ describe('Results.vue', () => {
         expect(wrapper.vm.decisions).toEqual({ [item_id]:{1:{id:1, item_id ,review_status: ReviewDecision.Wikidata}}});
     });
 
-    it('Shows confirmation dialog after successful put requests', async () => {
-        // Ensure a successful response (axios throws on any failed response from 400 up)
-        axios.put.mockImplementationOnce(() => true);
-
-        const item_id = 'Q321';
-        const decisions = { [item_id]:{1:{id:1, item_id ,review_status: ReviewDecision.Wikidata}}};
-        const wrapper = mount(Results, {
-            mocks,
-            data() {
-                return {
-                    decisions
-                }
-            }
-        });
-        const dialog = wrapper.find('.confirmation-dialog .wikit-Dialog');
-
-        await wrapper.vm.send(item_id);
-
-        expect(dialog.isVisible()).toBe(true);
-    });
-
     it('Doesn\'t show confirmation dialog after failed put requests', async () => {
         // Ensure a failed response (axios throws on any failed response from 400 up)
         axios.put.mockImplementationOnce(() => { throw new Error() });


### PR DESCRIPTION
This change adds a quiet button to the Result Page's intro text,
which will open a dialog with detailed instructions about how to work
with the mismatches and how to resolve them properly.

Bug: [T290862](https://phabricator.wikimedia.org/T290862)