### PR TITLE
Simplify logic, Fix Browser Tests

### DIFF
--- a/resources/js/Pages/Results.vue
+++ b/resources/js/Pages/Results.vue
@@ -179,6 +179,8 @@
         submitting: boolean
     }
 
+    const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
     export default defineComponent({
         components: {
             Head,
@@ -296,32 +298,30 @@
                 try {
                     await axios.put('/mismatch-review', this.decisions[item]);
 
-                    this.showSubmitConfirmation(item);
-
                     // remove decision from this.decisions after it has been
                     // sent to the server successfully, to avoid sending them twice
                     delete this.decisions[item];
 
                     // adding this delay because when the response from the request happens
                     // too fast the overlay and progressbar flash
-                    setTimeout(() => {
-                        this.submitting = false;
-                        document.body.classList.remove('noscroll');
+                    await delay(250);
+                    this.submitting = false;
+                    document.body.classList.remove('noscroll');
 
-                        if(!this.disableConfirmation){
-                            confirmationDialog.show();
-                        }
-                    }, 250);
+                    this.showSubmitConfirmation(item);
+
+                    if(!this.disableConfirmation){
+                        confirmationDialog.show();
+                    }
                 } catch(e) {
                     this.requestError = true;
                     console.error("saving review decisions has failed", e);
 
                     // adding this delay because when the response from the request happens
                     // too fast the overlay and progressbar flash
-                    setTimeout(() => {
-                        this.submitting = false;
-                        document.body.classList.remove('noscroll');
-                    }, 250);
+                    await delay(250);
+                    this.submitting = false;
+                    document.body.classList.remove('noscroll');
                 }
             },
             clearSubmitConfirmation() {

--- a/resources/js/Pages/Results.vue
+++ b/resources/js/Pages/Results.vue
@@ -179,8 +179,6 @@
         submitting: boolean
     }
 
-    const SUBMITTING_DELAY_TIME = 1000;
-
     export default defineComponent({
         components: {
             Head,
@@ -281,6 +279,11 @@
 
                 this.clearSubmitConfirmation();
 
+                this.submitting = true;
+                // we can't access the body tag from inside vue, because the inertia instance
+                // is declared inside it, so we call it from the DOM directly
+                document.body.classList.add('noscroll');
+
                 // Casting to `any` since TS cannot understand $refs as
                 // component instances and complains about the usage of `show`
                 // See: https://github.com/vuejs/vue-class-component/issues/94
@@ -289,42 +292,37 @@
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 const confirmationDialog = this.$refs.confirmation as any;
 
-                this.submitting = true;
-
-                this.showSubmitConfirmation(item);
-
-                // remove decision from this.decisions after it has been
-                // sent to the server successfully, to avoid sending them twice
-                delete this.decisions[item];
-                // we can't access the body tag from inside vue, because the inertia instance
-                // is declared inside it, so we call it from the DOM directly
-                document.body.classList.add('noscroll');
-
                 // use axios in order to preserve saved mismatches
                 try {
                     await axios.put('/mismatch-review', this.decisions[item]);
+
+                    this.showSubmitConfirmation(item);
+
                     // remove decision from this.decisions after it has been
                     // sent to the server successfully, to avoid sending them twice
                     delete this.decisions[item];
 
-                    if(!this.disableConfirmation){
-                        setTimeout(() => { 
-                            confirmationDialog.show();
-                        // the transition between the loading state 
-                        // and the dialog looks better with a small delay between them    
-                        }, SUBMITTING_DELAY_TIME + 100)}
+                    // adding this delay because when the response from the request happens
+                    // too fast the overlay and progressbar flash
+                    setTimeout(() => {
+                        this.submitting = false;
+                        document.body.classList.remove('noscroll');
 
+                        if(!this.disableConfirmation){
+                            confirmationDialog.show();
+                        }
+                    }, 250);
                 } catch(e) {
                     this.requestError = true;
                     console.error("saving review decisions has failed", e);
-                }
 
-                // adding this delay because when the response from the request happens 
-                // too fast the overlay and progressbar flash
-                setTimeout(() => { 
-                    this.submitting = false;
-                    document.body.classList.remove('noscroll');
-                }, SUBMITTING_DELAY_TIME);
+                    // adding this delay because when the response from the request happens
+                    // too fast the overlay and progressbar flash
+                    setTimeout(() => {
+                        this.submitting = false;
+                        document.body.classList.remove('noscroll');
+                    }, 250);
+                }
             },
             clearSubmitConfirmation() {
                 this.lastSubmitted = '';
@@ -392,7 +390,7 @@ h2 {
     // For a proof of concept on how this can include also determinate loading, see:
     // https://codepen.io/xumium/pen/LYLZbva?editors=1100
     // We ensure semantic usage by only targeting generic elements that set the
-    // correct role 
+    // correct role
     &[role=progressbar] {
         position: fixed;
         top: 0;
@@ -410,7 +408,7 @@ h2 {
             background: $wikit-Progress-inline-background-color;
         }
 
-        // Indeterminate progress bars should not set the `aria-valuenow` 
+        // Indeterminate progress bars should not set the `aria-valuenow`
         // attribute
         &:not([aria-valuenow])::before {
             width: 30%;

--- a/tests/Browser/ResultsTest.php
+++ b/tests/Browser/ResultsTest.php
@@ -164,38 +164,12 @@ class ResultsTest extends DuskTestCase
                     'option' => 3,
                     'label' => 'Wrong data on external source'
                 ])
-                ->waitFor('@confirmation-dialog', 10)
-                ->assertSee('Next steps')
-                ->press('Proceed')
-                ->waitUntilMissing('@confirmation-dialog')
                 //load the page again
                 ->refresh()
                 // a 'notice' message indicates that the review status has been submitted
                 // and thus the mismatch can no longer be found when refreshing the results
                 ->assertSee('No mismatches have been found for')
                 ->assertSeeLink($mismatch->item_id);
-        });
-    }
-
-    public function test_apply_changes_button_prompts_overlay_and_progress_bar_while_submitting_results()
-    {
-        $import = ImportMeta::factory()
-        ->for(User::factory()->uploader())
-        ->create();
-
-        $mismatch = Mismatch::factory()
-            ->for($import)
-            ->create();
-
-        $this->browse(function (Browser $browser) use ($mismatch) {
-            $browser->loginAs(User::factory()->create())
-                ->visit(new ResultsPage($mismatch->item_id))
-                ->decideAndApply($mismatch, [
-                    'option' => 3,
-                    'label' => 'Wrong data on external source'
-                ])
-                ->assertVisible('.overlay')
-                ->assertVisible('.progressbar');
         });
     }
 
@@ -217,7 +191,8 @@ class ResultsTest extends DuskTestCase
                     'option' => 3,
                     'label' => 'Wrong data on external source'
                 ])
