### PR TITLE
Validate maximal amount of Item IDs on the client side

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -18,6 +18,7 @@
     "log-out": "Log out",
     "mismatch-finder-title": "Mismatch Finder",
     "item-form-error-message-empty": "Please provide the Item identifiers in order to perform the check.",
+    "item-form-error-message-max": "Please reduce the number of item identifiers to fit the limit ($1)",
     "item-form-error-message-invalid": "One or more Item identifiers couldn't be processed. Please make sure to add only one identifier per line, without spaces or commas. Item identifiers should only be a set of valid numbers preceded by the letter Q (for example: Q1256).",
     "server-error": "The server encountered a temporary error and could not complete your request. Please try again.",
     "column-property": "Property",

--- a/public/i18n/qqq.json
+++ b/public/i18n/qqq.json
@@ -15,6 +15,7 @@
     "log-out": "The call to action for user log out",
     "mismatch-finder-title": "The main title of the website",
     "item-form-error-message-empty": "A warning message when no Item ids are provided",
+    "item-form-error-message-max": "An error message when too many item ids are provided",
     "item-form-error-message-invalid": "An error message when invalid Item ids are provided",
     "server-error": "An error message when the server encountered an error retrieving results",
     "column-property": "Property column on mismatches table",

--- a/resources/js/Pages/Home.vue
+++ b/resources/js/Pages/Home.vue
@@ -120,6 +120,8 @@
         errors : { [ key : string ] : string }
     }
 
+    export const MAX_NUM_IDS = 600; 
+
     export default defineComponent({
         components: {
             Head,
@@ -150,9 +152,9 @@
                     message: this.$i18n('item-form-error-message-empty')
                 },
                 {
-                    check: (ids: Array<string>) => ids.length > 600,
+                    check: (ids: Array<string>) => ids.length > MAX_NUM_IDS,
                     type: 'error',
-                    message: this.$i18n('item-form-error-message-max', 600)
+                    message: this.$i18n('item-form-error-message-max', MAX_NUM_IDS)
                 },
                 {
                     check: (ids: Array<string>) => !ids.every(value => /^[Qq]\d+$/.test( value.trim() )),

--- a/resources/js/Pages/Home.vue
+++ b/resources/js/Pages/Home.vue
@@ -150,6 +150,11 @@
                     message: this.$i18n('item-form-error-message-empty')
                 },
                 {
+                    check: (ids: Array<string>) => ids.length > 600,
+                    type: 'error',
+                    message: this.$i18n('item-form-error-message-max', 600)
+                },
+                {
                     check: (ids: Array<string>) => !ids.every(value => /^[Qq]\d+$/.test( value.trim() )),
                     type: 'error',
                     message: this.$i18n('item-form-error-message-invalid')

--- a/resources/js/Pages/Home.vue
+++ b/resources/js/Pages/Home.vue
@@ -141,28 +141,27 @@
             serializeInput: function(): string {
                 return this.sanitizeArray().join('|');
             },
-            checkEmpty(): void {
-                if( !this.form.itemsInput ) {
-                    this.validationError = {
-                        type: 'warning',
-                        message: this.$i18n('item-form-error-message-empty')
-                    };
-                }
-            },
             validate(): void {
                 this.validationError = null;
-                this.checkEmpty();
 
-                let valid = this.sanitizeArray().every( function( currentValue: string ) {
-                    let trimmedLine = currentValue.trim();
-                    return trimmedLine.match( /^[Qq]\d+$/ );
-                });
+                const rules = [{
+                    check: (ids: Array<string>) => ids.length < 1,
+                    type: 'warning',
+                    message: this.$i18n('item-form-error-message-empty')
+                },
+                {
+                    check: (ids: Array<string>) => !ids.every(value => /^[Qq]\d+$/.test( value.trim() )),
+                    type: 'error',
+                    message: this.$i18n('item-form-error-message-invalid')
+                }];
 
-                if( !valid ) {
-                    this.validationError = {
-                        type: 'error',
-                        message: this.$i18n('item-form-error-message-invalid')
-                    };
+                const sanitized = this.sanitizeArray();
+
+                for(let {check, type, message} of rules){
+                    if(check(sanitized)){
+                        this.validationError = { type, message };
+                        return;
+                    }
                 }
             },
             send(): void {

--- a/tests/Vue/Pages/Home.spec.js
+++ b/tests/Vue/Pages/Home.spec.js
@@ -67,7 +67,7 @@ describe('Home.vue', () => {
     it('validates that items in textarea input dont exceed the maximum number of ids', async () => {
         const store = new Vuex.Store();
 
-        const itemsInput = rangeIds(1, MAX_NUM_IDS + 2).join('\n');
+        const itemsInput = Array(MAX_NUM_IDS + 2).fill('Q21').join('\n');
 
         const wrapper = mount(Home, {
             mocks,

--- a/tests/Vue/Pages/Home.spec.js
+++ b/tests/Vue/Pages/Home.spec.js
@@ -87,11 +87,3 @@ describe('Home.vue', () => {
     });
 
 })
-
-const rangeIds = (start, end, step = 1) => {
-    let output = [];
-    for (let i = start; i < end; i += step) {
-      output.push('Q' + i);
-    }
-    return output;
-  };

--- a/tests/Vue/Pages/Home.spec.js
+++ b/tests/Vue/Pages/Home.spec.js
@@ -1,6 +1,6 @@
 import { mount, createLocalVue } from '@vue/test-utils';
 import Vuex from 'vuex'
-import Home from '@/Pages/Home.vue';
+import Home, { MAX_NUM_IDS } from '@/Pages/Home.vue'
 
 // Stub the inertia vue components module entirely so that we don't run into
 // issues with the Head component.
@@ -64,4 +64,34 @@ describe('Home.vue', () => {
         expect(dialog.isVisible()).toBe(true);
     });
 
+    it('validates that items in textarea input dont exceed the maximum number of ids', async () => {
+        const store = new Vuex.Store();
+
+        const itemsInput = rangeIds(1, MAX_NUM_IDS + 2).join('\n');
+
+        const wrapper = mount(Home, {
+            mocks,
+            localVue,
+            store,
+            data() {
+                return {
+                    form: {
+                        itemsInput
+                    }
+                }
+            }
+        });
+
+        wrapper.vm.validate();
+        expect(wrapper.vm.validationError.message).toBe('item-form-error-message-max');
+    });
+
 })
+
+const rangeIds = (start, end, step = 1) => {
+    let output = [];
+    for (let i = start; i < end; i += step) {
+      output.push('Q' + i);
+    }
+    return output;
+  };


### PR DESCRIPTION
This change adds client side validation logic to warn users if they input more than 600 IDs in the item ID form. Additionally, the client side validation logic has been slightly restructured to allow for easier expansion or modification of the form's validation rules.

Bug: [T295019](https://phabricator.wikimedia.org/T295019)