### PR TITLE
Remove explicit uuid npm dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
                 "date-fns": "^2.29.2",
                 "lodash": "^4.17.21",
                 "ress": "^5.0.2",
-                "uuid": "^8.3.2",
                 "vue": "^2.6.14",
                 "vue-banana-i18n": "1.5.0",
                 "vuex": "^3.6.2"
@@ -20,7 +19,6 @@
             "devDependencies": {
                 "@types/jest": "^28.1.8",
                 "@types/lodash": "^4.14.184",
-                "@types/uuid": "^8.3.4",
                 "@typescript-eslint/eslint-plugin": "^5.36.2",
                 "@typescript-eslint/parser": "^5.36.2",
                 "@vue/eslint-config-typescript": "^11.0.0",
@@ -3091,12 +3089,6 @@
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
             "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
-            "dev": true
-        },
-        "node_modules/@types/uuid": {
-            "version": "8.3.4",
-            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-            "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
             "dev": true
         },
         "node_modules/@types/ws": {
@@ -14498,6 +14490,7 @@
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
             "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "dev": true,
             "bin": {
                 "uuid": "dist/bin/uuid"
             }
@@ -17851,12 +17844,6 @@
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
             "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
-            "dev": true
-        },
-        "@types/uuid": {
-            "version": "8.3.4",
-            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-            "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
             "dev": true
         },
         "@types/ws": {
@@ -26442,7 +26429,8 @@
         "uuid": {
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "dev": true
         },
         "v8-to-istanbul": {
             "version": "9.0.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "devDependencies": {
         "@types/jest": "^28.1.8",
         "@types/lodash": "^4.14.184",
-        "@types/uuid": "^8.3.4",
         "@typescript-eslint/eslint-plugin": "^5.36.2",
         "@typescript-eslint/parser": "^5.36.2",
         "@vue/eslint-config-typescript": "^11.0.0",
@@ -49,7 +48,6 @@
         "date-fns": "^2.29.2",
         "lodash": "^4.17.21",
         "ress": "^5.0.2",
-        "uuid": "^8.3.2",
         "vue": "^2.6.14",
         "vue-banana-i18n": "1.5.0",
         "vuex": "^3.6.2"


### PR DESCRIPTION
We haven’t imported the package since 450a139894 replaced the local Dialog component (which uses uuid v4 for an HTML ID) with the Wikit version.

Bug: [T315965](https://phabricator.wikimedia.org/T315965)