### PR TITLE
Add website footer

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -74,5 +74,11 @@
     "wikidata-tool-footer-about-us": "About us",
     "wikidata-tool-footer-privacy": "Privacy Policy",
     "wikidata-tool-footer-wmde": "Wikimedia Deutschland",
-    "wikidata-tool-footer-team": "Made with ♥ by the <a href=\"$1\">Wikidata Team</a>"
+    "wikidata-tool-footer-team": "Made with ♥ by the <a href=\"$1\">Wikidata Team</a>",
+    "mismatch-finder-license": "BSD 3-Clause License",
+    "mismatch-finder-footer-more-tools": "More Data Quality Tools",
+    "tool-query-builder": "Query Builder",
+    "tool-item-quality-evaluator": "Item Quality Evaluator",
+    "tool-curious-facts": "Curious Facts",
+    "tool-constraints-violation-checker": "Constraint Violation Checker"
 }

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -66,5 +66,13 @@
     "faq-dialog-question-contributing": "How can I contribute new mismatches?",
     "faq-dialog-answer-contributing": "If you've compared Wikidata's data against an external data source and have found mismatches, you can open a ticket in <a href=\"$1\">Phabricator</a>.",
     "faq-dialog-question-more-info": "Where can I find more information?",
-    "faq-dialog-answer-more-info": "This tool’s documentation and the source code are available on <a href=\"$1\">GitHub</a>. You can read more about Mismatch Finder on <a href=\"$2\">Wikidata</a> or you can <a href=\"$3\">give us feedback</a>."
+    "faq-dialog-answer-more-info": "This tool’s documentation and the source code are available on <a href=\"$1\">GitHub</a>. You can read more about Mismatch Finder on <a href=\"$2\">Wikidata</a> or you can <a href=\"$3\">give us feedback</a>.",
+    "wikidata-tool-footer-about-tool": "About $1",
+    "wikidata-tool-footer-license": "Licensed under <a href=\"$1\">$2</a>",
+    "wikidata-tool-footer-source": "View Source",
+    "wikidata-tool-footer-issues": "Report an issue",
+    "wikidata-tool-footer-about-us": "About us",
+    "wikidata-tool-footer-privacy": "Privacy Policy",
+    "wikidata-tool-footer-wmde": "Wikimedia Deutschland",
+    "wikidata-tool-footer-team": "Made with ♥ by the <a href=\"$1\">Wikidata Team</a>"
 }

--- a/public/i18n/qqq.json
+++ b/public/i18n/qqq.json
@@ -71,5 +71,11 @@
     "wikidata-tool-footer-about-us": "Footer section title about the Wikimedia Organization",
     "wikidata-tool-footer-privacy": "Footer link to view the privacy policy",
     "wikidata-tool-footer-wmde": "Footer link to Wikimedia Deutschland's homepage",
-    "wikidata-tool-footer-team": "Footer sentence denoting the creators of the tool. Accepts team url as $1 and team name as $2"
+    "wikidata-tool-footer-team": "Footer sentence denoting the creators of the tool. Accepts team url as $1 and team name as $2",
+    "mismatch-finder-license": "Name of the license used by mismatch finder",
+    "mismatch-finder-footer-more-tools": "Title of the more data quality tools footer section",
+    "tool-query-builder": "Query Builder tool name",
+    "tool-item-quality-evaluator": "Item Quality Evaluator tool name",
+    "tool-curious-facts": "Curious Facts tool name",
+    "tool-constraints-violation-checker": "Constraint Violation Checker tool name"
 }

--- a/public/i18n/qqq.json
+++ b/public/i18n/qqq.json
@@ -63,5 +63,13 @@
     "faq-dialog-question-contributing": "A question about how to contribute mismatches to the tool",
     "faq-dialog-answer-contributing": "An answer describing how to contribute mismatches to the tool, using a link to the relevant phabricator board",
     "faq-dialog-question-more-info": "A question about where to find additional information on the mismatch finder",
