### PR TITLE
Add FAQ dialog to item query page

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -58,13 +58,13 @@
     "faq-dialog-title": "More on the Mismatch Finder",
     "faq-dialog-question-finding-mismatches": "How are mismatches found?",
     "faq-dialog-answer-finding-mismatches": "The Mismatch Finder shows you the origin of each mismatch in the results table. The mismatches come from a variety of sources, notably:",
-    "faq-dialog-answer-finding-mismatches-sources-1": "Researchers that are analyzing Wikidata’s data;",
-    "faq-dialog-answer-finding-mismatches-sources-2": "Large reusers of Wikidata’s data;",
-    "faq-dialog-answer-finding-mismatches-sources-3": "Invdividual contributors working with Wikidata’s data;",
+    "faq-dialog-answer-finding-mismatches-sources-1": "Researchers that are analyzing Wikidata's data;",
+    "faq-dialog-answer-finding-mismatches-sources-2": "Large reusers of Wikidata's data;",
+    "faq-dialog-answer-finding-mismatches-sources-3": "Individual contributors working with Wikidata's data;",
     "faq-dialog-question-relevance": "How fresh are the mismatches?",
     "faq-dialog-answer-relevance": "It depends! Inspecting external databases, catalogs and websites takes a lot of time and resources; the checks are performed periodically in batches. We try hard to remove outdated mismatches, but you might still find some.",
     "faq-dialog-question-contributing": "How can I contribute new mismatches?",
     "faq-dialog-answer-contributing": "If you've compared Wikidata's data against an external data source and have found mismatches, you can open a ticket in <a href=\"$1\">Phabricator</a>.",
     "faq-dialog-question-more-info": "Where can I find more information?",
-    "faq-dialog-answer-more-info": "This tool’s documentation and the source code are available on <a href=\"$1\">GitHub</a>. You can read more about Mismatch Finder on <a href=\"$2\">Wikidata</a> or you can <a href=\"$3\">give us feedback.</a>"
+    "faq-dialog-answer-more-info": "This tool’s documentation and the source code are available on <a href=\"$1\">GitHub</a>. You can read more about Mismatch Finder on <a href=\"$2\">Wikidata</a> or you can <a href=\"$3\">give us feedback</a>."
 }

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -53,5 +53,18 @@
     "instructions-dialog-message-instruction-external": "Mismatch on external data source: use this option if the error lies in the external data source. When possible, please inform the data source's maintainers of the error or correct the mismatch yourself.",
     "instructions-dialog-message-instruction-both": "Both are wrong: use this option if you find there are errors on both sides. When possible, please use the link to the Wikidata statement to correct the mismatch and/or inform the data source’s maintainers of the error.",
     "instructions-dialog-message-instruction-none": "None of the above: use this option if none of the other options are applicable. This might for example be the case if the mismatch has already been resolved by someone else.",
-    "results-back-button": "Refine Item Selection"
+    "results-back-button": "Refine Item Selection",
+    "faq-button": "More Information",
+    "faq-dialog-title": "More on the Mismatch Finder",
+    "faq-dialog-question-finding-mismatches": "How are mismatches found?",
+    "faq-dialog-answer-finding-mismatches": "The Mismatch Finder shows you the origin of each mismatch in the results table. The mismatches come from a variety of sources, notably:",
+    "faq-dialog-answer-finding-mismatches-sources-1": "Researchers that are analyzing Wikidata’s data;",
+    "faq-dialog-answer-finding-mismatches-sources-2": "Large reusers of Wikidata’s data;",
+    "faq-dialog-answer-finding-mismatches-sources-3": "Invdividual contributors working with Wikidata’s data;",
+    "faq-dialog-question-relevance": "How fresh are the mismatches?",
+    "faq-dialog-answer-relevance": "It depends! Inspecting external databases, catalogs and websites takes a lot of time and resources; the checks are performed periodically in batches. We try hard to remove outdated mismatches, but you might still find some.",
+    "faq-dialog-question-contributing": "How can I contribute new mismatches?",
+    "faq-dialog-answer-contributing": "If you've compared Wikidata's data against an external data source and have found mismatches, you can open a ticket in <a href=\"$1\">Phabricator</a>.",
+    "faq-dialog-question-more-info": "Where can I find more information?",
+    "faq-dialog-answer-more-info": "This tool’s documentation and the source code are available on <a href=\"$1\">GitHub</a>. You can read more about Mismatch Finder on <a href=\"$2\">Wikidata</a> or you can <a href=\"$3\">give us feedback.</a>"
 }

