### PR TITLE
Show confirmation message after review submission

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -33,6 +33,7 @@
     "review-status-both": "Both are wrong",
     "review-status-none": "None of the above",
     "result-form-submit": "Apply changes",
+    "changes-submitted-message": "Changes successfully submitted for:",
     "log-in-message": "Please <a href=\"$1\">log in</a> to be able to make any changes.",
     "results-page-description": "You can fix them! The table below presents you with links to the statement on Wikidata and to the entry on the external source. You can compare the values and manually fix the mismatch, editing Wikidata or the external data source. After investigating and fixing the mismatch, you can indicate their status using the options from the drop-down.",
     "results-page-title": "What should I do with the mismatches?",

--- a/public/i18n/qqq.json
+++ b/public/i18n/qqq.json
@@ -30,6 +30,7 @@
     "review-status-both": "Label that indicates that the data mismatch is on both sources. Used as an option in the in review decision dropdown",
     "review-status-none": "Label that indicates that the data mismatch is not on any source. Used as an option in the in review decision dropdown",
     "result-form-submit": "The call to action on the Results Item Mismatches Table button",
+    "changes-submitted-message": "A confirmation message for successful mismatch review submissions",
     "log-in-message": "A message to notify users to log in to make any changes",
     "results-page-description": "The description of the Results page",
     "results-page-title": "The title of the Results page",

