### PR TITLE
Update Jest-related npm dependencies to latest ^28

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
                 "vuex": "^3.6.2"
             },
             "devDependencies": {
-                "@types/jest": "^28.1.6",
+                "@types/jest": "^28.1.8",
                 "@types/lodash": "^4.14.182",
                 "@types/uuid": "^8.3.4",
                 "@typescript-eslint/eslint-plugin": "^5.36.2",
@@ -38,7 +38,7 @@
                 "resolve-url-loader": "^5.0.0",
                 "sass": "^1.54.0",
                 "sass-loader": "^13.0.2",
-                "ts-jest": "^28.0.7",
+                "ts-jest": "^28.0.8",
                 "ts-loader": "^9.3.1",
                 "typescript": "^4.7.4",
                 "vue-jest": "^3.0.7",
@@ -2949,12 +2949,12 @@
             }
         },
         "node_modules/@types/jest": {
-            "version": "28.1.6",
-            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.6.tgz",
-            "integrity": "sha512-0RbGAFMfcBJKOmqRazM8L98uokwuwD5F8rHrv/ZMbrZBwVOWZUyPG6VFNscjYr/vjM3Vu4fRrCPbOs42AfemaQ==",
+            "version": "28.1.8",
+            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.8.tgz",
+            "integrity": "sha512-8TJkV++s7B6XqnDrzR1m/TT0A0h948Pnl/097veySPN67VRAgQ4gZ7n2KfJo2rVq6njQjdxU3GCCyDvAeuHoiw==",
             "dev": true,
             "dependencies": {
-                "jest-matcher-utils": "^28.0.0",
+                "expect": "^28.0.0",
                 "pretty-format": "^28.0.0"
             }
         },
@@ -14020,9 +14020,9 @@
             }
         },
         "node_modules/ts-jest": {
-            "version": "28.0.7",
-            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-28.0.7.tgz",
-            "integrity": "sha512-wWXCSmTwBVmdvWrOpYhal79bDpioDy4rTT+0vyUnE3ZzM7LOAAGG9NXwzkEL/a516rQEgnMmS/WKP9jBPCVJyA==",
+            "version": "28.0.8",
+            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-28.0.8.tgz",
+            "integrity": "sha512-5FaG0lXmRPzApix8oFG8RKjAz4ehtm8yMKOTy5HX3fY6W8kmvOrmcY0hKDElW52FJov+clhUbrKAqofnj4mXTg==",
             "dev": true,
             "dependencies": {
                 "bs-logger": "0.x",
@@ -17709,12 +17709,12 @@
             }
         },
         "@types/jest": {
-            "version": "28.1.6",
-            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.6.tgz",
-            "integrity": "sha512-0RbGAFMfcBJKOmqRazM8L98uokwuwD5F8rHrv/ZMbrZBwVOWZUyPG6VFNscjYr/vjM3Vu4fRrCPbOs42AfemaQ==",
+            "version": "28.1.8",
+            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.8.tgz",
+            "integrity": "sha512-8TJkV++s7B6XqnDrzR1m/TT0A0h948Pnl/097veySPN67VRAgQ4gZ7n2KfJo2rVq6njQjdxU3GCCyDvAeuHoiw==",
             "dev": true,
             "requires": {
-                "jest-matcher-utils": "^28.0.0",
+                "expect": "^28.0.0",
                 "pretty-format": "^28.0.0"
             }
         },
@@ -26099,9 +26099,9 @@
             }
         },
         "ts-jest": {
-            "version": "28.0.7",
-            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-28.0.7.tgz",
-            "integrity": "sha512-wWXCSmTwBVmdvWrOpYhal79bDpioDy4rTT+0vyUnE3ZzM7LOAAGG9NXwzkEL/a516rQEgnMmS/WKP9jBPCVJyA==",
+            "version": "28.0.8",
+            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-28.0.8.tgz",
+            "integrity": "sha512-5FaG0lXmRPzApix8oFG8RKjAz4ehtm8yMKOTy5HX3fY6W8kmvOrmcY0hKDElW52FJov+clhUbrKAqofnj4mXTg==",
             "dev": true,
             "requires": {
                 "bs-logger": "0.x",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "production": "mix --production"
     },
     "devDependencies": {
-        "@types/jest": "^28.1.6",
+        "@types/jest": "^28.1.8",
         "@types/lodash": "^4.14.182",
         "@types/uuid": "^8.3.4",
         "@typescript-eslint/eslint-plugin": "^5.36.2",
@@ -34,7 +34,7 @@
         "resolve-url-loader": "^5.0.0",
         "sass": "^1.54.0",
         "sass-loader": "^13.0.2",
-        "ts-jest": "^28.0.7",
+        "ts-jest": "^28.0.8",
         "ts-loader": "^9.3.1",
         "typescript": "^4.7.4",
         "vue-jest": "^3.0.7",


### PR DESCRIPTION
But I don’t think we can upgrade to ^29 yet, it doesn’t look like ts-jest has a matching version for that.

Bug: [T315965](https://phabricator.wikimedia.org/T315965)