--- a/public/i18n/qqq.json
+++ b/public/i18n/qqq.json
@@ -50,5 +50,18 @@
     "instructions-dialog-message-instruction-external": "Instruction when to choose the review status 'external source'",
     "instructions-dialog-message-instruction-both": "Instruction when to choose the review status 'both'",
     "instructions-dialog-message-instruction-none": "Instruction when to choose the review status 'none'",
-    "results-back-button": "A button to return back to the item query page and refine search results"
+    "results-back-button": "A button to return back to the item query page and refine search results",
+    "faq-button": "A button to trigger the mismatch finder FAQ dialog",
+    "faq-dialog-title": "FAQ Dialog title",
+    "faq-dialog-question-finding-mismatches": "A question regarding mismatch sources",
+    "faq-dialog-answer-finding-mismatches": "Answer introducing various sources for mismatches",
+    "faq-dialog-answer-finding-mismatches-sources-1": "A source for mismatches",
+    "faq-dialog-answer-finding-mismatches-sources-2": "A source for mismatches",
+    "faq-dialog-answer-finding-mismatches-sources-3": "A source for mismatches",
+    "faq-dialog-question-relevance": "A question regarding the age and relevance of mismatches",
+    "faq-dialog-answer-relevance": "An answer regarding the age of mismatches",
+    "faq-dialog-question-contributing": "A question about how to contribute mismatches to the tool",
+    "faq-dialog-answer-contributing": "An answer describing how to contribute mismatches to the tool, using a link to the relevant phabricator board",
+    "faq-dialog-question-more-info": "A question about where to find additional information on the mismatch finder",
+    "faq-dialog-answer-more-info": "An answer listing various links with more information about the mismatch finder tool"
 }

--- a/resources/js/Pages/Home.vue
+++ b/resources/js/Pages/Home.vue
@@ -73,6 +73,7 @@
                 />
                 <div class="form-buttons">
                     <wikit-button
+                        class="submit-ids"
                         variant="primary"
                         type="progressive"
                         native-type="submit"

--- a/resources/js/Pages/Home.vue
+++ b/resources/js/Pages/Home.vue
@@ -2,7 +2,56 @@
     <div class="page-container home-page">
         <Head title="Mismatch Finder" />
         <section id="description-section">