-    "faq-dialog-answer-more-info": "An answer listing various links with more information about the mismatch finder tool"
+    "faq-dialog-answer-more-info": "An answer listing various links with more information about the mismatch finder tool",
+    "wikidata-tool-footer-about-tool": "Footer section title about the tool itself. Accepts tool name as $1",
+    "wikidata-tool-footer-license": "Footer sentence denoting the license accepts license url as $1 and license name as $2",
+    "wikidata-tool-footer-source": "Footer link to view source code",
+    "wikidata-tool-footer-issues": "Footer link to report an issue",
+    "wikidata-tool-footer-about-us": "Footer section title about the Wikimedia Organization",
+    "wikidata-tool-footer-privacy": "Footer link to view the privacy policy",
+    "wikidata-tool-footer-wmde": "Footer link to Wikimedia Deutschland's homepage",
+    "wikidata-tool-footer-team": "Footer sentence denoting the creators of the tool. Accepts team url as $1 and team name as $2"
 }

--- a/resources/js/Components/WikidataToolFooter.vue
+++ b/resources/js/Components/WikidataToolFooter.vue
@@ -11,9 +11,19 @@
             </section>
             <section>
                 <h2 class="h5">{{ $i18n('wikidata-tool-footer-about-us') }}</h2>
-                <p><a href="#">{{ $i18n('wikidata-tool-footer-privacy') }}</a></p>
-                <p><a href="#">{{ $i18n('wikidata-tool-footer-wmde') }}</a></p>
-                <p v-i18n-html:wikidata-tool-footer-team="['#', 'Wikidata Team']" />
+                <p>
+                    <a href="https://foundation.wikimedia.org/wiki/Non-wiki_privacy_policy">
+                        {{ $i18n('wikidata-tool-footer-privacy') }}
+                    </a>
+                </p>
+                <p>
+                    <a href="https://www.wikimedia.de/">
+                        {{ $i18n('wikidata-tool-footer-wmde') }}
+                    </a>
+                </p>
+                <p v-i18n-html:wikidata-tool-footer-team="[
+                    'https://www.wikidata.org/wiki/Wikidata:Contact_the_development_team'
+                ]" />
             </section>
             <slot />
         </footer>

--- a/resources/js/Components/WikidataToolFooter.vue
+++ b/resources/js/Components/WikidataToolFooter.vue
@@ -1,13 +1,13 @@
 <template>
     <div class="footer-container">
-        <footer class="content-wrap">
+        <footer :class="contentClass">
             <section>
                 <h2 class="h5">
-                    {{ $i18n('wikidata-tool-footer-about-tool', "Mismatch Finder") }}
+                    {{ $i18n('wikidata-tool-footer-about-tool', labels.tool) }}
                 </h2>
-                <p v-i18n-html:wikidata-tool-footer-license="['#', 'BSD 3-Clause License' ]"/>
-                <p><a href="#">{{ $i18n('wikidata-tool-footer-source') }}</a></p>
-                <p><a href="#">{{ $i18n('wikidata-tool-footer-issues') }}</a></p>
+                <p v-i18n-html:wikidata-tool-footer-license="[urls.license, labels.license ]"/>
+                <p><a :href="urls.source">{{ $i18n('wikidata-tool-footer-source') }}</a></p>
+                <p><a :href="urls.issues">{{ $i18n('wikidata-tool-footer-issues') }}</a></p>
             </section>
             <section>
                 <h2 class="h5">{{ $i18n('wikidata-tool-footer-about-us') }}</h2>
@@ -24,7 +24,36 @@
 import Vue, { PropType } from 'vue';
 import { Link as WikitLink } from '@wmde/wikit-vue-components';
 
+interface FooterLabels {
+    tool: string;
+    license: string;
+}
+
+interface FooterUrls {
+    license: string;
+    source: string;
+    issues: string;
+}
+
 export default Vue.extend({
+    name: 'WikidataToolFooter',
+    components: {
+        WikitLink,
+    },
+    props: {
+        contentClass: {
+            type: String,
+            default: '',
+        },
+        labels: {
+            type: Object as PropType<FooterLabels>,
+            required: true,
+        },
+        urls: {
+            type: Object as PropType<FooterUrls>,
+            required: true,
+        },
+    }
 });
 </script>
 

