### PR TITLE
Update version of wikit and wikit-tokens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,8 @@
             "dependencies": {
                 "@inertiajs/inertia": "^0.11.0",
                 "@inertiajs/inertia-vue": "^0.8.0",
-                "@wmde/wikit-tokens": "^3.0.0-alpha.6",
-                "@wmde/wikit-vue-components": "^2.1.0-alpha.10",
+                "@wmde/wikit-tokens": "^2.1.0-alpha.13",
+                "@wmde/wikit-vue-components": "^2.1.0-alpha.13",
                 "date-fns": "^2.29.1",
                 "lodash": "^4.17.21",
                 "ress": "^5.0.2",
@@ -3629,28 +3629,23 @@
             }
         },
         "node_modules/@wmde/wikit-tokens": {
-            "version": "3.0.0-alpha.6",
-            "resolved": "https://registry.npmjs.org/@wmde/wikit-tokens/-/wikit-tokens-3.0.0-alpha.6.tgz",
-            "integrity": "sha512-oNB61nnE2DbwwFWgGWxh+1u9KciMrSyEq8lVvU663+K035bC96EOVpI8D/bqOQ2QxpRrEGRhYvzcXj9f3p8AXA=="
+            "version": "2.1.0-alpha.13",
+            "resolved": "https://registry.npmjs.org/@wmde/wikit-tokens/-/wikit-tokens-2.1.0-alpha.13.tgz",
+            "integrity": "sha512-fvit58V8L25Pj5U1FjqIzZfQrt1l8EvDiN99zEQZsafJ8+kN22KZx2SikgjRRckIJeosACn07rDGlglF3CtkMQ=="
         },
         "node_modules/@wmde/wikit-vue-components": {
-            "version": "2.1.0-alpha.12",
-            "resolved": "https://registry.npmjs.org/@wmde/wikit-vue-components/-/wikit-vue-components-2.1.0-alpha.12.tgz",
-            "integrity": "sha512-K0vafGGoR5vYnkNxUK9AH9fc5OVsMTHdVjmrZdPT2BdC/jdLBKCxDBdO1BAERWkAULRDF0psFv885apkcQhRyA==",
+            "version": "2.1.0-alpha.13",
+            "resolved": "https://registry.npmjs.org/@wmde/wikit-vue-components/-/wikit-vue-components-2.1.0-alpha.13.tgz",
+            "integrity": "sha512-SoCy1InY50TRnKA/5AJ4Zj5U8g08IdzqWaG7lxz/YMc7ZwHFoTr7eo2b3SDdhBl2v4JSlHucm8T3e9lbbKmoAw==",
             "dependencies": {
                 "@vue/composition-api": "^1.0.0-beta.20",
-                "@wmde/wikit-tokens": "^2.1.0-alpha.12",
+                "@wmde/wikit-tokens": "^2.1.0-alpha.13",
                 "core-js": "^3.7.0",
                 "lodash.debounce": "^4.0.8",
                 "lodash.isequal": "^4.5.0",
                 "ress": "^3.0.0",
                 "vue": "^2.6.12"
             }
-        },
-        "node_modules/@wmde/wikit-vue-components/node_modules/@wmde/wikit-tokens": {
-            "version": "2.1.0-alpha.12",
-            "resolved": "https://registry.npmjs.org/@wmde/wikit-tokens/-/wikit-tokens-2.1.0-alpha.12.tgz",
-            "integrity": "sha512-r55MkQ7Hq6TA5VOusbAZFbe8TQBFeSkwJksU4sk6NviEB1KDCAva5IW7MGeGlX5x773T03oLUi6Xd2yq3wtNsQ=="
         },
         "node_modules/@wmde/wikit-vue-components/node_modules/ress": {
             "version": "3.0.0",
@@ -18251,17 +18246,17 @@
             "requires": {}
         },
         "@wmde/wikit-tokens": {
-            "version": "3.0.0-alpha.6",
-            "resolved": "https://registry.npmjs.org/@wmde/wikit-tokens/-/wikit-tokens-3.0.0-alpha.6.tgz",
-            "integrity": "sha512-oNB61nnE2DbwwFWgGWxh+1u9KciMrSyEq8lVvU663+K035bC96EOVpI8D/bqOQ2QxpRrEGRhYvzcXj9f3p8AXA=="
+            "version": "2.1.0-alpha.13",
+            "resolved": "https://registry.npmjs.org/@wmde/wikit-tokens/-/wikit-tokens-2.1.0-alpha.13.tgz",
+            "integrity": "sha512-fvit58V8L25Pj5U1FjqIzZfQrt1l8EvDiN99zEQZsafJ8+kN22KZx2SikgjRRckIJeosACn07rDGlglF3CtkMQ=="
         },
         "@wmde/wikit-vue-components": {
-            "version": "2.1.0-alpha.12",
-            "resolved": "https://registry.npmjs.org/@wmde/wikit-vue-components/-/wikit-vue-components-2.1.0-alpha.12.tgz",
-            "integrity": "sha512-K0vafGGoR5vYnkNxUK9AH9fc5OVsMTHdVjmrZdPT2BdC/jdLBKCxDBdO1BAERWkAULRDF0psFv885apkcQhRyA==",
+            "version": "2.1.0-alpha.13",
+            "resolved": "https://registry.npmjs.org/@wmde/wikit-vue-components/-/wikit-vue-components-2.1.0-alpha.13.tgz",
+            "integrity": "sha512-SoCy1InY50TRnKA/5AJ4Zj5U8g08IdzqWaG7lxz/YMc7ZwHFoTr7eo2b3SDdhBl2v4JSlHucm8T3e9lbbKmoAw==",
             "requires": {
                 "@vue/composition-api": "^1.0.0-beta.20",
-                "@wmde/wikit-tokens": "^2.1.0-alpha.12",
+                "@wmde/wikit-tokens": "^2.1.0-alpha.13",
                 "core-js": "^3.7.0",
                 "lodash.debounce": "^4.0.8",
                 "lodash.isequal": "^4.5.0",
@@ -18269,11 +18264,6 @@
                 "vue": "^2.6.12"
             },
             "dependencies": {
-                "@wmde/wikit-tokens": {
-                    "version": "2.1.0-alpha.12",
-                    "resolved": "https://registry.npmjs.org/@wmde/wikit-tokens/-/wikit-tokens-2.1.0-alpha.12.tgz",
-                    "integrity": "sha512-r55MkQ7Hq6TA5VOusbAZFbe8TQBFeSkwJksU4sk6NviEB1KDCAva5IW7MGeGlX5x773T03oLUi6Xd2yq3wtNsQ=="
-                },
                 "ress": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/ress/-/ress-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "dependencies": {
         "@inertiajs/inertia": "^0.11.0",
         "@inertiajs/inertia-vue": "^0.8.0",
-        "@wmde/wikit-tokens": "^3.0.0-alpha.6",
-        "@wmde/wikit-vue-components": "^2.1.0-alpha.10",
+        "@wmde/wikit-tokens": "^2.1.0-alpha.13",
+        "@wmde/wikit-vue-components": "^2.1.0-alpha.13",
         "date-fns": "^2.29.1",
         "lodash": "^4.17.21",
         "ress": "^5.0.2",


### PR DESCRIPTION
This change should show full opacity in the TextArea placeholder in Firefox and the Textarea placeholder font color should be `#72777d`

Bug: [T312633](https://phabricator.wikimedia.org/T312633)