-            <p id="about-description" >{{ $i18n('about-mismatch-finder-description') }}</p>
+            <header class="description-header">
+                <h2 class="h4">{{ $i18n('about-mismatch-finder-title') }}</h2>
+                <wikit-button
+                    class="instructions-button"
+                    variant="quiet"
+                    type="progressive"
+                    @click.native="$refs.faq.show()"
+                >
+                    <template #prefix>
+                        <icon type="info-outlined" size="medium" color="inherit"/>
+                    </template>
+                    {{ $i18n('faq-button') }}
+                </wikit-button>
+            </header>
+
+            <wikit-dialog class="instructions-dialog"
+                :title="$i18n('faq-dialog-title')"
+                ref="faq"
+                :actions="[{
+                    label: $i18n('confirm-dialog-button'),
+                    namespace: 'faq-confirm'
+                }]"
+                @action="(_, dialog) => dialog.hide()"
+                dismiss-button
+            >
+                <section>
+                    <h3 class="h5">{{ $i18n('faq-dialog-question-finding-mismatches' )}}</h3>
+                    <p>{{ $i18n('faq-dialog-answer-finding-mismatches') }}</p>
+                    <ul>
+                        <li>{{ $i18n('faq-dialog-answer-finding-mismatches-sources-1') }}</li>
+                        <li>{{ $i18n('faq-dialog-answer-finding-mismatches-sources-2') }}</li>
+                        <li>{{ $i18n('faq-dialog-answer-finding-mismatches-sources-3') }}</li>
+                    </ul>
+                </section>
+                <section>
+                    <h3 class="h5">{{ $i18n('faq-dialog-question-relevance') }}</h3>
+                    <p>{{ $i18n('faq-dialog-answer-relevance') }}</p>
+                </section>
+                <section>
+                    <h3 class="h5">{{ $i18n('faq-dialog-question-contributing') }}</h3>
+                    <p v-i18n-html:faq-dialog-answer-contributing></p>
+                </section>
+                <section>
+                    <h3 class="h5">{{ $i18n('faq-dialog-question-more-info') }}</h3>
+                    <p v-i18n-html:faq-dialog-answer-more-info></p>
+                </section>
+            </wikit-dialog>
+            <p id="about-description" >
+                {{ $i18n('about-mismatch-finder-description') }}
+            </p>
         </section>
 
         <section id="message-section">
@@ -42,10 +91,12 @@
     import { Head } from '@inertiajs/inertia-vue';
     import {
         Button as WikitButton,
+        Icon,
         Message,
         TextArea
     } from '@wmde/wikit-vue-components';
 