--- a/resources/js/Components/WikidataToolFooter.vue
+++ b/resources/js/Components/WikidataToolFooter.vue
@@ -84,7 +84,11 @@ export default Vue.extend({
         }
 
         section {
-            margin-block-end: $dimension-layout-small;
+            margin-block-end: 0;
+        }
+
+        section + section {
+            margin-block-start: $dimension-layout-small;
         }
 
         p {
@@ -99,8 +103,12 @@ export default Vue.extend({
             flex-direction: row;
             padding: $dimension-layout-small;
 
-            & section {
+            section {
                 margin-inline-end: $dimension-layout-large;
+            }
+
+            section + section {
+                margin-block-start: 0;
             }
         }
     }

--- a/resources/js/Components/WikidataToolFooter.vue
+++ b/resources/js/Components/WikidataToolFooter.vue
@@ -1,0 +1,67 @@
+<template>
+    <div class="footer-container">
+        <footer class="content-wrap">
+            <section>
+                <h2 class="h5">About Mismatch Finder</h2>
+                <p>Licensed under <a href="#">BSD 3-Clause License</a></p>
+                <p><a href="#">View Source</a></p>
+                <p><a href="#">Report an issue</a></p>
+            </section>
+            <section>
+                <h2 class="h5">About us</h2>
+                <p><a href="#">Privacy Policy</a></p>
+                <p><a href="#">Wikimedia Deutschland</a></p>
+                <p><a href="#">Made by the Wikidata team</a></p>
+            </section>
+            <slot />
+        </footer>
+    </div>
+</template>
+
+<script lang="ts">
+import Vue, { PropType } from 'vue';
+import { Link as WikitLink } from '@wmde/wikit-vue-components';
+
+export default Vue.extend({
+});
+</script>
+
+<style lang="scss">
+@import '~@wmde/wikit-tokens/dist/_variables.scss';
+
+.footer-container {
+    background-color: $color-base-90;
+
+    & > footer {
+        margin: auto;
+        padding: $dimension-layout-xsmall;
+        display: flex;
+        flex-direction: column;
+
+        .h5 {
+            margin: 0 0 $dimension-layout-xsmall 0;
+        }
+
+        section {
+            margin-block-end: $dimension-layout-small;
+        }
+
+        p {
+            margin-block-end: 0;
+        }
+
+        p + p {
+            margin-block-start: $dimension-layout-xxsmall;
+        }
+
+        @media (min-width: $width-breakpoint-tablet) {
+            flex-direction: row;
+            padding: $dimension-layout-small;
+
+            & section {
+                margin-inline-end: $dimension-layout-large;
+            }
+        }
+    }
+}
+</style>

--- a/resources/js/Components/WikidataToolFooter.vue
+++ b/resources/js/Components/WikidataToolFooter.vue
@@ -2,16 +2,18 @@
     <div class="footer-container">
         <footer class="content-wrap">
             <section>
-                <h2 class="h5">About Mismatch Finder</h2>
-                <p>Licensed under <a href="#">BSD 3-Clause License</a></p>
-                <p><a href="#">View Source</a></p>
-                <p><a href="#">Report an issue</a></p>
+                <h2 class="h5">
+                    {{ $i18n('wikidata-tool-footer-about-tool', "Mismatch Finder") }}
+                </h2>
+                <p v-i18n-html:wikidata-tool-footer-license="['#', 'BSD 3-Clause License' ]"/>
+                <p><a href="#">{{ $i18n('wikidata-tool-footer-source') }}</a></p>
+                <p><a href="#">{{ $i18n('wikidata-tool-footer-issues') }}</a></p>
             </section>
             <section>
-                <h2 class="h5">About us</h2>
-                <p><a href="#">Privacy Policy</a></p>
-                <p><a href="#">Wikimedia Deutschland</a></p>
-                <p><a href="#">Made by the Wikidata team</a></p>
+                <h2 class="h5">{{ $i18n('wikidata-tool-footer-about-us') }}</h2>
+                <p><a href="#">{{ $i18n('wikidata-tool-footer-privacy') }}</a></p>
+                <p><a href="#">{{ $i18n('wikidata-tool-footer-wmde') }}</a></p>
+                <p v-i18n-html:wikidata-tool-footer-team="['#', 'Wikidata Team']" />
             </section>
             <slot />
         </footer>

--- a/resources/js/Components/WikidataToolFooter.vue
+++ b/resources/js/Components/WikidataToolFooter.vue
@@ -6,20 +6,20 @@
                     {{ $i18n('wikidata-tool-footer-about-tool', labels.tool) }}
                 </h2>
                 <p v-i18n-html:wikidata-tool-footer-license="[urls.license, labels.license ]"/>
-                <p><a :href="urls.source">{{ $i18n('wikidata-tool-footer-source') }}</a></p>
-                <p><a :href="urls.issues">{{ $i18n('wikidata-tool-footer-issues') }}</a></p>
+                <p><wikit-link :href="urls.source">{{ $i18n('wikidata-tool-footer-source') }}</wikit-link></p>
+                <p><wikit-link :href="urls.issues">{{ $i18n('wikidata-tool-footer-issues') }}</wikit-link></p>
             </section>
             <section>
                 <h2 class="h5">{{ $i18n('wikidata-tool-footer-about-us') }}</h2>
                 <p>
-                    <a href="https://foundation.wikimedia.org/wiki/Non-wiki_privacy_policy">
+                    <wikit-link href="https://foundation.wikimedia.org/wiki/Non-wiki_privacy_policy">
                         {{ $i18n('wikidata-tool-footer-privacy') }}
-                    </a>
+                    </wikit-link>
                 </p>
                 <p>
-                    <a href="https://www.wikimedia.de/">
+                    <wikit-link href="https://www.wikimedia.de/">
                         {{ $i18n('wikidata-tool-footer-wmde') }}
-                    </a>
+                    </wikit-link>
                 </p>
                 <p v-i18n-html:wikidata-tool-footer-team="[
                     'https://www.wikidata.org/wiki/Wikidata:Contact_the_development_team'

--- a/resources/js/Pages/Layout.vue
+++ b/resources/js/Pages/Layout.vue
@@ -13,8 +13,8 @@
         <wikidata-tool-footer
             content-class="content-wrap"
             :labels="{
-                tool: 'Mismatch Finder',
-                license: 'BSD 3-Clause License'
+                tool: $i18n('mismatch-finder-title'),
+                license: $i18n('mismatch-finder-license'),
             }"
             :urls="{
                 license: 'https://github.com/wmde/wikidata-mismatch-finder/blob/93e692f6310595f75dcb971d7fb42a7ed7479af0/LICENSE',
@@ -23,11 +23,11 @@
             }"
         >
             <section>
-                <h2 class="h5">More Data Quality Tools</h2>
-                <p><a href="#">Query Builder</a></p>
-                <p><a href="#">Item Quality Evaluator</a></p>
-                <p><a href="#">Curious Facts</a></p>
-                <p><a href="#">Constraint Violation Checker</a></p>
+                <h2 class="h5">{{ $i18n('mismatch-finder-footer-more-tools') }}</h2>
+                <p><a href="#">{{ $i18n('tool-query-builder') }}</a></p>
+                <p><a href="#">{{ $i18n('tool-item-quality-evaluator') }}</a></p>
+                <p><a href="#">{{ $i18n('tool-curious-facts') }}</a></p>
+                <p><a href="#">{{ $i18n('tool-constraints-violation-checker') }}</a></p>
             </section>
         </wikidata-tool-footer>
     </div>

--- a/resources/js/Pages/Layout.vue
+++ b/resources/js/Pages/Layout.vue
@@ -4,7 +4,7 @@
             <header>
                 <img src="/images/wikidata-logo.svg" class="wikidata-logo" alt="Wikidata-logo" width="160" />
                 <div class="auth-widget">
-                    <AuthWidget :user="user" />
+                    <auth-widget :user="user" />
                 </div>
             </header>
             <h1>{{ $i18n('mismatch-finder-title') }}</h1>
@@ -24,10 +24,26 @@
         >
             <section>
                 <h2 class="h5">{{ $i18n('mismatch-finder-footer-more-tools') }}</h2>
-                <p><a href="#">{{ $i18n('tool-query-builder') }}</a></p>
-                <p><a href="#">{{ $i18n('tool-item-quality-evaluator') }}</a></p>
-                <p><a href="#">{{ $i18n('tool-curious-facts') }}</a></p>
-                <p><a href="#">{{ $i18n('tool-constraints-violation-checker') }}</a></p>
+                <p>
+                    <wikit-link href="https://query.wikidata.org/querybuilder/">
+                        {{ $i18n('tool-query-builder') }}
+                    </wikit-link>
+                </p>
+                <p>
+                    <wikit-link href="https://item-quality-evaluator.toolforge.org/">
+                        {{ $i18n('tool-item-quality-evaluator') }}
+                    </wikit-link>
+                </p>
+                <p>
+                    <wikit-link href="https://wikidata-analytics.wmcloud.org/app/CuriousFacts">
+                        {{ $i18n('tool-curious-facts') }}
+                    </wikit-link>
+                </p>
+                <p>
+                    <wikit-link href="https://github.com/wmde/wikidata-constraints-violation-checker">
+                        {{ $i18n('tool-constraints-violation-checker') }}
+                    </wikit-link>
+                </p>
             </section>
         </wikidata-tool-footer>
     </div>
@@ -35,6 +51,8 @@
 
 <script lang="ts">
     import { PropType } from 'vue';
+    import { Link as WikitLink } from '@wmde/wikit-vue-components';
+
     import AuthWidget from '../Components/AuthWidget.vue';
     import WikidataToolFooter from '../Components/WikidataToolFooter.vue';
 
@@ -44,7 +62,8 @@
     export default defineComponent({
         components: {
             AuthWidget,
-            WikidataToolFooter
+            WikidataToolFooter,
+            WikitLink
         },
         props: {
             user: Object as PropType<User>

--- a/resources/js/Pages/Layout.vue
+++ b/resources/js/Pages/Layout.vue
@@ -10,7 +10,18 @@
             <h1>{{ $i18n('mismatch-finder-title') }}</h1>
             <slot />
         </main>
-        <wikidata-tool-footer>
+        <wikidata-tool-footer
+            content-class="content-wrap"
+            :labels="{
+                tool: 'Mismatch Finder',
+                license: 'BSD 3-Clause License'
+            }"
+            :urls="{
+                license: 'https://github.com/wmde/wikidata-mismatch-finder/blob/93e692f6310595f75dcb971d7fb42a7ed7479af0/LICENSE',
+                source: 'https://github.com/wmde/wikidata-mismatch-finder',
+                issues: 'https://phabricator.wikimedia.org/project/board/5385/'
+            }"
+        >
             <section>
                 <h2 class="h5">More Data Quality Tools</h2>
                 <p><a href="#">Query Builder</a></p>

--- a/resources/js/Pages/Layout.vue
+++ b/resources/js/Pages/Layout.vue
@@ -17,6 +17,7 @@
                 license: $i18n('mismatch-finder-license'),
             }"
             :urls="{
+                // eslint-disable-next-line max-len
                 license: 'https://github.com/wmde/wikidata-mismatch-finder/blob/93e692f6310595f75dcb971d7fb42a7ed7479af0/LICENSE',
                 source: 'https://github.com/wmde/wikidata-mismatch-finder',
                 issues: 'https://phabricator.wikimedia.org/project/board/5385/'

--- a/resources/js/Pages/Layout.vue
+++ b/resources/js/Pages/Layout.vue
@@ -17,8 +17,7 @@
                 license: $i18n('mismatch-finder-license'),
             }"
             :urls="{