--- a/resources/js/Pages/Results.vue
+++ b/resources/js/Pages/Results.vue
@@ -359,7 +359,9 @@ h2 {
     justify-content: space-between;
     align-items: flex-start;
     gap: $dimension-layout-xsmall;
-    min-height: 4.75em;
+    // calculate the footer height to reserve space for
+    // messages with two lines (1.5 line height plus padding)
+    min-height: calc(2*1.5em + 2*$dimension-spacing-large);
 
     .form-success-message {
         max-width: 705px;

--- a/resources/js/Pages/Results.vue
+++ b/resources/js/Pages/Results.vue
@@ -353,7 +353,7 @@ h2 {
 }
 
 .mismatches-form-footer {
-    padding-top: $dimension-layout-xsmall;
+    margin-top: $dimension-layout-xsmall;
     display: flex;
     flex-direction: row;
     justify-content: space-between;

--- a/resources/js/Pages/Results.vue
+++ b/resources/js/Pages/Results.vue
@@ -355,19 +355,17 @@ h2 {
 .mismatches-form-footer {
     margin-top: $dimension-layout-xsmall;
     display: flex;
-    flex-direction: row;
+    flex-direction: row-reverse;
     justify-content: space-between;
+    align-items: flex-start;
+    gap: $dimension-layout-xsmall;
     min-height: 4.75em;
 
     .form-success-message {
-        width: 100%;
         max-width: 705px;
-        margin-inline-end: $dimension-layout-xsmall;
-    }
-
-    .form-buttons {
-        text-align: end;
+        flex-shrink: 0;
+        flex-grow: 1;
+        order: 1;
     }
 }
-
 </style>

--- a/resources/js/Pages/Results.vue
+++ b/resources/js/Pages/Results.vue
@@ -79,23 +79,27 @@
                         :disabled="!user"
                         @decision="recordDecision"
                     />
-                    <Message type="success" v-if="lastSubmitted === item">
-                        <span>{{ $i18n('changes-submitted-message') }}</span>
-                        <span class="message-link">
-                            <wikit-link :href="`https://www.wikidata.org/wiki/${item}`" target="_blank">
-                                {{labels[item]}} ({{item}})
-                            </wikit-link>
-                        </span>
-                    </Message>
-                    <div class="form-buttons">
-                        <wikit-button
-                            :disabled="!user"
-                            variant="primary"
-                            type="progressive"
-                            native-type="submit"
-                        >
-                            {{ $i18n('result-form-submit') }}
-                        </wikit-button>
+                    <div class="form-footer">
+                        <div class="form-success-message">
+                            <Message type="success" v-if="lastSubmitted === item">
+                                <span>{{ $i18n('changes-submitted-message') }}</span>
+                                <span class="message-link">
+                                    <wikit-link :href="`https://www.wikidata.org/wiki/${item}`" target="_blank">
+                                        {{labels[item]}} ({{item}})
+                                    </wikit-link>
+                                </span>
+                            </Message>
+                        </div>
+                        <div class="form-buttons">
+                            <wikit-button
+                                :disabled="!user"
+                                variant="primary"
+                                type="progressive"
+                                native-type="submit"
+                            >
+                                {{ $i18n('result-form-submit') }}
+                            </wikit-button>
+                        </div>
                     </div>
                 </form>
             </section>
@@ -350,8 +354,22 @@ h2 {
     }
 }
 
-.form-buttons {
-    text-align: end;
-    margin-top: $dimension-layout-xsmall;
+.form-footer {
+    padding-top: $dimension-layout-xsmall;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    min-height: 4.75em;
+
+    .form-success-message {
+        width: 100%;
+        max-width: 705px;
+        margin-inline-end: $dimension-layout-xsmall;
+    }
+
+    .form-buttons {
+        text-align: end;
+    }
 }
+
 </style>

--- a/resources/js/Pages/Results.vue
+++ b/resources/js/Pages/Results.vue
@@ -79,17 +79,15 @@
                         :disabled="!user"
                         @decision="recordDecision"
                     />
-                    <div class="form-footer">
-                        <div class="form-success-message">
-                            <Message type="success" v-if="lastSubmitted === item">
-                                <span>{{ $i18n('changes-submitted-message') }}</span>
-                                <span class="message-link">
-                                    <wikit-link :href="`https://www.wikidata.org/wiki/${item}`" target="_blank">
-                                        {{labels[item]}} ({{item}})
-                                    </wikit-link>
-                                </span>
-                            </Message>
-                        </div>
+                    <footer class="mismatches-form-footer">
+                        <Message class="form-success-message" type="success" v-if="lastSubmitted === item">
+                            <span>{{ $i18n('changes-submitted-message') }}</span>
+                            <span class="message-link">
+                                <wikit-link :href="`https://www.wikidata.org/wiki/${item}`" target="_blank">
+                                    {{labels[item]}} ({{item}})
+                                </wikit-link>
+                            </span>
+                        </Message>
                         <div class="form-buttons">
                             <wikit-button
                                 :disabled="!user"
@@ -100,7 +98,7 @@
                                 {{ $i18n('result-form-submit') }}
                             </wikit-button>
                         </div>
-                    </div>
+                    </footer>
                 </form>
             </section>
         </section>
@@ -354,7 +352,7 @@ h2 {
     }
 }
 
-.form-footer {
+.mismatches-form-footer {
     padding-top: $dimension-layout-xsmall;
     display: flex;
     flex-direction: row;

--- a/resources/js/Pages/Results.vue
+++ b/resources/js/Pages/Results.vue
@@ -79,6 +79,14 @@
                         :disabled="!user"
                         @decision="recordDecision"
                     />
+                    <Message type="success" v-if="lastSubmitted === item">
+                        <span>{{ $i18n('changes-submitted-message') }}</span>
+                        <span class="message-link">
+                            <wikit-link :href="`https://www.wikidata.org/wiki/${item}`" target="_blank">
+                                {{labels[item]}} ({{item}})
+                            </wikit-link>
+                        </span>
+                    </Message>
                     <div class="form-buttons">
                         <wikit-button
                             :disabled="!user"
@@ -161,7 +169,8 @@
         decisions: DecisionMap,
         disableConfirmation: boolean,
         pageDirection: string,
-        requestError: boolean
+        requestError: boolean,
+        lastSubmitted: string
     }
 
     export default defineComponent({
@@ -229,7 +238,8 @@
                 decisions: {},
                 disableConfirmation: false,
                 pageDirection: 'ltr',
-                requestError: false
+                requestError: false,
+                lastSubmitted: ''
             }
         },
         methods: {
@@ -260,6 +270,8 @@
                     return;
                 }
 
+                this.clearSubmitConfirmation();
+
                 // Casting to `any` since TS cannot understand $refs as
                 // component instances and complains about the usage of `show`
                 // See: https://github.com/vuejs/vue-class-component/issues/94
@@ -272,6 +284,8 @@
                 try {
                     await axios.put('/mismatch-review', this.decisions[item]);
 
+                    this.showSubmitConfirmation(item);
+
                     // remove decision from this.decisions after it has been
                     // sent to the server successfully, to avoid sending them twice
                     delete this.decisions[item];
@@ -283,6 +297,12 @@
                     this.requestError = true;
                     console.error("saving review decisions has failed", e);
                 }
+            },
+            clearSubmitConfirmation() {
+                this.lastSubmitted = '';
+            },
+            showSubmitConfirmation( item: string ) {
+                this.lastSubmitted = item;
             },
             // Anotating dialog as `any` since typescript doesn't fully
             // understand component instances and complains about usage of the

--- a/tests/Browser/ResultsTest.php
+++ b/tests/Browser/ResultsTest.php
@@ -207,6 +207,30 @@ class ResultsTest extends DuskTestCase
         });
     }
 