+    import WikitDialog from '../Components/Dialog.vue';
     import defineComponent from '../types/defineComponent';
 
     interface HomeState {
@@ -65,9 +116,11 @@
     export default defineComponent({
         components: {
             Head,
+            Icon,
             Message,
             TextArea,
-            WikitButton
+            WikitButton,
+            WikitDialog
         },
         methods: {
             splitInput: function(): Array<string> {

--- a/resources/js/Pages/Home.vue
+++ b/resources/js/Pages/Home.vue
@@ -1,8 +1,7 @@
 <template>
     <div class="page-container home-page">
         <Head title="Mismatch Finder" />
-        <section id="intro-section">
-            <h2 class="h4">{{ $i18n('about-mismatch-finder-title') }}</h2>
+        <section id="description-section">
             <p id="about-description" >{{ $i18n('about-mismatch-finder-description') }}</p>
         </section>
 

--- a/resources/js/Pages/Home.vue
+++ b/resources/js/Pages/Home.vue
@@ -42,11 +42,17 @@
                 </section>
                 <section>
                     <h3 class="h5">{{ $i18n('faq-dialog-question-contributing') }}</h3>
-                    <p v-i18n-html:faq-dialog-answer-contributing></p>
+                    <p v-i18n-html:faq-dialog-answer-contributing="[
+                        'https://phabricator.wikimedia.org/'
+                    ]"></p>
                 </section>
                 <section>
                     <h3 class="h5">{{ $i18n('faq-dialog-question-more-info') }}</h3>
-                    <p v-i18n-html:faq-dialog-answer-more-info></p>
+                    <p v-i18n-html:faq-dialog-answer-more-info="[
+                        'https://github.com/wmde/wikidata-mismatch-finder',
+                        'https://www.wikidata.org/wiki/Wikidata:Mismatch_Finder',
+                        'https://www.wikidata.org/wiki/Wikidata_talk:Mismatch_Finder'
+                    ]"></p>
                 </section>
             </wikit-dialog>
             <p id="about-description" >

--- a/resources/js/Pages/Home.vue
+++ b/resources/js/Pages/Home.vue
@@ -5,7 +5,7 @@
             <header class="description-header">
                 <h2 class="h4">{{ $i18n('about-mismatch-finder-title') }}</h2>
                 <wikit-button
-                    class="instructions-button"
+                    id="faq-button"
                     variant="quiet"
                     type="progressive"
                     @click.native="$refs.faq.show()"
@@ -17,7 +17,7 @@
                 </wikit-button>
             </header>
 
-            <wikit-dialog class="instructions-dialog"
+            <wikit-dialog id="faq-dialog"
                 :title="$i18n('faq-dialog-title')"
                 ref="faq"
                 :actions="[{

--- a/resources/js/Pages/Results.vue
+++ b/resources/js/Pages/Results.vue
@@ -8,7 +8,7 @@
             <header class="description-header">
                 <h2 class="h4">{{ $i18n('results-page-title') }}</h2>
                 <wikit-button
-                    class="instructions-button"
+                    id="instructions-button"
                     variant="quiet"
                     type="progressive"
                     @click.native="showInstructionsDialog"
@@ -20,7 +20,7 @@
                 </wikit-button>
             </header>
 
-            <wikit-dialog class="instructions-dialog"
+            <wikit-dialog id="instructions-dialog"
                 :title="$i18n('instructions-dialog-title')"
                 ref="inctructionsDialog"
                 :actions="[{

--- a/resources/js/Pages/Results.vue
+++ b/resources/js/Pages/Results.vue
@@ -5,7 +5,7 @@
             {{ $i18n('results-back-button') }}
         </wikit-button>
         <section id="description-section">
-            <div class="description-header">
+            <header class="description-header">
                 <h2 class="h4">{{ $i18n('results-page-title') }}</h2>
                 <wikit-button
                     class="instructions-button"
@@ -18,7 +18,7 @@
                     </template>
                     {{$i18n('results-instructions-button')}}
                 </wikit-button>
-            </div>
+            </header>
 
             <wikit-dialog class="instructions-dialog"
                 :title="$i18n('instructions-dialog-title')"
@@ -31,7 +31,7 @@
                 dismiss-button
             >
                 <p>{{ $i18n('instructions-dialog-message-upload-info-description') }}</p>
-                <p class="list-intro">{{ $i18n('instructions-dialog-message-intro') }}</p>
+                <p>{{ $i18n('instructions-dialog-message-intro') }}</p>
                 <ul>
                     <li>{{ $i18n('instructions-dialog-message-instruction-wikidata') }}</li>
                     <li>{{ $i18n('instructions-dialog-message-instruction-external') }}</li>
@@ -99,7 +99,7 @@
             @dismissed="disableConfirmation = false"
             dismiss-button
         >
-            <p class="list-intro">{{ $i18n('confirmation-dialog-message-intro') }}</p>
+            <p>{{ $i18n('confirmation-dialog-message-intro') }}</p>
             <ul>
                 <li>{{ $i18n('confirmation-dialog-message-tip-1') }}</li>
                 <li>{{ $i18n('confirmation-dialog-message-tip-2') }}</li>
@@ -319,19 +319,5 @@ h2 {
 .form-buttons {
     text-align: end;
     margin-top: $dimension-layout-xsmall;
-}
-
-p.list-intro {
-    margin-bottom: 0
-}
-
-#description-section {
-
-    .description-header {
-        display: flex;
-        flex-direction: row;
-        align-items: center;
-        justify-content: space-between;
-    }
 }
 </style>

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -99,11 +99,19 @@ li {
     border-radius: $border-radius-base;
 }
 
-#intro-section,
 #error-section,
 #message-section,
 #description-section {
     max-width: 705px;
+}
+
+#description-section {
+    .description-header {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
+    }
 }
 
 // this ensures that there will be a space if there is more than one message

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -13,7 +13,7 @@ body {
     padding: 0 $dimension-layout-xsmall;
     margin: 0 auto;
     @include body-text;
-    
+
     &.app-container {
         max-width: 1168px;
     }
@@ -126,39 +126,7 @@ li {
     text-decoration: none;
 }
 
-.store header{
-    flex-direction: row;
-
-    @media (max-width: $width-breakpoint-tablet) {
-        flex-direction: column-reverse;
-    }
-
-    h1 {
-        margin: 0;
-    }
-
-    .auth-widget {
-        @media (max-width: $width-breakpoint-tablet) {
-            margin-bottom: $dimension-layout-xsmall;
-        }
-    }
-}
-
-.website {
-    header {
-        .wikidata-logo {
-            @media (max-width: $width-breakpoint-tablet) {
-                margin-bottom: $dimension-layout-small;
-            }
-        }
-
-        @media (max-width: $width-breakpoint-tablet) {
-            flex-direction: column;
-        }
-    }
-}
-
-header {
+main > header {
     display: flex;
     justify-content: space-between;
     margin: $dimension-layout-small 0;
@@ -186,6 +154,38 @@ header {
         }
     }
 }
+
+.store > main > header{
+    flex-direction: row;
+
+    @media (max-width: $width-breakpoint-tablet) {
+        flex-direction: column-reverse;
+    }
+
+    h1 {
+        margin: 0;
+    }
+
+    .auth-widget {
+        @media (max-width: $width-breakpoint-tablet) {
+            margin-bottom: $dimension-layout-xsmall;
+        }
+    }
+}
+
+.website > main > header {
+        .wikidata-logo {
+        @media (max-width: $width-breakpoint-tablet) {
+            margin-bottom: $dimension-layout-small;
+        }
+    }
+
+    @media (max-width: $width-breakpoint-tablet) {
+        flex-direction: column;
+    }
+}
+
+
 
 nav.tabs {
     display: flex;

--- a/tests/Browser/ItemsFormTest.php
+++ b/tests/Browser/ItemsFormTest.php
@@ -32,7 +32,7 @@ class ItemsFormTest extends DuskTestCase
 
             $browser->visit(new HomePage)
                     ->keys('@items-input', 'Q23', '{return_key}', 'Q42')
-                    ->press('button')
+                    ->press('.submit-ids')
                     ->waitFor('.results-page')
                     ->assertTitle('Mismatch Finder - Results')
                     ->assertSee("Q23")
@@ -44,7 +44,7 @@ class ItemsFormTest extends DuskTestCase
     {
         $this->browse(function (Browser $browser) {
             $browser->visit(new HomePage)
-                    ->press('button')
+                    ->press('.submit-ids')
                     ->assertSee('Please provide the Item identifiers in order to perform the check.');
 
             $this->assertStringContainsString('--warning', $browser->attribute('@items-input', 'class'));
@@ -55,10 +55,10 @@ class ItemsFormTest extends DuskTestCase
     {
         $this->browse(function (Browser $browser) {
             $browser->visit(new HomePage)
-                    ->press('button')
+                    ->press('.submit-ids')
                     ->assertSee('Please provide the Item identifiers in order to perform the check.')
                     ->keys('@items-input', 'Q1', '{return_key}', 'Q2')
-                    ->press('button')
+                    ->press('.submit-ids')
                     ->assertDontSee('Please provide the Item identifiers in order to perform the check.');
         });
     }
@@ -68,7 +68,7 @@ class ItemsFormTest extends DuskTestCase
         $this->browse(function (Browser $browser) {
             $browser->visit(new HomePage)
                     ->keys('@items-input', 'Q1234-invalid')
-                    ->press('button')
+                    ->press('.submit-ids')
                     ->assertSee('One or more Item identifiers couldn\'t be processed.');
 
             $this->assertStringContainsString('--error', $browser->attribute('@items-input', 'class'));
@@ -80,7 +80,7 @@ class ItemsFormTest extends DuskTestCase
         $this->browse(function (Browser $browser) {
             $browser->visit(new HomePage)
                     ->keys('@items-input', '{return_key}', 'Q100', '{return_key}', '{return_key}', 'Q2')
-                    ->press('button')
+                    ->press('.submit-ids')
                     ->waitFor('.results-page')
                     ->assertPathIs('/results')
                     ->assertQueryStringHas('ids', 'Q100|Q2');
@@ -92,7 +92,7 @@ class ItemsFormTest extends DuskTestCase
         $this->browse(function (Browser $browser) {
             $browser->visit(new HomePage)
                 ->keys('@items-input', 'Q23', '{return_key}', 'Q42')
-                ->press('button')
+                ->press('.submit-ids')
                 ->waitFor('.results-page')
                 ->press('.back-button')
                 ->waitFor('.home-page')

--- a/tests/Vue/Pages/Home.spec.js
+++ b/tests/Vue/Pages/Home.spec.js
@@ -24,7 +24,7 @@ describe('Home.vue', () => {
 
         const store = new Vuex.Store({});
 
-        const wrapper = mount(Home, { 
+        const wrapper = mount(Home, {
             mocks,
             localVue,
             store,
@@ -45,13 +45,23 @@ describe('Home.vue', () => {
         const itemsInput = 'Q1\n\nQ2\n';
         const store = new Vuex.Store({state: {lastSearchedIds: itemsInput} });
 
-        const wrapper = mount(Home, { 
+        const wrapper = mount(Home, {
             mocks,
             localVue,
             store
         });
 
         expect( wrapper.vm.form.itemsInput ).toEqual(itemsInput);
+    });
+
+    it('shows dialog after clicking the more info button', async () => {
+        const store = new Vuex.Store();
+
+        const wrapper = mount(Home, { mocks, localVue, store });
+        await wrapper.find('.instructions-button').trigger('click');
+
+        const dialog = wrapper.find('.instructions-dialog .wikit-Dialog');
+        expect(dialog.isVisible()).toBe(true);
     });
 
 })

--- a/tests/Vue/Pages/Home.spec.js
+++ b/tests/Vue/Pages/Home.spec.js
@@ -58,9 +58,9 @@ describe('Home.vue', () => {
         const store = new Vuex.Store();
 
         const wrapper = mount(Home, { mocks, localVue, store });
-        await wrapper.find('.instructions-button').trigger('click');
+        await wrapper.find('#faq-button').trigger('click');
 
-        const dialog = wrapper.find('.instructions-dialog .wikit-Dialog');
+        const dialog = wrapper.find('#faq-dialog .wikit-Dialog');
         expect(dialog.isVisible()).toBe(true);
     });
 

--- a/tests/Vue/Pages/Results.spec.js
+++ b/tests/Vue/Pages/Results.spec.js
@@ -28,16 +28,16 @@ describe('Results.vue', () => {
         const intro = wrapper.find('#about-description');
         expect(intro.isVisible()).toBe(true);
 
-        const instructionsButton = wrapper.find('.instructions-button');
+        const instructionsButton = wrapper.find('#instructions-button');
         expect(instructionsButton.isVisible()).toBe(true);
 
     });
 
     it('shows dialog after clicking the instructions button', async () => {
         const wrapper = mount(Results, { mocks });
-        await wrapper.find('.instructions-button').trigger('click');
+        await wrapper.find('#instructions-button').trigger('click');
 
-        const dialog = wrapper.find('.instructions-dialog .wikit-Dialog');
+        const dialog = wrapper.find('#instructions-dialog .wikit-Dialog');
         expect(dialog.isVisible()).toBe(true);
     });
 


### PR DESCRIPTION
This change adds a dialog containing an FAQ regarding the mismatch finder tool and it's uses. Additionally, some IDs and classes were changed in order to make our naming convention more consistent, and general header styles were more appropriately scoped in order not to interfere with specific section header styles.

Bug: [T287357](https://phabricator.wikimedia.org/T287357)