-                // eslint-disable-next-line max-len
-                license: 'https://github.com/wmde/wikidata-mismatch-finder/blob/93e692f6310595f75dcb971d7fb42a7ed7479af0/LICENSE',
+                license: 'https://github.com/wmde/wikidata-mismatch-finder/blob/license/bsd-3-clause/LICENSE',
                 source: 'https://github.com/wmde/wikidata-mismatch-finder',
                 issues: 'https://phabricator.wikimedia.org/project/board/5385/'
             }"

--- a/resources/js/Pages/Layout.vue
+++ b/resources/js/Pages/Layout.vue
@@ -1,14 +1,39 @@
 <template>
-  <main class="website">
-    <header>
-      <img src="/images/wikidata-logo.svg" class="wikidata-logo" alt="Wikidata-logo" width="160" />
-      <div class="auth-widget">
-        <AuthWidget :user="user" />
-      </div>
-    </header>
-    <h1>{{ $i18n('mismatch-finder-title') }}</h1>
-    <slot />
-  </main>
+    <div class="website">
+        <main class="content-wrap">
+            <header>
+                <img src="/images/wikidata-logo.svg" class="wikidata-logo" alt="Wikidata-logo" width="160" />
+                <div class="auth-widget">
+                    <AuthWidget :user="user" />
+                </div>
+            </header>
+            <h1>{{ $i18n('mismatch-finder-title') }}</h1>
+            <slot />
+        </main>
+        <div class="footer-container">
+            <footer class="content-wrap">
+                <section>
+                    <h2 class="h5">About Mismatch Finder</h2>
+                    <p>Licensed under <a href="#">BSD 3-Clause License</a></p>
+                    <p><a href="#">View Source</a></p>
+                    <p><a href="#">Report an issue</a></p>
+                </section>
+                <section>
+                    <h2 class="h5">About us</h2>
+                    <p><a href="#">Privacy Policy</a></p>
+                    <p><a href="#">Wikimedia Deutschland</a></p>
+                    <p><a href="#">Made by the Wikidata team</a></p>
+                </section>
+                <section>
+                    <h2 class="h5">More Data Quality Tools</h2>
+                    <p><a href="#">Query Builder</a></p>
+                    <p><a href="#">Item Quality Evaluator</a></p>
+                    <p><a href="#">Curious Facts</a></p>
+                    <p><a href="#">Constraint Violation Checker</a></p>
+                </section>
+            </footer>
+        </div>
+    </div>
 </template>
 
 <script lang="ts">