+    public function test_new_review_status_submit_triggers_confirmation_success_message()
+    {
+        $import = ImportMeta::factory()
+        ->for(User::factory()->uploader())
+        ->create();
+
+        $mismatch = Mismatch::factory()
+            ->for($import)
+            ->create();
+
+        $this->browse(function (Browser $browser) use ($mismatch) {
+            $browser->script('localStorage.clear()');
+            $browser->loginAs(User::factory()->create())
+                ->visit(new ResultsPage($mismatch->item_id))
+                ->decideAndApply($mismatch, [
+                    'option' => 3,
+                    'label' => 'Wrong data on external source'
+                ])
+                ->waitFor('@confirmation-dialog')
+                ->assertPresent("#item-mismatches-{$mismatch->item_id} .wikit-Message--success")
+                ->assertSee('Changes successfully submitted for');
+        });
+    }
+
     public function test_new_review_status_submit_prompts_confirmation_dialog()
     {
         $import = ImportMeta::factory()

--- a/tests/Vue/Pages/Results.spec.js
+++ b/tests/Vue/Pages/Results.spec.js
@@ -45,6 +45,10 @@ describe('Results.vue', () => {
         })
     }
 
+    beforeEach(async () => {
+        axios.put = jest.fn();
+    });
+
     it('displays intro text and instructions button', () => {
         const wrapper = mountWithMocks();
 
@@ -267,4 +271,84 @@ describe('Results.vue', () => {
 
         expect(dialog.isVisible()).toBe(false);
     });
+
+    it('Displays a confirmation message after submitting a review decision', async () => {
+        const results = {
+            'Q321': [{
+                id: 123,
+                item_id: 'Q321',
+                property_id: 'P123',
+                wikidata_value: 'Q1986',
+                external_value: 'Another Value',
+                import_meta: {
+                    user: {
+                        username: 'some_user_name'
+                    },
+                    created_at: '2021-09-23'
+                },
+            }]
+        };
+
+        const item_id = 'Q321';
+        const decisions = { [item_id]:{1:{id:1, item_id ,review_status: ReviewDecision.Wikidata}}};
+        const wrapper = mountWithMocks({
+            props: { results },
+            data: { decisions }
+        });
+
+        await wrapper.vm.send( item_id );
+
+        expect(wrapper.vm.lastSubmitted).toEqual('Q321');
+        expect(wrapper.find('#item-mismatches-Q321 .wikit-Message--success').isVisible()).toBe(true);
+    });
+
+    it('Removes first confirmation message before submitting a second review decision', async () => {
+        const results = {
+            'Q321': [{
+                id: 123,
+                item_id: 'Q321',
+                property_id: 'P123',
+                wikidata_value: 'Q1986',
+                external_value: 'Another Value',
+                import_meta: {
+                    user: {
+                        username: 'some_user_name'
+                    },
+                    created_at: '2021-09-23'
+                },
+            }],
+            'Q987': [{
+                id: 654,
+                item_id: 'Q987',
+                property_id: 'p789',
+                property_label: 'some property',
+                wikidata_value: 'Some value',
+                value_label: null,
+                external_value: 'Another Value',
+                import_meta: {
+                    user: {
+                        username: 'some_user_name'
+                    },
+                    created_at: '2021-09-23'
+                },
+            }]
+        };
+
+        const lastSubmitted = 'Q321';
+        const item_id = 'Q987';
+        const decisions = { [item_id]:{1:{id:1, item_id ,review_status: ReviewDecision.Wikidata}}};
+        const wrapper = mountWithMocks({
+            props: { results },
+            data: { decisions, lastSubmitted}
+        });
+
+        expect(wrapper.find('#item-mismatches-Q321 .wikit-Message--success').isVisible()).toBe(true);
+
+        await wrapper.vm.send( item_id );
+
+        expect(wrapper.vm.lastSubmitted).toEqual('Q987');
+        expect(wrapper.find('#item-mismatches-Q321 .wikit-Message--success').exists()).toBe(false);
+        expect(wrapper.find('#item-mismatches-Q987 .wikit-Message--success').isVisible()).toBe(true);
+    });
+
 })


### PR DESCRIPTION
This change adds a confirmation message on the results page below the
table after the users has successfully submitted his review decisions
for an Item. The message will remain on the page until the next review
decisions are submitted.

Bug: [T293874](https://phabricator.wikimedia.org/T293874)