### PR TITLE
Add instructions on mismatch reviews via REST API

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -79,31 +79,31 @@ The request body should include the following fields:
 
 Once an import is submitted, the newly created import status will be included in the response, alongside an api link to check its status again. Additionally, the status of the last 10 imports in to Mismatch Finder can be checked at our [import status page](https://mismatch-finder.toolforge.org/store/imports).
 
-For more information take a look at our [REST API documentation](https://mismatch-finder.toolforge.org/api-docs#/store/post_imports).
+For more information take a look at our [REST API documentation](https://mismatch-finder.toolforge.org/api-docs/index.html#/store/post_imports).
 
 ### Reviewing Mismatches
 
 
 #### Review
 
-To review mismatches by Item ID, users may send a request to our `GET /mismatches` api endpoint.
+To review mismatches by Item ID, users may send a request to our `GET /api/mismatches` api endpoint.
 
 The request should include the required `ids` query parameter to specify Item IDs. For example, the following request will retrieve all mismatches for Items `Q1` and `Q2`:
 
 ```
-GET /mismatches?ids=Q1|Q2
+GET /api/mismatches?ids=Q1|Q2
 ```
 
-For more information take a look at our [REST API documentation](https://mismatch-finder.toolforge.org/api-docs#/store/get_mismatches).
+For more information take a look at our [REST API documentation](https://mismatch-finder.toolforge.org/api-docs/index.html#/store/get_mismatches).
 
 #### Submit decisions
 
-To submit a decision regarding a particular mismatch, users may send a request to `PUT /mismatches/{mismatchId}`.
+To submit a decision regarding a particular mismatch, users may send a request to `PUT /api/mismatches/{mismatchId}`.
 
 The decision regarding a mismatch should be sent using the mismatch's id. For example, to submit a decision regarding mismatch `42` we will send the following request:
 
 ```
-PUT /mismatches/42
+PUT /api/mismatches/42
 ```
 
 The request body should include the decision itself as a json object. That is, to decide that the mismatch in data is on the external source, the user would send:
@@ -118,10 +118,11 @@ _**Note**: any other fields related to a mismatch and included in the request wi
 
 The only possible values for a review status are:
 
+- `"pending"` - The mismatch is awaiting a review decision.
 - `"wikidata"` - The mismatching information is on Wikidata.
 - `"external"` - The mismatching information is on the external source.
 - `"both"` - Both sources are incorrect.
 - `"none"` - None of the above.
 
-For more information take a look at our [REST API documentation](https://mismatch-finder.toolforge.org/api-docs#/store/put_mismatches__mismatchId_).
+For more information take a look at our [REST API documentation](https://mismatch-finder.toolforge.org/api-docs/index.html#/store/put_mismatches__mismatchId_).
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -81,3 +81,47 @@ Once an import is submitted, the newly created import status will be included in
 
 For more information take a look at our [REST API documentation](https://mismatch-finder.toolforge.org/api-docs#/store/post_imports).
 
+### Reviewing Mismatches
+
+
+#### Review
+
+To review mismatches by Item ID, users may send a request to our `GET /mismatches` api endpoint.
+
+The request should include the required `ids` query parameter to specify Item IDs. For example, the following request will retrieve all mismatches for Items `Q1` and `Q2`:
+
+```
+GET /mismatches?ids=Q1|Q2
+```
+
+For more information take a look at our [REST API documentation](https://mismatch-finder.toolforge.org/api-docs#/store/get_mismatches).
+
+#### Submit decisions
+
+To submit a decision regarding a particular mismatch, users may send a request to `PUT /mismatches/{mismatchId}`.
+
+The decision regarding a mismatch should be sent using the mismatch's id. For example, to submit a decision regarding mismatch `42` we will send the following request:
+
+```
+PUT /mismatches/42
+```
+
+The request body should include the decision itself as a json object. That is, to decide that the mismatch in data is on the external source, the user would send:
+
+```json
+{
+    "review_status": "external"
+}
+```
+
+_**Note**: any other fields related to a mismatch and included in the request will be prohibited and result in a validation error._
+
+The only possible values for a review status are:
+
+- `"wikidata"` - The mismatching information is on Wikidata.
+- `"external"` - The mismatching information is on the external source.
+- `"both"` - Both sources are incorrect.
+- `"none"` - None of the above.
+
+For more information take a look at our [REST API documentation](https://mismatch-finder.toolforge.org/api-docs#/store/put_mismatches__mismatchId_).
+

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -65,8 +65,6 @@ You can consult this [mismatch file](exampleMismatchFile.csv) for a valid exampl
 
 ### Uploading an import file
 
-<!-- TODO: Replace this description with a link to our API Specification, once deployed (See T287948). -->
-
 To upload an import file, users may send a request to our `POST /api/imports` api endpoint. 
 
 The request should include the `Authorization` header with a personal [access token](#apiAccess). Additionally, the request should include a `Content-Type: multipart/form-data` header.
@@ -80,3 +78,6 @@ The request body should include the following fields:
 * `expires` - _(Optional)_ An ISO formatted date to describe the date where the mismatches imported will be no longer relevant. If omitted, mismatches from the import will expire after 6 months by default.
 
 Once an import is submitted, the newly created import status will be included in the response, alongside an api link to check its status again. Additionally, the status of the last 10 imports in to Mismatch Finder can be checked at our [import status page](https://mismatch-finder.toolforge.org/store/imports).
+
+For more information take a look at our [REST API documentation](https://mismatch-finder.toolforge.org/api-docs#/store/post_imports).
+

--- a/public/api-docs/index.html
+++ b/public/api-docs/index.html
@@ -15,6 +15,7 @@
           SwaggerUIBundle({
             url: "/api-docs/mismatchfinder-api-spec.yml",
             dom_id: '#swagger-ui',
+            deepLinking: true,
             presets: [
               SwaggerUIBundle.presets.apis
             ]


### PR DESCRIPTION
This change adds instructions on how to review Mismatches using our REST API. In addition, we enable deep linking within our API documentation, to allow linking to particular endpoint specifications.

Bug: [T290182](https://phabricator.wikimedia.org/T290182)