### PR TITLE
Handle server side validation errors in client

### DIFF
--- a/app/Http/Middleware/SimulateError.php
+++ b/app/Http/Middleware/SimulateError.php
@@ -33,6 +33,8 @@ class SimulateError
             throw new RuntimeException("Simulated Server Error");
         } elseif ($request->header('X-Mismatch-Finder-Not-Found') == $request->path()) {
             abort(404);
+        } elseif ($request->header('X-Mismatch-Finder-Invalid') == $request->path()) {
+            abort(422);
         }
 
         return $next($request);

--- a/resources/js/Pages/Home.vue
+++ b/resources/js/Pages/Home.vue
@@ -61,7 +61,7 @@
         </section>
 
         <section id="message-section">
-            <Message v-if="unexpectedError" type="error">
+            <Message v-if="unexpectedError || serversideValidationError" type="error">
                 <span>{{ $i18n('server-error') }}</span>
             </Message>
         </section>
@@ -114,6 +114,10 @@
             type: string,
             message: string
         }
+    }
+
+    interface ErrorMessages {
+        [ key : string ] : string
     }
 
     interface FlashMessages {
@@ -183,6 +187,10 @@
             },
         },
         computed: {
+            serversideValidationError() {
+                const errors = this.$page.props.errors as ErrorMessages;
+                return errors && Object.keys(errors).length > 0;
+            },
             unexpectedError() {
                 const flashMessages = this.$page.props.flash as FlashMessages;
                 return (flashMessages.errors && flashMessages.errors.unexpected);

--- a/resources/js/Pages/Results.vue
+++ b/resources/js/Pages/Results.vue
@@ -289,6 +289,7 @@
                     // remove decision from this.decisions after it has been
                     // sent to the server successfully, to avoid sending them twice
                     delete this.decisions[item];
+                    this.requestError = false;
 
                     await overlay.hide();
                     this.showSubmitConfirmation(item);

--- a/resources/js/Pages/Results.vue
+++ b/resources/js/Pages/Results.vue
@@ -48,7 +48,7 @@
                 {{ $i18n('results-page-description') }}
             </p>
         </section>
-        <section id="error-section" v-if="unexpectedError || requestError">
+        <section id="error-section" v-if="requestError">
             <Message type="error" class="generic-error">{{ $i18n('server-error') }}</Message>
         </section>
         <section id="message-section">
@@ -160,10 +160,6 @@
         [entityId: string]: string
     }
 
-    interface FlashMessages {
-        errors : { [ key : string ] : string }
-    }
-
     interface DecisionMap {
         [entityId: string]: {
             [id: number]: MismatchDecision
@@ -212,10 +208,6 @@
             notFoundItemIds() {
                 return this.item_ids.filter( id => !this.results[id] )
             },
-            unexpectedError() {
-                const flashMessages = this.$page.props.flash as FlashMessages;
-                return (flashMessages.errors && flashMessages.errors.unexpected);
-            }
         },
         mounted(){
             if(!this.$store.state.lastSearchedIds) {

--- a/tests/Browser/ItemsFormTest.php
+++ b/tests/Browser/ItemsFormTest.php
@@ -113,4 +113,16 @@ class ItemsFormTest extends DuskTestCase
                 // See: https://stackoverflow.com/q/67690990#comment119647867_67690990
         });
     }
+
+    public function test_shows_error_message_from_results_url_with_invalid_input()
+    {
+        $this->browse(function (Browser $browser) {
+            // browse to Homepage so that Laravel has something to redirect back to
+            $browser->visit('/');
+
+            $browser->visit('/results?ids=Q42|L123')
+                ->waitFor('.home-page')
+                ->assertVisible('#message-section .wikit-Message--error.wikit');
+        });
+    }
 }

--- a/tests/Vue/Pages/Home.spec.js
+++ b/tests/Vue/Pages/Home.spec.js
@@ -139,4 +139,13 @@ describe('Home.vue', () => {
             message: 'item-form-error-message-invalid'}
         );
     });
+
+    it('shows error message upon serverside validation errors', async () => {
+        mocks.$page.props.errors = { 'someKey' : 'someError'}
+        const store = new Vuex.Store();
+        const wrapper = mount(Home, { mocks, localVue, store });
+
+        const errorMessage = wrapper.find('#message-section .wikit-Message--error.wikit');
+        expect(errorMessage.isVisible()).toBe(true);
+    });
 })

--- a/tests/Vue/Pages/Results.spec.js
+++ b/tests/Vue/Pages/Results.spec.js
@@ -225,7 +225,7 @@ describe('Results.vue', () => {
 
     });
 
-    it('Handles errors on axios put requests gracefully', async () => {
+    it('Handles errors on axios PUT requests gracefully', async () => {
         // mock axios error response
         axios.put = jest.fn().mockRejectedValue('Error');
 
@@ -239,6 +239,15 @@ describe('Results.vue', () => {
 
         //the decisions object will remain untouched after the failed put request
         expect(Object.keys(wrapper.vm.decisions)).toContain(item_id);
+    });
+
+    it('Shows error message on failed axios PUT request', async () => {
+        const wrapper = mountWithMocks({
+            data: { 'requestError' : true }
+        });
+
+        const errorMessage = wrapper.find('#error-section .wikit-Message--error.wikit');
+        expect(errorMessage.isVisible()).toBe(true);
     });
 
     it('Does not send a put request without any decisions', () => {

--- a/tests/Vue/Pages/Results.spec.js
+++ b/tests/Vue/Pages/Results.spec.js
@@ -250,6 +250,23 @@ describe('Results.vue', () => {
         expect(errorMessage.isVisible()).toBe(true);
     });
 
+    it('Clears error message on successful axios PUT request', async () => {
+
+        const item_id = 'Q321';
+        const decisions = { [item_id]:{1:{id:1, item_id ,review_status: ReviewDecision.Wikidata}}};
+        const wrapper = mountWithMocks({
+            data: {
+                decisions,
+                'requestError' : true
+            }
+        });
+
+        await wrapper.vm.send( item_id );
+
+        const errorMessage = wrapper.find('#error-section .wikit-Message--error.wikit');
+        expect(errorMessage.exists()).toBe(false);
+    });
+
     it('Does not send a put request without any decisions', () => {
         // clear mock object
         axios.put = jest.fn();


### PR DESCRIPTION
This change adds a computed property to the Home page, which will trigger an error message box in case of serverside validation errors of requested item IDs. Additionally it adds one unit tests to check that the error message box is also shown on the Results page in case of a failed axios PUT request to submit review decisions, as well as one to check that the box disappears again after a successful submit request.

Bug: [T295541](https://phabricator.wikimedia.org/T295541)