### PR TITLE
Metrics/requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,3 +58,6 @@ PUSHER_APP_CLUSTER=mt1
 
 MIX_PUSHER_APP_KEY="${PUSHER_APP_KEY}"
 MIX_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
+
+STATSD_HOST='https://www.wikidata.org/beacon/statsv'
+STATSD_NAMESPACE='Wikidata.mismatch-finder'

--- a/app/Exceptions/StatsdClientException.php
+++ b/app/Exceptions/StatsdClientException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+class StatsdClientException extends Exception
+{
+    //
+}

--- a/app/Http/Controllers/ImportController.php
+++ b/app/Http/Controllers/ImportController.php
@@ -14,6 +14,8 @@ use App\Services\StatsdAPIClient;
 
 class ImportController extends Controller
 {
+    use Traits\StatsTracker;
+
     /** @var string */
     public const RESOURCE_NAME = 'imports';
 
@@ -22,8 +24,9 @@ class ImportController extends Controller
      *
      * @return void
      */
-    public function __construct()
+    public function __construct(StatsdAPIClient $statsd)
     {
+        $this->statsd = $statsd;
         $this->middleware('auth:sanctum')->only('store');
     }
 
@@ -91,8 +94,7 @@ class ImportController extends Controller
             new ImportCSV($meta)
         ])->dispatch();
 
-        //collect metric
-        $statsd->sendStats('import_mismatch_file');
+        $this->trackImportStats();
 
         return new ImportMetaResource($meta);
     }

--- a/app/Http/Controllers/Traits/StatsTracker.php
+++ b/app/Http/Controllers/Traits/StatsTracker.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers\Traits;
+
+trait StatsTracker
+{
+    public function trackRequestStats()
+    {
+        $this->statsd->sendStats('mismatch_request');
+    }
+
+    public function trackReviewStats()
+    {
+        $this->statsd->sendStats('mismatch_review');
+    }
+
+    public function trackImportStats()
+    {
+        $this->statsd->sendStats('import_mismatch_file');
+    }
+}

--- a/app/Providers/StatsdAPIProvider.php
+++ b/app/Providers/StatsdAPIProvider.php
@@ -16,7 +16,7 @@ class StatsdAPIProvider extends ServiceProvider
     {
         $this->app->singleton(StatsdAPIClient::class, function ($app) {
 
-            return new StatsdAPIClient(config('wikidata.statsd.endpoint_url'));
+            return new StatsdAPIClient(config('wikidata.statsd.endpoint_url'), config('wikidata.statsd.namespace'));
         });
     }
 

--- a/app/Providers/StatsdAPIProvider.php
+++ b/app/Providers/StatsdAPIProvider.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use App\Services\StatsdAPIClient;
+
+class StatsdAPIProvider extends ServiceProvider
+{
+    /**
+     * Register services.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->app->singleton(StatsdAPIClient::class, function ($app) {
+
+            return new StatsdAPIClient(config('wikidata.statsd.endpoint_url'));
+        });
+    }
+
+    /**
+     * Bootstrap services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        //
+    }
+}

--- a/app/Services/StatsdAPIClient.php
+++ b/app/Services/StatsdAPIClient.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Http;
 use Illuminate\Http\Client\Response;
 use App\Exceptions\StatsdClientException;
 
-class StatsdClient
+class StatsdAPIClient
 {
 
     /**

--- a/app/Services/StatsdAPIClient.php
+++ b/app/Services/StatsdAPIClient.php
@@ -17,6 +17,11 @@ class StatsdAPIClient
     public function __construct(string $baseUrl, string $namespace)
     {
         $this->baseUrl = $baseUrl;
+
+        if (!app()->environment('production')) {
+            $namespace .= '-test';
+        }
+
         $this->namespace = $namespace;
     }
 

--- a/app/Services/StatsdAPIClient.php
+++ b/app/Services/StatsdAPIClient.php
@@ -14,14 +14,15 @@ class StatsdAPIClient
      */
     private $baseUrl;
 
-    public function __construct(string $baseUrl)
+    public function __construct(string $baseUrl, string $namespace)
     {
         $this->baseUrl = $baseUrl;
+        $this->namespace = $namespace;
     }
 
     public function sendStats(string $metric): Response
     {
-        $response = Http::post($this->baseUrl. '?Wikidata.mismatch-finder.' . $metric . '=1c');
+        $response = Http::post($this->baseUrl. '?' .$this->namespace . '.' . $metric . '=1c');
 
         // Checking for an errors field in the response, since Wikibase api
         // responds with 200 even for erroneous requests

--- a/app/Services/StatsdClient.php
+++ b/app/Services/StatsdClient.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Http\Client\Response;
+use App\Exceptions\StatsdClientException;
+
+class StatsdClient
+{
+
+    /**
+     * @var string statsd endpoint url
+     */
+    private $baseUrl;
+
+    public function __construct(string $baseUrl)
+    {
+        $this->baseUrl = $baseUrl;
+    }
+
+    public function sendStats(string $metric): Response
+    {
+        $response = Http::post($this->baseUrl. '?Wikidata.mismatch-finder.' . $metric . '=1c');
+
+        // Checking for an errors field in the response, since Wikibase api
+        // responds with 200 even for erroneous requests
+        if (isset($response['error'])) {
+            throw new StatsdClientException($response['error']['info']);
+        }
+
+        return $response;
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -181,6 +181,7 @@ return [
          * Custom Service Providers
          */
         App\Providers\WikidataAPIProvider::class,
+        App\Providers\StatsdAPIProvider::class
     ],
 
     /*

--- a/config/wikidata.php
+++ b/config/wikidata.php
@@ -9,5 +9,9 @@ return [
         'response_cache' => [
             'ttl' => env('WIKIDATA_API_CACHE_TTL', 60 * 60 * 60 * 24) // 1 day arbitrarily chosen as default
         ]
+        ],
+    'statsd' => [
+        'endpoint_url' => env('STATSD_HOST', 'https://www.wikidata.org/beacon/statsv'),
+        'namespace' =>  env('STATSD_NAMESPACE', 'Wikidata.mismatch-finder')
     ]
 ];


### PR DESCRIPTION
TODO: ~~find out why stats are being sent from the Results controller for `mismatch_request` but same code is not sending anything from MismatchController:get when accessed through the web endpoint. Do I need to make some code injection somewhere?~~ please double check. I think this is working now.  

The stats can be seen in [Graphite](https://graphite.wikimedia.org/?showTarget=Wikidata.mismatch-finder.mismatch_review.rate&width=586&height=308&target=Wikidata.mismatch-finder.mismatch_review.lower&target=Wikidata.mismatch-finder.mismatch_review.mean&target=Wikidata.mismatch-finder.mismatch_review.count) and [Grafana](https://grafana-rw.wikimedia.org/d/knCj7WA7z/wikidata-mismatch-finder?orgId=1)

MismatchController is sending the stats from the index and update methods in the api. 

UPDATE: i am not aware at the moment on the other metrics we need but maybe it would make sense to send also the operation to the `sendStats` function? In this case `increment` but the function can also be modified if needed in the future and not necessarily in this PR. This PR assumes we would only want to send increments to graphite

Bug: [T295758](https://phabricator.wikimedia.org/T295758)