### PR TITLE
Fix CI Issues

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,10 +7,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
         - uses: actions/checkout@v2
+
+        - name: Setup PHP
+          uses: shivammathur/setup-php@v2
+          with:
+            php-version: '7.3'
+
         - name: Install Composer Dependencies
           run: composer install --no-progress --prefer-dist --optimize-autoloader
+
         - name: PHP Lint
-          run: "composer run lint"
+          run: composer run lint
 
   js-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,22 +7,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
         - uses: actions/checkout@v2
-        - name: Install Composer Dependencies
-          uses: php-actions/composer@v6
+
+        - name: Setup PHP
+          uses: shivammathur/setup-php@v2
           with:
-            php_version: 7.3
-            php_extensions: zip
+            php-version: '7.3'
+
+        - name: Install Composer Dependencies
+          run: composer install --no-progress --prefer-dist --optimize-autoloader
+
         - name: Prepare The Environment
           run: cp .env.example .env
+
         - name: Generate Application Key
-          run: |
-            php artisan key:generate
+          run: php artisan key:generate
+
         - name: Run Feature Tests
-          uses: php-actions/phpunit@v3
-          with:
-            version: 9
-            php_version: 7.3
-            php_extensions: zip
+          run: php artisan test
 
   js-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,16 +8,21 @@ jobs:
     steps:
         - uses: actions/checkout@v2
         - name: Install Composer Dependencies
-          run: composer install --no-progress --prefer-dist --optimize-autoloader
+          uses: php-actions/composer@v6
+          with:
+            php_version: 7.3
+            php_extensions: zip
         - name: Prepare The Environment
           run: cp .env.example .env
         - name: Generate Application Key
           run: |
             php artisan key:generate
-        - name: phpunit
-          uses: php-actions/phpunit@v9
+        - name: Run Feature Tests
+          uses: php-actions/phpunit@v3
           with:
+            version: 9
             php_version: 7.3
+            php_extensions: zip
 
   js-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This change pins the PHP version of each of our jobs to PHP 7.3 (same version as toolforge). Additionally, some redundant action dependencies are removed for consistency.

Bug: [T296846](https://phabricator.wikimedia.org/T296846)