### PR TITLE
Add expiry data columns to report

### DIFF
--- a/app/Services/ImportReport.php
+++ b/app/Services/ImportReport.php
@@ -40,7 +40,9 @@ class ImportReport
                 $mismatches_both,
                 $mismatches_none,
                 $mismatches_pending,
-                $percent_completed
+                $percent_completed,
+                $each_import->expires,
+                $each_import->expires > now()
             ]);
         }
 

--- a/app/Services/ImportReport.php
+++ b/app/Services/ImportReport.php
@@ -42,7 +42,7 @@ class ImportReport
                 $mismatches_pending,
                 $percent_completed,
                 $each_import->expires,
-                $each_import->expires > now()
+                $each_import->expires < now() ? 'y' : 'n'
             ]);
         }
 

--- a/config/imports.php
+++ b/config/imports.php
@@ -45,6 +45,8 @@ return [
             "decisions with an error in neither",
             "undecided mismatches",
             "% completed",
+            "expiry date",
+            "expired?"
         ]
     ]
 ];

--- a/tests/Feature/ImportReportTest.php
+++ b/tests/Feature/ImportReportTest.php
@@ -42,6 +42,8 @@ class ImportReportTest extends TestCase
         $total = $mismatches->count();
         $pending = $mismatches->where('review_status', 'pending')->count();
 
+        $this->travelTo(now()); // stop the clock
+
         $expected = $this->formatCsv([
             config('imports.report.headers'),
             [
@@ -65,6 +67,8 @@ class ImportReportTest extends TestCase
         $result = Storage::get($filename);
 
         $this->assertSame($expected, $result);
+
+        $this->travelBack(); // resumes the clock
     }
     /**
      * @return void

--- a/tests/Feature/ImportReportTest.php
+++ b/tests/Feature/ImportReportTest.php
@@ -57,7 +57,7 @@ class ImportReportTest extends TestCase
                 $pending, // Pending count
                 100 - ($pending / $total * 100), // % completed
                 $import->expires, // Expiry date
-                $import->expires > now() // Expired
+                $import->expires < now() ? 'y' : 'n' // Expired
             ]
         ]);
 

--- a/tests/Feature/ImportReportTest.php
+++ b/tests/Feature/ImportReportTest.php
@@ -54,6 +54,8 @@ class ImportReportTest extends TestCase
                 $mismatches->where('review_status', 'none')->count(), // Error on none count
                 $pending, // Pending count
                 100 - ($pending / $total * 100), // % completed
+                $import->expires, // Expiry date
+                $import->expires > now() // Expired
             ]
         ]);
 


### PR DESCRIPTION
This change adds import expiration data as a followup to the import overview report.

Bug: [T295759](https://phabricator.wikimedia.org/T295759)