### PR TITLE
Fix import validation timeout issues

### DIFF
--- a/app/Jobs/ValidateCSV.php
+++ b/app/Jobs/ValidateCSV.php
@@ -116,7 +116,7 @@ class ValidateCSV implements ShouldQueue
                 'max:' . $rules['external_value']['max_length']
             ],
             'external_url' => [
-                // 'url',
+                'url',
                 'max:' . $rules['external_url']['max_length']
             ]
         ]);

--- a/app/Jobs/ValidateCSV.php
+++ b/app/Jobs/ValidateCSV.php
@@ -49,15 +49,12 @@ class ValidateCSV implements ShouldQueue
         $filepath = Storage::disk('local')
         ->path('mismatch-files/' . $this->meta->filename);
 
-        Log::debug('Validating CSV file for import ' . $this->meta->id);
-
         $reader->lines($filepath)
             ->each(function ($mismatch, $i) use ($valueValidator) {
                 $error = $this->checkFieldErrors($mismatch)
                     ?? $this->checkValueErrors($mismatch, $valueValidator);
 
                 if ($error) {
-                    Log::debug("Import failed on line  $i with error: $error");
                     throw new ImportValidationException($i, $error);
                 }
             });

--- a/app/Rules/WikidataValue.php
+++ b/app/Rules/WikidataValue.php
@@ -40,9 +40,7 @@ class WikidataValue implements Rule
 
         try {
             $this->wikidata->parseValue($property, $wikidataValue);
-            Log::debug('Parsed: ' . $wikidataValue);
         } catch (WikibaseValueParserException $e) {
-            Log::debug('Failed: ' . $wikidataValue . ' with error: ' . $e->getMessage());
             return false;
         }
 

--- a/app/Rules/WikidataValue.php
+++ b/app/Rules/WikidataValue.php
@@ -5,7 +5,6 @@ namespace App\Rules;
 use Illuminate\Contracts\Validation\Rule;
 use App\Services\WikibaseAPIClient;
 use App\Exceptions\WikibaseValueParserException;
-use Illuminate\Support\Facades\Log;
 
 class WikidataValue implements Rule
 {

--- a/app/Rules/WikidataValue.php
+++ b/app/Rules/WikidataValue.php
@@ -5,6 +5,7 @@ namespace App\Rules;
 use Illuminate\Contracts\Validation\Rule;
 use App\Services\WikibaseAPIClient;
 use App\Exceptions\WikibaseValueParserException;
+use Illuminate\Support\Facades\Log;
 
 class WikidataValue implements Rule
 {
@@ -39,7 +40,9 @@ class WikidataValue implements Rule
 
         try {
             $this->wikidata->parseValue($property, $wikidataValue);
+            Log::debug('Parsed: ' . $wikidataValue);
         } catch (WikibaseValueParserException $e) {
+            Log::debug('Failed: ' . $wikidataValue . ' with error: ' . $e->getMessage());
             return false;
         }
 

--- a/containers/production-queue.yaml
+++ b/containers/production-queue.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: artisan-queue
           image: docker-registry.tools.wmflabs.org/toolforge-php73-sssd-base:latest
-          command: [ "php", "artisan", "queue:work" ]
+          command: [ "php", "artisan", "queue:work", "--timeout=1200" ]
           workingDir: /data/project/mismatch-finder/mismatch-finder-repo
           env:
             - name: HOME

--- a/containers/staging-queue.yaml
+++ b/containers/staging-queue.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: artisan-queue
           image: docker-registry.tools.wmflabs.org/toolforge-php73-sssd-base:latest
-          command: [ "php", "artisan", "queue:work" ]
+          command: [ "php", "artisan", "queue:work", "--timeout=900" ]
           workingDir: /data/project/mismatch-finder-staging/mismatch-finder-repo-next
           env:
             - name: HOME

--- a/containers/staging-queue.yaml
+++ b/containers/staging-queue.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: artisan-queue
           image: docker-registry.tools.wmflabs.org/toolforge-php73-sssd-base:latest
-          command: [ "php", "artisan", "queue:work", "--timeout=900" ]
+          command: [ "php", "artisan", "queue:work", "--timeout=1200" ]
           workingDir: /data/project/mismatch-finder-staging/mismatch-finder-repo-next
           env:
             - name: HOME


### PR DESCRIPTION
This change increased the production and staging queue workers timeout limit from 1 minute to 20 minutes. In addition, more explicit error logging is added for cases when an unexpected error occurs.

Bug: [T300649](https://phabricator.wikimedia.org/T300649)