### PR TITLE
Add user id to results page response

### DIFF
--- a/app/Http/Controllers/ResultsController.php
+++ b/app/Http/Controllers/ResultsController.php
@@ -28,7 +28,8 @@ class ResultsController extends Controller
     public function index(MismatchGetRequest $request, WikibaseAPIClient $wikidata): Response
     {
         $user = Auth::user() ? [
-            'name' => Auth::user()->username
+            'name' => Auth::user()->username,
+            'id' => Auth::user()->mw_userid
         ] : null;
 
         $itemIds = $request->input('ids');

--- a/tests/Feature/WebResultsRouteTest.php
+++ b/tests/Feature/WebResultsRouteTest.php
@@ -32,6 +32,22 @@ class WebResultsRouteTest extends TestCase
             });
     }
 
+    public function test_results_page_has_user()
+    {
+        $user = User::factory()->create();
+        $response = $this->actingAs($user)->get(route('results', [
+            'ids' => 'Q1|Q2'
+        ]));
+
+        $response->assertSuccessful();
+        $response->assertViewIs('app')
+            ->assertInertia(function (Assert $page) use ($user) {
+                $page->component('Results')
+                    ->where('user.id', $user->mw_userid)
+                    ->where('user.name', $user->username);
+            });
+    }
+
     /**
      * Test that the /results response contains mismatch data
      *


### PR DESCRIPTION
This change includes a small fix to a bug detected while reviewing another PR. The user ID was not actually included in the response to the results page, which causes the confirmation dialogs checkbox value to be saved in local storage under a key that does not differentiate between users. This meant that two separate users on the same machine were actually sharing the same setting (if the decided not to display the confirmation message again).

Bug: [T297608](https://phabricator.wikimedia.org/T297608)