### PR TITLE
Correctly send list parameters to the action API

### DIFF
--- a/app/Services/WikibaseAPIClient.php
+++ b/app/Services/WikibaseAPIClient.php
@@ -27,6 +27,15 @@ class WikibaseAPIClient
         $this->cache = $cache;
     }
 
+    private function list(array $values): string
+    {
+        if (str_contains(implode($values), '|')) {
+            return "\x1f" . implode("\x1f", $values);
+        } else {
+            return implode('|', $values);
+        }
+    }
+
     private function get(string $action, array $params): Response
     {
         $response = Http::withMiddleware($this->cache)
@@ -58,7 +67,7 @@ class WikibaseAPIClient
     {
         try {
             return $this->get('wbparsevalue', [
-                'values' => implode('|', $values),
+                'values' => $this->list($values),
                 'property' => $property,
                 'validate' => true
             ]);
@@ -152,7 +161,7 @@ class WikibaseAPIClient
     public function formatEntities(array $ids, string $lang): Response
     {
         $response = $this->get('wbformatentities', [
-            'ids' => implode('|', $ids),
+            'ids' => $this->list($ids),
             'uselang' => $lang
         ]);
 
@@ -178,8 +187,8 @@ class WikibaseAPIClient
     public function getEntities(array $ids, array $props): Response
     {
         return $this->get('wbgetentities', [
-            'ids' => implode('|', $ids),
-            'props' => implode('|', $props),
+            'ids' => $this->list($ids),
+            'props' => $this->list($props),
         ]);
     }
 

--- a/tests/Feature/WikibaseAPIClientTest.php
+++ b/tests/Feature/WikibaseAPIClientTest.php
@@ -112,6 +112,33 @@ class WikibaseAPIClientTest extends TestCase
         $this->assertSame(['P123' => []], $data);
     }
 
+    public function test_parse_values_internal_pipe(): void
+    {
+        Http::fake(function (Request $req) {
+            return Http::response(['results' => [
+                ['raw' => 'a|b', 'value' => 'a|b', 'type' => 'string', 'valid' => true],
+                ['raw' => 'c|d', 'value' => 'c|d', 'type' => 'string', 'valid' => true],
+            ]], 200);
+        });
+
+        $mockCache = Mockery::mock(CacheMiddleware::class)->shouldIgnoreMissing();
+
+        $client = new WikibaseAPIClient(self::FAKE_API_URL, $mockCache);
+        $parsed = $client->parseValues(['P1' => ['a|b', 'c|d']]);
+
+        $this->assertActionRequest(self::FAKE_API_URL, 'wbparsevalue', [
+            'values' => "\x1fa|b\x1fc|d",
+            'property' => 'P1',
+            'validate' => true,
+        ]);
+
+        $expected = ['P1' => [
+            'a|b' => '{"raw":"a|b","value":"a|b","type":"string","valid":true}',
+            'c|d' => '{"raw":"c|d","value":"c|d","type":"string","valid":true}',
+        ]];
+        $this->assertSame($expected, $parsed);
+    }
+
     public function test_format_values_returns_values_from_api_responses(): void
     {
         Http::fake(function (Request $req) {


### PR DESCRIPTION
If any list items contain '|', we shouldn’t combine the list items with '|', but instead with U+001F (ASCII Unit Separator), with an additional U+001F at the beginning to mark the payload as using this separator instead of the usual pipe.