### PR TITLE
Track open vs reviewed mismatches via statsv

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -2,6 +2,7 @@
 
 namespace App\Console;
 
+use App\Console\Tasks\TrackMismatchRatio;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 
@@ -24,7 +25,9 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        // $schedule->command('inspire')->hourly();
+        $schedule->call(new TrackMismatchRatio())
+            ->description("Tracking task that runs every minute")
+            ->everyMinute();
     }
 
     /**

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -26,8 +26,8 @@ class Kernel extends ConsoleKernel
     protected function schedule(Schedule $schedule)
     {
         $schedule->call(new TrackMismatchRatio())
-            ->description("Tracking task that runs every minute")
-            ->everyMinute();
+            ->description("Task to track the 'pending vs reviewed' ratio once per day")
+            ->daily();
     }
 
     /**

--- a/app/Console/Tasks/TrackMismatchRatio.php
+++ b/app/Console/Tasks/TrackMismatchRatio.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Console\Tasks;
+
+use App\Http\Controllers\Traits\StatsTracker;
+use App\Models\Mismatch;
+use App\Services\StatsdAPIClient;
+
+class TrackMismatchRatio
+{
+    use StatsTracker;
+
+    /**
+     * Instantiate a new task instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->statsd = new StatsdAPIClient(
+            config('wikidata.statsd.endpoint_url'),
+            config('wikidata.statsd.namespace')
+        );
+    }
+
+    /**
+     * Invoke the tracking task.
+     *
+     * @return void
+     */
+    public function __invoke()
+    {
+        $total_unexpired = Mismatch::whereHas('importMeta', function ($import) {
+            $import->where('expires', '>=', now());
+        })->count();
+
+        $total_unexpired_reviewed = Mismatch::whereHas('importMeta', function ($import) {
+            $import->where('expires', '>=', now());
+        })->where('review_status', '!=', 'pending')
+          ->count();
+
+        $this->trackMismatchRatio($total_unexpired, $total_unexpired_reviewed);
+    }
+}

--- a/app/Http/Controllers/Traits/StatsTracker.php
+++ b/app/Http/Controllers/Traits/StatsTracker.php
@@ -18,4 +18,18 @@ trait StatsTracker
     {
         $this->statsd->sendStats('import_mismatch_file');
     }
+
+    /**
+     * Track the current 'total vs reviewed' mismatch ratio via statsv
+     *
+     * @param int $total    Total number of unexpired mismatches
+     * @param int $reviewed Total number of unexpired mismatches that are reviewed
+     *
+     * @return void
+     */
+    public function trackMismatchRatio(int $total, int $reviewed)
+    {
+        $this->statsd->sendStats('total_mismatches', $total);
+        $this->statsd->sendStats('reviewed_mismatches', $reviewed);
+    }
 }