@@ -30,16 +55,62 @@
 @import '~@wmde/wikit-tokens/dist/_variables.scss';
 
 .website {
-    max-width: 1168px;
-}
-
-@media (max-width: $width-breakpoint-tablet) {
-    .website > header {
-        flex-direction: column;
+    .content-wrap {
+        max-width: 1168px;
     }
 
     .wikidata-logo {
-        margin-bottom: $dimension-layout-small;
+        margin-block-end: $dimension-layout-small;
+    }
+
+    .footer-container {
+        background-color: $color-base-90;
+
+        & > footer {
+            margin: auto;
+            padding: $dimension-layout-xsmall;
+            display: flex;
+
+            .h5 {
+                margin: 0 0 $dimension-layout-xsmall 0;
+            }
+
+            section {
+                margin-block-end: $dimension-layout-small;
+            }
+
+            p {
+                margin-block-end: 0;
+            }
+
+            p + p {
+                margin-block-start: $dimension-layout-xxsmall;
+            }
+        }
+    }
+
+    main > header,
+    .footer-container > footer {
+        flex-direction: column;
+    }
+
+    @media (min-width: $width-breakpoint-tablet) {
+        main > header,
+        .footer-container > footer {
+            flex-direction: row;
+        }
+
+        .wikidata-logo {
+            margin-block-end: 0;
+        }
+
+        .footer-container > footer {
+            padding: $dimension-layout-small;
+
+            section {
+                margin-inline-end: $dimension-layout-large;
+            }
+        }
     }
 }
 </style>

--- a/resources/js/Pages/Layout.vue
+++ b/resources/js/Pages/Layout.vue
@@ -10,41 +10,31 @@
             <h1>{{ $i18n('mismatch-finder-title') }}</h1>
             <slot />
         </main>
-        <div class="footer-container">
-            <footer class="content-wrap">
-                <section>
-                    <h2 class="h5">About Mismatch Finder</h2>
-                    <p>Licensed under <a href="#">BSD 3-Clause License</a></p>
-                    <p><a href="#">View Source</a></p>
-                    <p><a href="#">Report an issue</a></p>
-                </section>
-                <section>
-                    <h2 class="h5">About us</h2>
-                    <p><a href="#">Privacy Policy</a></p>
-                    <p><a href="#">Wikimedia Deutschland</a></p>
-                    <p><a href="#">Made by the Wikidata team</a></p>
-                </section>
-                <section>
-                    <h2 class="h5">More Data Quality Tools</h2>
-                    <p><a href="#">Query Builder</a></p>
-                    <p><a href="#">Item Quality Evaluator</a></p>
-                    <p><a href="#">Curious Facts</a></p>
-                    <p><a href="#">Constraint Violation Checker</a></p>
-                </section>
-            </footer>
-        </div>
+        <wikidata-tool-footer>
+            <section>
+                <h2 class="h5">More Data Quality Tools</h2>
+                <p><a href="#">Query Builder</a></p>
+                <p><a href="#">Item Quality Evaluator</a></p>
+                <p><a href="#">Curious Facts</a></p>
+                <p><a href="#">Constraint Violation Checker</a></p>
+            </section>
+        </wikidata-tool-footer>
     </div>
 </template>
 
 <script lang="ts">
     import { PropType } from 'vue';
     import AuthWidget from '../Components/AuthWidget.vue';
+    import WikidataToolFooter from '../Components/WikidataToolFooter.vue';
 
     import defineComponent from '../types/defineComponent';
     import User from '../types/User';
 
     export default defineComponent({
-        components: { AuthWidget },
+        components: {
+            AuthWidget,
+            WikidataToolFooter
+        },
         props: {
             user: Object as PropType<User>
         }
@@ -63,53 +53,17 @@
         margin-block-end: $dimension-layout-small;
     }
 
-    .footer-container {
-        background-color: $color-base-90;
-
-        & > footer {
-            margin: auto;
-            padding: $dimension-layout-xsmall;
-            display: flex;
-
-            .h5 {
-                margin: 0 0 $dimension-layout-xsmall 0;
-            }
-
-            section {
-                margin-block-end: $dimension-layout-small;
-            }
-
-            p {
-                margin-block-end: 0;
-            }
-
-            p + p {
-                margin-block-start: $dimension-layout-xxsmall;
-            }
-        }
-    }
-
-    main > header,
-    .footer-container > footer {
+    main > header {
         flex-direction: column;
     }
 
     @media (min-width: $width-breakpoint-tablet) {
-        main > header,
-        .footer-container > footer {
+        main > header {
             flex-direction: row;
         }
 
         .wikidata-logo {
             margin-block-end: 0;
-        }
-
-        .footer-container > footer {
-            padding: $dimension-layout-small;
-
-            section {
-                margin-inline-end: $dimension-layout-large;
-            }
         }
     }
 }

--- a/tests/Vue/Components/WikidataToolFooter.spec.js
+++ b/tests/Vue/Components/WikidataToolFooter.spec.js
@@ -1,0 +1,88 @@
+import { createLocalVue, mount } from "@vue/test-utils";
+import WikidataToolFooter from "@/Components/WikidataToolFooter.vue";
+
+describe("WikidataToolFooter.vue", () => {
+    function mockI18n(key, ...params) {
+        return key + (params.length ? ` : ${params.join(', ')}` : '');
+    }
+
+    function mountWithMocks(props = {}, slot = '') {
+        const defaultProps = {
+            labels: {},
+            urls: {}
+        };
+
+        const localVue = createLocalVue();
+
+        localVue.directive('i18n-html', (elem, { arg, value }) => {
+            elem.innerHTML = mockI18n(arg, ...value);
+        });
+
+        return mount(WikidataToolFooter, {
+            propsData: {
+                ...defaultProps,
+                ...props
+            },
+            slots: {
+                default: slot
+            },
+            mocks: {
+                $i18n: mockI18n
+            },
+            localVue
+        });
+    }
+
+    it("renders a footer", () => {
+        const wrapper = mountWithMocks();
+        expect(wrapper.find("footer").exists()).toBe(true);
+    });
+
+    it("accepts a content class", () => {
+        const contentClass = "custom-class";
+
+        const wrapper = mountWithMocks({ contentClass });
+
+        expect(wrapper.props().contentClass).toBe(contentClass);
+        expect(wrapper.find("footer").classes()).toContain(contentClass);
+    });
+
+    it("accepts a labels prop", () => {
+        const labels = {
+            tool: "Tool",
+            license: "License"
+        };
+
+        const wrapper = mountWithMocks({ labels });
+
+        expect(wrapper.props().labels).toBe(labels);
+
+        Object.values(labels).forEach(label => {
+            expect(wrapper.html()).toContain(label);
+        });
+    });
+
+    it("accepts a urls prop", () => {
+        const urls = {
+            license: "https://license.example.com",
+            source: "https://source.example.com",
+            issues: "https://issues.example.com",
+        };
+
+        const wrapper = mountWithMocks({ urls });
+
+        expect(wrapper.props().urls).toBe(urls);
+
+        Object.values(urls).forEach(url => {
+            expect(wrapper.html()).toContain(url);
+        });
+    });
+
+    it("accepts arbitrary html", () => {
+        const html = '<div class="arbitrary">Some arbitrary html</div>';
+
+        const wrapper = mountWithMocks(null, html);
+
+        expect(wrapper.find(".arbitrary").exists()).toBe(true);
+    });
+})


### PR DESCRIPTION
This change adds a footer to the Mismatch Finder tool's website. The footer is created as a base abstract component, which is meant to be copied and reused in additional wikidata tools in the future. However, it is also able to accept arbitrary context related html which are more relevant to the tool that includes it.

Design can be reviewed at: https://mismatch-finder-staging.toolforge.org/

Bug: [T287359](https://phabricator.wikimedia.org/T287359)