### PR TITLE
Make getPropertyDatatypes() return missing properties

### DIFF
--- a/app/Services/WikibaseAPIClient.php
+++ b/app/Services/WikibaseAPIClient.php
@@ -192,13 +192,22 @@ class WikibaseAPIClient
         ]);
     }
 
+    /**
+     * Get the datatypes of the given property IDs.
+     *
+     * @param string[] $ids
+     * @return (string|null)[] Mapping the property ID to the datatype,
+     * or null if the property does not exist.
+     */
     public function getPropertyDatatypes(array $ids): array
     {
         return collect($ids)
             ->chunk(50) // wbgetentities allows up to 50 IDs per request
             ->map(function ($chunk) {
-                $response = $this->getEntities($chunk->toArray(), ['datatype']);
-                return array_column($response['entities'], 'datatype', 'id');
+                $chunkIds = $chunk->toArray();
+                $response = $this->getEntities($chunkIds, ['datatype']);
+                return array_column($response['entities'], 'datatype', 'id') +
+                    array_fill_keys($chunkIds, null);
             })
             ->collapse()
             ->toArray();

--- a/tests/Feature/WikibaseAPIClientTest.php
+++ b/tests/Feature/WikibaseAPIClientTest.php
@@ -296,7 +296,7 @@ class WikibaseAPIClientTest extends TestCase
 
     public function test_get_property_datatypes_returns_datatype_array(): void
     {
-        $fakeIds = ['P1234', 'P5678'];
+        $fakeIds = ['P1234', 'P5678', 'P9'];
         $fakePayload = [
             'action' => 'wbgetentities',
             'format' => 'json',
@@ -315,10 +315,15 @@ class WikibaseAPIClientTest extends TestCase
                 'datatype' => 'time',
                 'id' => 'P5678',
             ],
+            'P9' => [
+                'id' => 'P9',
+                'missing' => '',
+            ],
         ]];
         $expectedResult = [
             'P1234' => 'wikibase-item',
             'P5678' => 'time',
+            'P9' => null,
         ];
 
         Http::fake(function (Request $req) use ($fakePayload, $fakeResponseBody) {


### PR DESCRIPTION
If a property doesn’t exist, map that ID to null instead of not including it in the returned array at all (which is what `array_column()` does, apparently). This means callers don’t have to check if the array key exists or not – most callers only compare `$datatypes[$propertyId]` to a constant string anyways (`=== 'time'`, `=== 'wikibase-item'` etc.), so for them it’s fine if the array contains null (making the comparison false).