### PR TITLE
Add sensible default port to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,8 @@ APP_NAME=Laravel
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
-APP_URL=http://localhost
+APP_PORT=1337
+APP_URL="http://localhost:${APP_PORT}"
 ASSET_URL="${APP_URL}"
 
 MEDIAWIKI_OAUTH_CLIENT_ID=


### PR DESCRIPTION
Instead of letting many new developers run into errors while following the "Quickstart" guide, set a default that has a good chance to work out of the box.

Furthermore, if that APP_PORT env variable is available, it should be part of the example env file in either way, because that file gives the impression of being comprehensive.
