### PR TITLE
Allow searching mismatches for up to 600 items

### DIFF
--- a/config/mismatches.php
+++ b/config/mismatches.php
@@ -28,7 +28,7 @@ return [
             'format' => '/^Q\d+$/i'
         ],
         'ids' => [
-            'max' => 50
+            'max' => 600 // Max number of item-ids to fetch mismatches for at once
         ],
         'review_status' => [
             'accepted_values' => ['pending','wikidata', 'external','both','none']


### PR DESCRIPTION
This change updates validation rules for the maximum amount of items users are allowed to search mismatches for.

Bug: [T297769](https://phabricator.wikimedia.org/T297769)