### PR TITLE
Add method to get datatype of properties

### DIFF
--- a/app/Services/WikibaseAPIClient.php
+++ b/app/Services/WikibaseAPIClient.php
@@ -83,4 +83,24 @@ class WikibaseAPIClient
             ->map('strip_tags')
             ->toArray();
     }
+
+    public function getEntities(array $ids, array $props): Response
+    {
+        return $this->get('wbgetentities', [
+            'ids' => implode('|', $ids),
+            'props' => implode('|', $props),
+        ]);
+    }
+
+    public function getPropertyDatatypes(array $ids): array
+    {
+        return collect($ids)
+            ->chunk(50) // wbgetentities allows up to 50 IDs per request
+            ->map(function ($chunk) {
+                $response = $this->getEntities($chunk->toArray(), ['datatype']);
+                return array_column($response['entities'], 'datatype', 'id');
+            })
+            ->collapse()
+            ->toArray();
+    }
 }


### PR DESCRIPTION
Bug: [T321173](https://phabricator.wikimedia.org/T321173)

----

Not used directly yet (I have some WIP in the `parse+format` branch, commit 4b93d386b9), but uploaded as a separate pull request to unblock [T321165](https://phabricator.wikimedia.org/T321165).