-                ->waitFor('@confirmation-dialog', 10)
+                ->waitFor('@confirmation-dialog')
+                ->pause(250)
                 ->assertSee('Next steps')
                 ->press('Proceed')
                 ->waitUntilMissing('@confirmation-dialog')
@@ -252,6 +227,7 @@ class ResultsTest extends DuskTestCase
                     'label' => 'Wrong data on external source'
                 ])
                 ->waitFor('@confirmation-dialog')
+                ->pause(250)
                 ->assertPresent("#item-mismatches-{$mismatch->item_id} .wikit-Message--success")
                 ->assertSee('Changes successfully submitted for');
         });
@@ -275,7 +251,8 @@ class ResultsTest extends DuskTestCase
                     'option' => 3,
                     'label' => 'Wrong data on external source'
                 ])
-                ->waitFor('@confirmation-dialog', 10)
+                ->waitFor('@confirmation-dialog')
+                ->pause(250)
                 ->assertSee('Next steps')
                 ->press('Proceed')
                 ->waitUntilMissing('@confirmation-dialog')
@@ -301,7 +278,8 @@ class ResultsTest extends DuskTestCase
                     'option' => 3,
                     'label' => 'Wrong data on external source'
                 ])
-                ->waitFor('@confirmation-dialog', 10)
+                ->waitFor('@confirmation-dialog')
+                ->pause(250)
                 ->within('@confirmation-dialog', function ($dialog) {
                     $dialog->assertSee('Do not show again')
                         ->assertVue('checked', false, '@disable-confirmation')
@@ -344,7 +322,8 @@ class ResultsTest extends DuskTestCase
                     'option' => 3,
                     'label' => 'Wrong data on external source'
                 ])
-                ->waitFor('@confirmation-dialog', 10)
+                ->waitFor('@confirmation-dialog')
+                ->pause(250)
                 ->within('@confirmation-dialog', function ($dialog) {
                     $dialog->assertSee('Do not show again')
                         ->assertVue('checked', false, '@disable-confirmation')

--- a/tests/Vue/Pages/Results.spec.js
+++ b/tests/Vue/Pages/Results.spec.js
@@ -6,8 +6,6 @@ import MismatchesTable from '@/Components/MismatchesTable.vue';
 import { ReviewDecision } from '@/types/Mismatch.ts';
 import axios from 'axios';
 
-const SUBMITTING_DELAY_TIME = 1000;
-
 // Stub the inertia vue components module entirely so that we don't run into
 // issues with the Head component.
 jest.mock('@inertiajs/inertia-vue', () => ({}));
@@ -220,14 +218,10 @@ describe('Results.vue', () => {
 
         const decisionsBeforeDelete = decisions[item_id];
         await wrapper.vm.send( item_id );
-        setTimeout(() => {
-            expect( axios.put ).toHaveBeenCalledWith( '/mismatch-review' , decisionsBeforeDelete );
+        expect( axios.put ).toHaveBeenCalledWith( '/mismatch-review' , decisionsBeforeDelete );
 
-            //the decisions object will be empty after sending the put request on one item
-            expect(wrapper.vm.decisions).toEqual({});
-
-        }, SUBMITTING_DELAY_TIME );
-        
+        //the decisions object will be empty after sending the put request on one item
+        expect(wrapper.vm.decisions).toEqual({});
 
     });
 
@@ -243,11 +237,8 @@ describe('Results.vue', () => {
 
         await wrapper.vm.send( item_id );
 
-        setTimeout(() => {
-            //the decisions object will remain untouched after the failed put request
-            expect(Object.keys(wrapper.vm.decisions)).toContain(item_id);
-        }, SUBMITTING_DELAY_TIME );
-        
+        //the decisions object will remain untouched after the failed put request
+        expect(Object.keys(wrapper.vm.decisions)).toContain(item_id);
     });
 
     it('Does not send a put request without any decisions', () => {


### PR DESCRIPTION
This change reverts the logic in the send method to its former procedure, but also adds logic to disable the submitting state, and reduces the flash wait to 250ms which provides a more subtle transition without making the user wait at least 1 second for fast requests.

In addition, an unnecessary browser test is removed, and pause times have been added to allow the confirmation dialog to finish animating before assertions.