### PR TITLE
Add advice about DB port to docs/README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -315,6 +315,9 @@ FORWARD_DB_PORT=3308
 ##...
 ```
 
+(You *don’t* need to adjust the `DB_PORT` in `.env.dusk.local` after this –
+that variable needs to match the `.env` `DB_PORT`, which you haven’t changed, not the `FORWARD_DB_PORT`.)
+
 #### `laravel.test`
 
 **Problem:** Sail refuses to start with the following error.


### PR DESCRIPTION
Apparently this confused me when I initially tried to set up mismatch finder (September 6 according to git) and I stashed it away at the time. Still seems helpful to add, I think.