### PR TITLE
Update inertia

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,8 +5,8 @@
     "packages": {
         "": {
             "dependencies": {
-                "@inertiajs/inertia": "^0.10.1",
-                "@inertiajs/inertia-vue": "^0.7.2",
+                "@inertiajs/inertia": "^0.11.0",
+                "@inertiajs/inertia-vue": "^0.8.0",
                 "@wmde/wikit-tokens": "^3.0.0-alpha.6",
                 "@wmde/wikit-vue-components": "^2.1.0-alpha.10",
                 "date-fns": "^2.28.0",
@@ -1788,9 +1788,9 @@
             "dev": true
         },
         "node_modules/@inertiajs/inertia": {
-            "version": "0.10.1",
-            "resolved": "https://registry.npmjs.org/@inertiajs/inertia/-/inertia-0.10.1.tgz",
-            "integrity": "sha512-Ntyaerh07QnpIOxC+qsteUZ9OGVWfogpg3fCkSxciaX6AZyYLT6t7IFPkefPShb9LC2G4Woh1hel4t/pMr2vRQ==",
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/@inertiajs/inertia/-/inertia-0.11.0.tgz",
+            "integrity": "sha512-QF4hctgFC+B/t/WClCwfOla+WoDE9iTltQJ0u+DCfjl0KdGoCvIxYiNtuH8h8oM+RQMb8orjbpW3pHapjYI5Vw==",
             "dependencies": {
                 "axios": "^0.21.1",
                 "deepmerge": "^4.0.0",
@@ -1798,15 +1798,15 @@
             }
         },
         "node_modules/@inertiajs/inertia-vue": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/@inertiajs/inertia-vue/-/inertia-vue-0.7.2.tgz",
-            "integrity": "sha512-b1DYsL8rG1UHoMJzzcS5Fc5RLtWJb1+Mh6l9HDW3HzRtHyRflshfgj2FICtd005bfNahBcmGSWIK/JW1zMU12g==",
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/@inertiajs/inertia-vue/-/inertia-vue-0.8.0.tgz",
+            "integrity": "sha512-+AQUo0lDArGGD9pj66pRju/gTHzVDYRI01c8htS1vqJeFORx7r5pvqC+QqBOGpwb7I5K15BUzLoxifUe+61oUw==",
             "dependencies": {
                 "lodash.clonedeep": "^4.5.0",
                 "lodash.isequal": "^4.5.0"
             },
             "peerDependencies": {
-                "@inertiajs/inertia": "^0.10.0",
+                "@inertiajs/inertia": "^0.11.0",
                 "vue": "^2.6.0"
             }
         },
@@ -16614,9 +16614,9 @@
             "dev": true
         },
         "@inertiajs/inertia": {
-            "version": "0.10.1",
-            "resolved": "https://registry.npmjs.org/@inertiajs/inertia/-/inertia-0.10.1.tgz",
-            "integrity": "sha512-Ntyaerh07QnpIOxC+qsteUZ9OGVWfogpg3fCkSxciaX6AZyYLT6t7IFPkefPShb9LC2G4Woh1hel4t/pMr2vRQ==",
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/@inertiajs/inertia/-/inertia-0.11.0.tgz",
+            "integrity": "sha512-QF4hctgFC+B/t/WClCwfOla+WoDE9iTltQJ0u+DCfjl0KdGoCvIxYiNtuH8h8oM+RQMb8orjbpW3pHapjYI5Vw==",
             "requires": {
                 "axios": "^0.21.1",
                 "deepmerge": "^4.0.0",
@@ -16634,9 +16634,9 @@
             }
         },
         "@inertiajs/inertia-vue": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/@inertiajs/inertia-vue/-/inertia-vue-0.7.2.tgz",
-            "integrity": "sha512-b1DYsL8rG1UHoMJzzcS5Fc5RLtWJb1+Mh6l9HDW3HzRtHyRflshfgj2FICtd005bfNahBcmGSWIK/JW1zMU12g==",
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/@inertiajs/inertia-vue/-/inertia-vue-0.8.0.tgz",
+            "integrity": "sha512-+AQUo0lDArGGD9pj66pRju/gTHzVDYRI01c8htS1vqJeFORx7r5pvqC+QqBOGpwb7I5K15BUzLoxifUe+61oUw==",
             "requires": {
                 "lodash.clonedeep": "^4.5.0",
                 "lodash.isequal": "^4.5.0"

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
         "vue-template-compiler": "^2.6.14"
     },
     "dependencies": {
-        "@inertiajs/inertia": "^0.10.1",
-        "@inertiajs/inertia-vue": "^0.7.2",
+        "@inertiajs/inertia": "^0.11.0",
+        "@inertiajs/inertia-vue": "^0.8.0",
         "@wmde/wikit-tokens": "^3.0.0-alpha.6",
         "@wmde/wikit-vue-components": "^2.1.0-alpha.10",
         "date-fns": "^2.28.0",

--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -32,7 +32,8 @@ async function setupI18n(locale: string): Promise<void>{
 
                 return page
             },
-            setup({ el, app, props }) {
+            setup({ el, app, props, plugin }) {
+                Vue.use(plugin)
                 new Vue({
                     render: h => h(app, props),
                     store


### PR DESCRIPTION
Autoregistration of InertiaPlugin has been removed. It needs to be added manually since 0.8.0. More info: https://inertiajs.com/releases/inertia-vue-0.8.0-2022-01-07

Bug: [T311401](https://phabricator.wikimedia.org/T311401)