### PR TITLE
Add methods to parse+format multiple data values at once

### DIFF
--- a/app/Rules/WikidataValue.php
+++ b/app/Rules/WikidataValue.php
@@ -38,7 +38,8 @@ class WikidataValue implements Rule
         ] = $value;
 
         try {
-            $this->wikidata->parseValue($property, $wikidataValue);
+            // TODO would be nice to validate batches of values at once
+            $this->wikidata->parseValues([$property => [$wikidataValue]]);
         } catch (WikibaseValueParserException $e) {
             return false;
         }

--- a/tests/Feature/WikibaseAPIClientTest.php
+++ b/tests/Feature/WikibaseAPIClientTest.php
@@ -65,12 +65,22 @@ class WikibaseAPIClientTest extends TestCase
 
         $expected = [
             'P1' => [
-                'abc' => '{"raw":"abc","value":"abc","type":"string","valid":true}',
-                'def' => '{"raw":"def","value":"def","type":"string","valid":true}',
+                'abc' => ['raw' => 'abc', 'value' => 'abc', 'type' => 'string', 'valid' => true],
+                'def' => ['raw' => 'def', 'value' => 'def', 'type' => 'string', 'valid' => true],
             ],
             'P2' => [
-                'Q1' => '{"raw":"Q1","value":{"entity-type":"item","id":"Q1"},"type":"wikibase-entityid","valid":true}',
-                'Q2' => '{"raw":"Q2","value":{"entity-type":"item","id":"Q2"},"type":"wikibase-entityid","valid":true}',
+                'Q1' => [
+                    'raw' => 'Q1',
+                    'value' => ['entity-type' => 'item', 'id' => 'Q1'],
+                    'type' => 'wikibase-entityid',
+                    'valid' => true,
+                ],
+                'Q2' => [
+                    'raw' => 'Q2',
+                    'value' => ['entity-type' => 'item', 'id' => 'Q2'],
+                    'type' => 'wikibase-entityid',
+                    'valid' => true,
+                ],
             ],
         ];
         $this->assertSame($expected, $parsed);
@@ -133,11 +143,11 @@ class WikibaseAPIClientTest extends TestCase
         $client = new WikibaseAPIClient(self::FAKE_API_URL, $mockCache);
         $parsed = $client->formatValues([
             'P1' => [
-                'abc' => '{"type":"string","value":"abc"}',
-                'def' => '{"type":"string","value":"def"}',
+                'abc' => ['type' => 'string', 'value' => 'abc'],
+                'def' => ['type' => 'string', 'value' => 'def'],
             ],
             'P2' => [
-                'xyz' => '{"type":"string","value":"xyz"}',
+                'xyz' => ['type' => 'string', 'value' => 'xyz'],
             ],
         ], 'en');
 
@@ -312,7 +322,7 @@ class WikibaseAPIClientTest extends TestCase
     public function methodProvider(): iterable
     {
         yield 'parseValuesForProperty' => ['parseValuesForProperty', ['P1234', ['fake-value']]];
-        yield 'formatValueForProperty' => ['formatValueForProperty', ['P1234', 'fake-value', 'en']];
+        yield 'formatValueForProperty' => ['formatValueForProperty', ['P1234', ['fake-value'], 'en']];
         yield 'formatEntities' => ['formatEntities', [['Q1234'], 'en']];
         yield 'getEntities' => ['getEntities', [['P1234'], ['datatype']]];
     }

--- a/tests/Unit/WikidataValueTest.php
+++ b/tests/Unit/WikidataValueTest.php
@@ -13,7 +13,7 @@ class WikidataValueTest extends TestCase
     public function test_passes_validation_when_client_returns(): void
     {
         $mockApiClient = Mockery::mock(WikibaseAPIClient::class);
-        $mockApiClient->shouldReceive('parseValue')->once();
+        $mockApiClient->shouldReceive('parseValues')->once();
 
         $rule = new WikidataValue($mockApiClient);
 
@@ -26,7 +26,7 @@ class WikidataValueTest extends TestCase
     public function test_fails_validation_when_client_throws(): void
     {
         $mockApiClient = Mockery::mock(WikibaseAPIClient::class);
-        $mockApiClient->shouldReceive('parseValue')->andThrow(
+        $mockApiClient->shouldReceive('parseValues')->andThrow(
             new WikibaseValueParserException()
         );
 


### PR DESCRIPTION
See individual commit messages. This pull request is based on #444; see also the `parse+format-3` branch (currently commit b303e24f19) for how this can be used (still needs to be cleaned up – but I think the two commits in this PR are ready for review).