### PR TITLE
Use button instead of link for description dialog

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -38,7 +38,7 @@
     "results-page-title": "What should I do with the mismatches?",
     "results-instructions-button": "Instruction",
     "confirmation-dialog-title": "Next steps",
-    "results-read-full-description-link": "read the full description",
+    "results-full-description-button": "read the full description",
     "confirmation-dialog-message-intro": "Now that the changes are submitted successfully, remember:",
     "confirmation-dialog-message-tip-1": "If the mismatch is on Wikidata, please use the link to the statement and edit it there to correct the mismatch.",
     "confirmation-dialog-message-tip-2": "If the mismatch is on the external source, please inform the data source's maintainers of the error or correct the mismatch yourself, if possible.",

--- a/public/i18n/qqq.json
+++ b/public/i18n/qqq.json
@@ -34,7 +34,7 @@
     "results-page-description": "The description of the Results page",
     "results-page-title": "The title of the Results page",
     "results-instructions-button": "The quiet button in the intro section to consult further instructions",
-    "results-read-full-description-link": "The link in the Upload info column to see a full description",
+    "results-full-description-button": "The button in the Upload info column to see a full description",
     "confirmation-dialog-title": "A title for the dialog that appears after changed have been successfully submitted",
     "confirmation-dialog-message-intro": "Short text to segue into possible followup actions to submitting a review decision",
     "confirmation-dialog-message-tip-1": "Tip to followup on a mismatch that was discovered in wikidata",

--- a/resources/js/Components/MismatchRow.vue
+++ b/resources/js/Components/MismatchRow.vue
@@ -57,11 +57,16 @@
                 <span class="upload-date">{{uploadDate}}</span>
                 <div class="description">
                   {{uploadInfoDescription}}
-                  <wikit-link v-if="shouldTruncate" class="full-description-link" href="#" @click.native="showDialog">
-                    {{$i18n('results-read-full-description-link')}}
-                  </wikit-link>
+                  <wikit-button
+                      v-if="shouldTruncate"
+                      class="full-description-button"
+                      variant="quiet"
+                      type="progressive"
+                      @click.native="showDialog"
+                  >
+                      {{$i18n('results-full-description-button')}}
+                  </wikit-button>
                 </div>
-                
             </div>
             <wikit-dialog class="full-description-dialog"
               :title="$i18n('column-upload-info')"
@@ -92,7 +97,7 @@
 import { formatISO } from 'date-fns';
 
 import Vue, { PropType } from 'vue';
-import { Dropdown, Link as WikitLink } from '@wmde/wikit-vue-components';
+import { Button as WikitButton, Dropdown, Link as WikitLink } from '@wmde/wikit-vue-components';
 import { MenuItem } from '@wmde/wikit-vue-components/dist/components/MenuItem';
 import WikitDialog from '../Components/Dialog.vue';
 
@@ -115,6 +120,7 @@ interface MismatchRowState {
 
 export default Vue.extend({
     components: {
+    WikitButton,
     WikitLink,
     WikitDialog,
     Dropdown,
@@ -181,7 +187,8 @@ export default Vue.extend({
     .wikit-Link__content {
       word-break: break-word;
     }
-    .wikit-Link.full-description-link {
-      display: inline;
+    .wikit-Button.full-description-button {
+      padding: 0px 2px;
+      font-weight: 400;
     }
 </style>

--- a/tests/Vue/Components/MismatchRow.spec.js
+++ b/tests/Vue/Components/MismatchRow.spec.js
@@ -200,7 +200,7 @@ describe('MismatchesRow.vue', () => {
         const descriptionElementText = td.find('.description').text();
 
         // workaround pseudo selector :not(.full-description-link) not working
-        const descriptionLinkText = td.find('.full-description-link').text();
+        const descriptionLinkText = td.find('.full-description-button').text();
         const renderedDescriptionText = descriptionElementText.replace(descriptionLinkText, '').trim();
 
         expect( wrapper.props().mismatch ).toBe( mismatch );
@@ -269,7 +269,7 @@ describe('MismatchesRow.vue', () => {
             }
         });
 
-        await wrapper.find('.full-description-link').trigger('click');
+        await wrapper.find('.full-description-button').trigger('click');
         
         const dialog = wrapper.find('.full-description-dialog .wikit-Dialog');
 


### PR DESCRIPTION
This change replaces the existing `<wikit-link>` element from the Results
Page's "Upload Info" column with a `<wikit-button>` component that is
styled in such a way, that it appears as an inline element.

Bug: [T290849](https://phabricator.wikimedia.org/T290849)