### PR TITLE
Extract loading overlay to a component

### DIFF
--- a/resources/js/Components/LoadingOverlay.vue
+++ b/resources/js/Components/LoadingOverlay.vue
@@ -23,7 +23,7 @@ export default Vue.extend({
     data() {
         return {
             shown: this.visible,
-            document: {
+            cachedStyles: {
                 overflow: 'auto'
             }
         };
@@ -34,17 +34,19 @@ export default Vue.extend({
                 return;
             }
 
+            // Determine the current styles for body, in order to cache the overflow
             const bodyStyles = window.getComputedStyle(document.body);
             this.shown = true;
 
-            this.document.overflow = bodyStyles.overflow;
+            this.cachedStyles.overflow = bodyStyles.overflow;
             document.body.style.overflow = 'hidden';
         },
         hide(): Promise<void> {
             return new Promise((resolve) => {
                 setTimeout(() => {
                     this.shown = false;
-                    document.body.style.overflow = this.document.overflow;
+                    // Restore previous overflow value
+                    document.body.style.overflow = this.cachedStyles.overflow;
                     resolve();
                 }, this.delay);
             });

--- a/resources/js/Components/LoadingOverlay.vue
+++ b/resources/js/Components/LoadingOverlay.vue
@@ -1,0 +1,115 @@
+<template>
+    <div class="loading-indicator" v-if="shown">
+        <div class="progressbar" role="progressbar" />
+        <div class="overlay" />
+    </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+
+export default Vue.extend({
+    name: 'LoadingOverlay',
+    props: {
+        delay: {
+            type: Number,
+            default: 250,
+        },
+        visible: {
+            type: Boolean,
+            default: false,
+        }
+    },
+    data() {
+        return {
+            shown: this.visible,
+        };
+    },
+    methods: {
+        show(): void {
+            this.shown = true;
+        },
+        hide(): Promise<void> {
+            return new Promise((resolve) => {
+                setTimeout(() => {
+                    this.shown = false;
+                    resolve();
+                }, this.delay);
+            });
+        },
+    },
+});
+</script>
+
+<style lang="scss">
+@import '~@wmde/wikit-tokens/dist/_variables.scss';
+
+.noscroll {
+    overflow: hidden;
+}
+
+$base: '.loading-indicator';
+
+#{$base} .overlay {
+    /**
+    * Layout
+    */
+    width: $wikit-Dialog-overlay-width;
+    height: $wikit-Dialog-overlay-height;
+    position: fixed;
+    top:0;
+    left:0;
+
+    z-index: 100;
+
+    /**
+    * Colors
+    */
+    background-color: $wikit-Dialog-overlay-background-color;
+    opacity: $wikit-Dialog-overlay-opacity;
+}
+
+#{$base} .progressbar {
+    // Currently the inline progress bar only supports indeterminate loading mode.
+    // For a proof of concept on how this can include also determinate loading, see:
+    // https://codepen.io/xumium/pen/LYLZbva?editors=1100
+    // We ensure semantic usage by only targeting generic elements that set the
+    // correct role
+    &[role=progressbar] {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: $wikit-Progress-inline-track-width;
+        height: $wikit-Progress-inline-track-height;
+
+        &::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            display: block;
+            height: 100%;
+            background: $wikit-Progress-inline-background-color;
+        }
+
+        // Indeterminate progress bars should not set the `aria-valuenow`
+        // attribute
+        &:not([aria-valuenow])::before {
+            width: 30%;
+            border-radius: $wikit-Progress-inline-indeterminate-border-radius;
+            animation-name: load-indeterminate;
+            animation-duration: $wikit-Progress-inline-animation-duration;
+            animation-timing-function: ease;
+            animation-iteration-count: infinite;
+            animation-delay: 0s;
+        }
+    }
+
+    @keyframes load-indeterminate {
+        0% { left: 0; }
+        50% { left: 70%; }
+        100% { left: 0; }
+    }
+    z-index: 101;
+}
+</style>

--- a/resources/js/Components/LoadingOverlay.vue
+++ b/resources/js/Components/LoadingOverlay.vue
@@ -23,16 +23,28 @@ export default Vue.extend({
     data() {
         return {
             shown: this.visible,
+            document: {
+                overflow: 'auto'
+            }
         };
     },
     methods: {
         show(): void {
+            if (this.shown) {
+                return;
+            }
+
+            const bodyStyles = window.getComputedStyle(document.body);
             this.shown = true;
+
+            this.document.overflow = bodyStyles.overflow;
+            document.body.style.overflow = 'hidden';
         },
         hide(): Promise<void> {
             return new Promise((resolve) => {
                 setTimeout(() => {
                     this.shown = false;
+                    document.body.style.overflow = this.document.overflow;
                     resolve();
                 }, this.delay);
             });
@@ -43,10 +55,6 @@ export default Vue.extend({
 
 <style lang="scss">
 @import '~@wmde/wikit-tokens/dist/_variables.scss';
-
-.noscroll {
-    overflow: hidden;
-}
 
 $base: '.loading-indicator';
 

--- a/tests/Vue/Components/LoadingOverlay.spec.js
+++ b/tests/Vue/Components/LoadingOverlay.spec.js
@@ -1,0 +1,44 @@
+import { mount } from '@vue/test-utils';
+import LoadingOverlay from '@/Components/LoadingOverlay.vue';
+
+describe('LoadingOverlay.vue', () => {
+    it('accepts delay prop', () => {
+        const delay = 1000;
+        const wrapper = mount(LoadingOverlay, {
+            propsData: { delay }
+        });
+
+        expect(wrapper.props().delay).toBe(delay);
+    });
+
+    it('accepts visible prop', () => {
+        const visible = true;
+        const wrapper = mount(LoadingOverlay, {
+            propsData: { visible }
+        });
+
+        expect(wrapper.props().visible).toBe(visible);
+        expect(wrapper.find('.loading-indicator').exists()).toBe(true);
+    });
+
+    it('renders when calling show method', () => {
+        const wrapper = mount(LoadingOverlay);
+
+        wrapper.vm.show();
+
+        return wrapper.vm.$nextTick().then(() => {
+            expect(wrapper.find('.loading-indicator').exists()).toBe(true);
+        });
+    });
+
+    it('hides when calling hide method', () => {
+        const wrapper = mount(LoadingOverlay);
+
+        // Hide returns a promise to ensure the animation completes at least after a minimal delay
+        return wrapper.vm.hide()
+            .then(() => wrapper.vm.$nextTick())
+            .then(() => {
+                expect(wrapper.find('.loading-indicator').exists()).toBe(false);
+            });
+    });
+});


### PR DESCRIPTION
This change takes the loading overlay created by @guergana and extracts it to its own component with `show` and `hide` methods, as suggested by @Silvan-WMDE in a call last week.