--- a/app/Http/Controllers/Traits/StatsTracker.php
+++ b/app/Http/Controllers/Traits/StatsTracker.php
@@ -4,16 +4,31 @@ namespace App\Http\Controllers\Traits;
 
 trait StatsTracker
 {
+    /**
+     * Track mismatch requests via statsv
+     *
+     * @return void
+     */
     public function trackRequestStats()
     {
         $this->statsd->sendStats('mismatch_request');
     }
 
+    /**
+     * Track mismatch reviews via statsv
+     *
+     * @return void
+     */
     public function trackReviewStats()
     {
         $this->statsd->sendStats('mismatch_review');
     }
 
+    /**
+     * Track mismatch file imports via statsv
+     *
+     * @return void
+     */
     public function trackImportStats()
     {
         $this->statsd->sendStats('import_mismatch_file');

--- a/app/Services/StatsdAPIClient.php
+++ b/app/Services/StatsdAPIClient.php
@@ -25,9 +25,9 @@ class StatsdAPIClient
         $this->namespace = $namespace;
     }
 
-    public function sendStats(string $metric): Response
+    public function sendStats(string $metric, int $value = 1): Response
     {
-        $response = Http::post($this->baseUrl. '?' .$this->namespace . '.' . $metric . '=1c');
+        $response = Http::post($this->baseUrl. '?' .$this->namespace . '.' . $metric . '=' . $value . 'c');
 
         // Checking for an errors field in the response, since Wikibase api
         // responds with 200 even for erroneous requests

--- a/containers/production-schedule.yaml
+++ b/containers/production-schedule.yaml
@@ -1,0 +1,31 @@
+---
+# Run the mismatch finder scheduler on kubernetes
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mismatch-finder.schedule
+  namespace: tool-mismatch-finder
+  labels:
+    name: mismatch-finder.schedule
+    toolforge: tool
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: mismatch-finder.schedule
+      toolforge: tool
+  template:
+    metadata:
+      labels:
+        name: mismatch-finder.schedule
+        toolforge: tool
+    spec:
+      containers:
+        - name: artisan-schedule
+          image: docker-registry.tools.wmflabs.org/toolforge-php73-sssd-base:latest
+          command: [ "php", "artisan", "schedule:work" ]
+          workingDir: /data/project/mismatch-finder/mismatch-finder-repo
+          env:
+            - name: HOME
+              value: /data/project/mismatch-finder
+          imagePullPolicy: Always

--- a/containers/production-schedule.yaml
+++ b/containers/production-schedule.yaml
@@ -1,7 +1,7 @@
 ---
 # Run the mismatch finder scheduler on kubernetes
-apiVersion: apps/v1
-kind: Deployment
+apiVersion: batch/v1beta1
+kind: CronJob
 metadata:
   name: mismatch-finder.schedule
   namespace: tool-mismatch-finder
@@ -9,23 +9,21 @@ metadata:
     name: mismatch-finder.schedule
     toolforge: tool
 spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      name: mismatch-finder.schedule
-      toolforge: tool
-  template:
-    metadata:
-      labels:
-        name: mismatch-finder.schedule
-        toolforge: tool
+  schedule: "* * * * *"
+  jobTemplate:
     spec:
-      containers:
-        - name: artisan-schedule
-          image: docker-registry.tools.wmflabs.org/toolforge-php73-sssd-base:latest
-          command: [ "php", "artisan", "schedule:work" ]
-          workingDir: /data/project/mismatch-finder/mismatch-finder-repo
-          env:
-            - name: HOME
-              value: /data/project/mismatch-finder
-          imagePullPolicy: Always
+      template:
+        metadata:
+          labels:
+            toolforge: tool
+        spec:
+          containers:
+          - name: artisan-schedule
+            image: docker-registry.tools.wmflabs.org/toolforge-php73-sssd-base:latest
+            command: [ "php", "artisan", "schedule:run" ]
+            workingDir: /data/project/mismatch-finder/mismatch-finder-repo
+            env:
+              - name: HOME
+                value: /data/project/mismatch-finder
+            imagePullPolicy: Always
+          restartPolicy: OnFailure

--- a/containers/staging-schedule.yaml
+++ b/containers/staging-schedule.yaml
@@ -1,7 +1,7 @@
 ---
 # Run the mismatch finder scheduler on kubernetes
-apiVersion: apps/v1
-kind: Deployment
+apiVersion: batch/v1beta1
+kind: CronJob
 metadata:
   name: mismatch-finder-staging.schedule
   namespace: tool-mismatch-finder-staging
@@ -9,23 +9,21 @@ metadata:
     name: mismatch-finder-staging.schedule
     toolforge: tool
 spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      name: mismatch-finder-staging.schedule
-      toolforge: tool
-  template:
-    metadata:
-      labels:
-        name: mismatch-finder-staging.schedule
-        toolforge: tool
+  schedule: "* * * * *"
+  jobTemplate:
     spec:
-      containers:
-        - name: artisan-schedule
-          image: docker-registry.tools.wmflabs.org/toolforge-php73-sssd-base:latest
-          command: [ "php", "artisan", "schedule:work" ]
-          workingDir: /data/project/mismatch-finder-staging/mismatch-finder-repo-next
-          env:
-            - name: HOME
-              value: /data/project/mismatch-finder-staging
-          imagePullPolicy: Always
+      template:
+        metadata:
+          labels:
+            toolforge: tool
+        spec:
+          containers:
+          - name: artisan-schedule
+            image: docker-registry.tools.wmflabs.org/toolforge-php73-sssd-base:latest
+            command: [ "php", "artisan", "schedule:run" ]
+            workingDir: /data/project/mismatch-finder-staging/mismatch-finder-repo-next
+            env:
+              - name: HOME
+                value: /data/project/mismatch-finder-staging
+            imagePullPolicy: Always
+          restartPolicy: OnFailure

--- a/containers/staging-schedule.yaml
+++ b/containers/staging-schedule.yaml
@@ -1,0 +1,31 @@
+---
+# Run the mismatch finder scheduler on kubernetes
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mismatch-finder-staging.schedule
+  namespace: tool-mismatch-finder-staging
+  labels:
+    name: mismatch-finder-staging.schedule
+    toolforge: tool
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: mismatch-finder-staging.schedule
+      toolforge: tool
+  template:
+    metadata:
+      labels:
+        name: mismatch-finder-staging.schedule
+        toolforge: tool
+    spec:
+      containers:
+        - name: artisan-schedule
+          image: docker-registry.tools.wmflabs.org/toolforge-php73-sssd-base:latest
+          command: [ "php", "artisan", "schedule:work" ]
+          workingDir: /data/project/mismatch-finder-staging/mismatch-finder-repo-next
+          env:
+            - name: HOME
+              value: /data/project/mismatch-finder-staging
+          imagePullPolicy: Always


### PR DESCRIPTION
This change adds a scheduled tracking task that runs every minute. It sends the
total number of mismatches and the number of reviewed mismatches to
statsv for reporting purposes.

Bug: [T295760](https://phabricator.wikimedia.org/T295760)


See "Total vs Reviewed" panel on [Grafana Dashboard](https://grafana-rw.wikimedia.org/d/knCj7WA7z/wikidata-mismatch-finder)