### PR TITLE
Correctly send list parameters to the action API

### DIFF
--- a/app/Services/WikibaseAPIClient.php
+++ b/app/Services/WikibaseAPIClient.php
@@ -27,6 +27,15 @@ class WikibaseAPIClient
         $this->cache = $cache;
     }
 
+    private function list(array $values): string
+    {
+        if (str_contains(implode($values), '|')) {
+            return "\x1f" . implode("\x1f", $values);
+        } else {
+            return implode('|', $values);
+        }
+    }
+
     private function get(string $action, array $params): Response
     {
         $response = Http::withMiddleware($this->cache)
@@ -58,7 +67,7 @@ class WikibaseAPIClient
     {
         try {
             return $this->get('wbparsevalue', [
-                'values' => implode('|', $values),
+                'values' => $this->list($values),
                 'property' => $property,
                 'validate' => true
             ]);
@@ -152,7 +161,7 @@ class WikibaseAPIClient
     public function formatEntities(array $ids, string $lang): Response
     {
         $response = $this->get('wbformatentities', [
-            'ids' => implode('|', $ids),
+            'ids' => $this->list($ids),
             'uselang' => $lang
         ]);
 
@@ -178,8 +187,8 @@ class WikibaseAPIClient
     public function getEntities(array $ids, array $props): Response
     {
         return $this->get('wbgetentities', [
-            'ids' => implode('|', $ids),
-            'props' => implode('|', $props),
+            'ids' => $this->list($ids),
+            'props' => $this->list($props),
         ]);
     }
 


### PR DESCRIPTION
If any list items contain '|', we shouldn’t combine the list items with '|', but instead with U+001F (ASCII Unit Separator), with an additional U+001F at the beginning to mark the payload as using this separator instead of the usual pipe.

---

This pull request is a repeat of #452, which I merged too early. It’s based on the `parse+format-2` branch (#449), so that GitHub will only show the one new commit that actually belongs to this pull request; however, it should only be merged after that other branch / PR has been merged into `main`.