### PR TITLE
Add controller and endpoint for retrieving 15 random mismatches

### DIFF
--- a/app/Http/Controllers/RandomizeController.php
+++ b/app/Http/Controllers/RandomizeController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Mismatch;
 use App\Services\StatsdAPIClient;
+use Illuminate\Support\Facades\Auth;
 
 class RandomizeController extends Controller
 {
@@ -39,6 +40,13 @@ class RandomizeController extends Controller
                 [ResultsController::class, 'index'],
                 ['ids' => $itemIdsToString]
             );
+        } else {
+            $user = Auth::user() ? [
+                'name' => Auth::user()->username,
+                'id' => Auth::user()->mw_userid
+            ] : null;
+            
+            return inertia('Results', [ 'user' => $user ]);
         }
     }
 }

--- a/app/Http/Controllers/RandomizeController.php
+++ b/app/Http/Controllers/RandomizeController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Mismatch;
+use App\Services\StatsdAPIClient;
+
+class RandomizeController extends Controller
+{
+    use Traits\ReviewMismatch, Traits\StatsTracker;
+
+    /**
+     * Instantiate a new controller instance.
+     *
+     * @return void
+     */
+    public function __construct(StatsdAPIClient $statsd)
+    {
+        $this->middleware('simulateError');
+        $this->statsd = $statsd;
+    }
+
+    public function index()
+    {
+        $itemIds = Mismatch::with('importMeta.user')
+            ->distinct()
+            ->where('review_status', 'pending')
+            ->whereHas('importMeta', function ($import) {
+                $import->where('expires', '>=', now());
+            })
+            ->inRandomOrder()
+            ->limit(15)
+            ->pluck('item_id')->toArray();
+        
+        if (count($itemIds) > 0) {
+            $itemIdsToString = implode('|', $itemIds);
+
+            return redirect()->action(
+                [ResultsController::class, 'index'],
+                ['ids' => $itemIdsToString]
+            );
+        }
+    }
+}

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -28,6 +28,7 @@
     "column-upload-info": "Upload info",
     "column-external-source": "External source",
     "no-mismatches-found-message": "No mismatches have been found for:",
+    "no-mismatches-available-for-review": "There are currently no mismatches available for review.",
     "review-status-pending": "Awaiting review",
     "review-status-wikidata": "Wrong data on Wikidata",
     "review-status-external": "Wrong data on external source",

--- a/public/i18n/qqq.json
+++ b/public/i18n/qqq.json
@@ -25,6 +25,7 @@
     "column-upload-info": "Upload Info column on mismatches table",
     "column-external-source": "External source column on mismatches table",
     "no-mismatches-found-message": "A message when no mismatches have been found for the provided Item Ids",
+    "no-mismatches-available-for-review": "A message when no unreviewed mismatches have been found. This message can be displayed when searching for random mismatches",
     "review-status-pending": "Label for pending review status. Default value for all un-reviewed mismatches",
     "review-status-wikidata": "Label that indicates that the mismatch is due to wrong data on Wikidata. Used as an option in the review decision dropdown",
     "review-status-external": "Label that indicates that the mismatch is due to wrong data on the external database. Used as an option in the review decision dropdown",

--- a/resources/js/Pages/Results.vue
+++ b/resources/js/Pages/Results.vue
@@ -61,6 +61,10 @@
                     </wikit-link>
                 </span>
             </Message>
+            <!-- The Results page without item_ids is used by RandomizeController. -->
+            <Message type="notice" v-if="item_ids.length === 0">
+                <span>{{ $i18n('no-mismatches-available-for-review') }}</span>
+            </Message>
             <Message type="warning" v-if="!user">
                 <span v-i18n-html:log-in-message="['/auth/login']"></span>
             </Message>

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use App\Models\ImportMeta;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Auth;
+use App\Http\Controllers\RandomizeController;
 use App\Http\Controllers\ResultsController;
 use App\Http\Controllers\ImportsOverviewController;
 
@@ -31,6 +32,9 @@ Route::get('/', function () {
 
 Route::get('/results', [ResultsController::class, 'index'])
     ->name('results');
+
+Route::get('/random', [RandomizeController::class, 'index'])
+    ->name('random');
 
 Route::put('/mismatch-review', [ResultsController::class, 'update'])
     ->middleware('auth')

--- a/tests/Feature/WebRandomRouteTest.php
+++ b/tests/Feature/WebRandomRouteTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\ImportMeta;
+use App\Models\Mismatch;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Inertia\Testing\AssertableInertia as Assert;
+use App\Models\User;
+
+class WebRandomRouteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Test the /random route
+     *
+     *  @return void
+     */
+    public function test_random_route_when_no_unreviewed_ids_available()
+    {
+
+        $import = ImportMeta::factory()
+        ->for(User::factory()->uploader())
+        ->create();
+
+        $mismatch = Mismatch::factory()
+            ->for($import)
+            ->state([
+                'review_status' => 'wikidata'
+            ])
+            ->create();
+
+        $response = $this->get(route('random'));
+
+        $response->assertSuccessful();
+        $response->assertViewIs('app')
+            ->assertInertia(function (Assert $page) {
+                $page->component('Results')
+                    ->missing('item_ids')
+                    ->missing('results');
+            });
+    }
+
+     /**
+     * Test the /random route redirects to /results when there are items to review
+     *
+     *  @return void
+     */
+    public function test_random_route_redirects_when_unreviewed_items_exist()
+    {
+        
+        $import = ImportMeta::factory()
+        ->for(User::factory()->uploader())
+        ->create();
+
+        $mismatch = Mismatch::factory()
+            ->for($import)
+            ->state([
+                'review_status' => 'pending'
+            ])
+            ->create();
+        
+        $redirect = $this->get(route('random'))
+            ->assertRedirect(route('results', ['ids' => $mismatch->item_id]));
+
+        // follow the redirect
+        $this->get($redirect->headers->get('Location'))
+            ->assertInertia(function (Assert $page) {
+                $page->component('Results')
+                ->has('item_ids')
+                ->has('results');
+            });
+    }
+}


### PR DESCRIPTION
For easy testing go to the route `/random`. I suggest removing the 
```
->whereHas('importMeta', function ($import) {
       $import->where('expires', '>=', now());
})
``` 
in both `RandomizeController` and `ResultsController` and in case you don't have current non-expired items to test with. 

Bug: [T302289](https://phabricator.wikimedia.org/T302289)