### PR TITLE
Display generic error message on failed requests

### DIFF
--- a/resources/js/Pages/Results.vue
+++ b/resources/js/Pages/Results.vue
@@ -46,8 +46,8 @@
                 {{ $i18n('results-page-description') }}
             </p>
         </section>
-        <section id="error-section" v-if="unexpectedError">
-            <Message type="error">{{ $i18n('server-error') }}</Message>
+        <section id="error-section" v-if="unexpectedError || requestError">
+            <Message type="error" class="generic-error">{{ $i18n('server-error') }}</Message>
         </section>
         <section id="message-section">
             <Message type="notice" v-if="notFoundItemIds.length">
@@ -159,7 +159,8 @@
     interface ResultsState {
         decisions: DecisionMap,
         disableConfirmation: boolean,
-        pageDirection: string
+        pageDirection: string,
+        requestError: boolean
     }
 
     export default defineComponent({
@@ -226,7 +227,8 @@
             return {
                 decisions: {},
                 disableConfirmation: false,
-                pageDirection: 'ltr'
+                pageDirection: 'ltr',
+                requestError: false
             }
         },
         methods: {
@@ -277,6 +279,7 @@
                         confirmationDialog.show();
                     }
                 } catch(e) {
+                    this.requestError = true;
                     console.error("saving review decisions has failed", e);
                 }
             },

--- a/tests/Browser/Pages/ResultsPage.php
+++ b/tests/Browser/Pages/ResultsPage.php
@@ -49,6 +49,7 @@ class ResultsPage extends Page
             '@back-button' => '.back-button',
             '@confirmation-dialog' => '.confirmation-dialog',
             '@disable-confirmation' => '.disable-confirmation',
+            '@error-section' => '#error-section',
             '@disable-confirmation-label' => '.disable-confirmation>.wikit-checkbox__label'
         ];
     }

--- a/tests/Browser/ResultsTest.php
+++ b/tests/Browser/ResultsTest.php
@@ -277,4 +277,26 @@ class ResultsTest extends DuskTestCase
                 ->assertVue('checked', false, '@disable-confirmation');
         });
     }
+
+    public function test_shows_message_when_submitting_review_status_for_deleted_item(){
+        $import = ImportMeta::factory()
+            ->for(User::factory()->uploader())
+            ->create();
+
+        $mismatch = Mismatch::factory()
+            ->for($import)
+            ->create();
+
+        $this->browse(function (Browser $browser) use ($mismatch) {
+            $results = $browser->loginAs(User::factory()->create())->visit(new ResultsPage($mismatch->item_id));
+
+            $mismatch->delete();
+
+            $results->decideAndApply($mismatch, [
+                'option' => 2,
+                'label' => 'Mismatch on external data source'
+            ])->waitFor('@error-section', 500)
+                ->assertVisible('.generic-error');
+        });
+    }
 }

--- a/tests/Browser/ResultsTest.php
+++ b/tests/Browser/ResultsTest.php
@@ -278,7 +278,8 @@ class ResultsTest extends DuskTestCase
         });
     }
 
-    public function test_shows_message_when_submitting_review_status_for_deleted_item(){
+    public function test_shows_message_when_submitting_review_status_for_deleted_item()
+    {
         $import = ImportMeta::factory()
             ->for(User::factory()->uploader())
             ->create();


### PR DESCRIPTION
This change adds a flag to display error messages derived from failed requests (status code >400).

Bug: [T295990](https://phabricator.wikimedia.org/T295990)