### PR TITLE
Fix missing labels on Items without mismatches

### DIFF
--- a/app/Http/Controllers/ResultsController.php
+++ b/app/Http/Controllers/ResultsController.php
@@ -34,10 +34,10 @@ class ResultsController extends Controller
             'id' => Auth::user()->mw_userid
         ] : null;
 
-        $itemIds = $request->input('ids');
+        $requestedItemIds = $request->input('ids');
 
         $mismatches = Mismatch::with('importMeta.user')
-            ->whereIn('item_id', $itemIds)
+            ->whereIn('item_id', $requestedItemIds)
             ->where('review_status', 'pending')
             ->whereHas('importMeta', function ($import) {
                 $import->where('expires', '>=', now());
@@ -61,7 +61,7 @@ class ResultsController extends Controller
         $props = array_merge(
             [
                 'user' => $user,
-                'item_ids' => $itemIds,
+                'item_ids' => $requestedItemIds,
                 // Use wikidata to fetch labels for found entity ids
                 'labels' => $wikidata->getLabels($entityIds, $lang),
                 'formatted_values' => $formattedTimeValues,

--- a/app/Http/Controllers/ResultsController.php
+++ b/app/Http/Controllers/ResultsController.php
@@ -47,9 +47,12 @@ class ResultsController extends Controller
         $propertyIds = $this->extractPropertyIds($mismatches);
         $datatypes = $wikidata->getPropertyDatatypes($propertyIds);
 
-        $entityIds = array_merge(
-            $propertyIds,
-            $this->extractItemIds($mismatches, $datatypes)
+        $entityIds = array_unique(
+            array_merge(
+                $propertyIds,
+                $this->extractItemIds($mismatches, $datatypes),
+                $requestedItemIds
+            )
         );
 
         $lang = App::getLocale();

--- a/tests/Feature/WebResultsRouteTest.php
+++ b/tests/Feature/WebResultsRouteTest.php
@@ -59,6 +59,7 @@ class WebResultsRouteTest extends TestCase
         ->for(User::factory()->uploader())
         ->create();
 
+        $noMismatchQid = 'Q999979999';
         $dateMismatch = Mismatch::factory()
             ->for($import)
             ->datatypeTime()
@@ -100,6 +101,7 @@ class WebResultsRouteTest extends TestCase
         };
 
         $assertLabels = function (Collection $labels) use (
+            $noMismatchQid,
             $dateMismatch,
             $dateMismatchQid,
             $itemMismatch,
@@ -109,6 +111,7 @@ class WebResultsRouteTest extends TestCase
         ) {
             return $labels->has([
                 // labels should include item + property id of each mismatch
+                $noMismatchQid,
                 $dateMismatchQid,
                 $dateMismatch->property_id,
                 $itemMismatchQid,
@@ -127,6 +130,7 @@ class WebResultsRouteTest extends TestCase
         };
 
         $withResultsPage = function (Assert $page) use (
+            $noMismatchQid,
             $dateMismatch,
             $dateMismatchQid,
             $itemMismatch,
@@ -146,7 +150,7 @@ class WebResultsRouteTest extends TestCase
         };
 
         $response = $this->get(route('results', [
-            'ids' => "$dateMismatchQid|$itemMismatchQid|$stringMismatchQid"
+            'ids' => "$dateMismatchQid|$itemMismatchQid|$stringMismatchQid|$noMismatchQid"
         ]));
 
         $response->assertSuccessful();


### PR DESCRIPTION
This was probably introduced in #444, when overlooking to consider that $mismatches does not contain info about Items that do not have mismatches and so fails to retrieve their labels.

TODO:
- [x] actually try it out
- [x] tests
- [x] better commit message

Bug: T321977