### PR TITLE
Fix outdated test for (not) submitting reviews

### DIFF
--- a/tests/Vue/Pages/Results.spec.js
+++ b/tests/Vue/Pages/Results.spec.js
@@ -238,15 +238,16 @@ describe('Results.vue', () => {
     });
 
     it('Does not send a put request without any decisions', () => {
+        // clear mock object
+        axios.put = jest.fn();
+
         const item_id = 'Q321';
         const decisions = { [item_id]:{1:{id:1, item_id ,review_status: ReviewDecision.Wikidata}}};
-        const inertiaPut = jest.fn();
         const wrapper = mountWithMocks({
-            mocks: { $inertia: { put: inertiaPut } },
             data: { decisions }
         });
         wrapper.vm.send( 'Q42' );
-        expect( inertiaPut ).not.toHaveBeenCalled();
+        expect( axios.put ).not.toHaveBeenCalled();
 
         //the decisions object will be untouched
         expect(wrapper.vm.decisions).toEqual({ [item_id]:{1:{id:1, item_id ,review_status: ReviewDecision.Wikidata}}});


### PR DESCRIPTION
This change adjusts a vue unit test to the switch from inertia to axios
that was done in PR #159 (commit ba5b704198ab). It must have been missed
back then.

Bug: T293730