### PR TITLE
meta_wikidata_value to replace calendar model if exists

### DIFF
--- a/app/Http/Controllers/ResultsController.php
+++ b/app/Http/Controllers/ResultsController.php
@@ -59,12 +59,26 @@ class ResultsController extends Controller
 
         $timeValues = $this->extractTimeValues($mismatches, $datatypes);
         $parsedTimeValues = $wikidata->parseValues($timeValues);
-        // assert if calendar model is specified
-        if (!empty($mismatches->meta_wikidata_value)) {
-            $parsedTimeValues[ 'calendarmodel' ] =
-            'http://www.wikidata.org/entity/' . $mismatches->meta_wikidata_value;
+        $updatedTimeValues = [];
+
+        foreach ($mismatches as $mismatch) {
+            $pid = $mismatch->property_id;
+            $wikidataValue = $mismatch->wikidata_value;
+            if (isset($parsedTimeValues[$pid][$wikidataValue])) {
+                $metaWikidataValue = $mismatch->meta_wikidata_value;
+                $key = $metaWikidataValue . '|' . $wikidataValue;
+                $updatedTimeValues[$pid][$key] = $parsedTimeValues[$pid][$wikidataValue];
+                // assert if a calendar model is specified and assign it if so
+                if ($metaWikidataValue) {
+                    var_dump($updatedTimeValues[$pid][$key]);
+                    $calendarModel = 'http://www.wikidata.org/entity/' . $metaWikidataValue;
+                    $updatedTimeValues[$pid][$key]['value']['calendarmodel'] = $calendarModel;
+                    var_dump($updatedTimeValues[$pid][$key]);
+                }
+            }
         }
-        $formattedTimeValues = $wikidata->formatValues($parsedTimeValues, $lang);
+
+        $formattedTimeValues = $wikidata->formatValues($updatedTimeValues, $lang);
 
 
         $props = array_merge(

--- a/app/Http/Controllers/ResultsController.php
+++ b/app/Http/Controllers/ResultsController.php
@@ -59,7 +59,13 @@ class ResultsController extends Controller
 
         $timeValues = $this->extractTimeValues($mismatches, $datatypes);
         $parsedTimeValues = $wikidata->parseValues($timeValues);
+        // assert if calendar model is specified
+        if ( !empty( $mismatches->meta_wikidata_value ) ) {
+            $parsedTimeValues[ 'calendarmodel' ] =
+            'http://www.wikidata.org/entity/' . $mismatches->meta_wikidata_value;
+        }
         $formattedTimeValues = $wikidata->formatValues($parsedTimeValues, $lang);
+
 
         $props = array_merge(
             [

--- a/app/Http/Controllers/ResultsController.php
+++ b/app/Http/Controllers/ResultsController.php
@@ -60,7 +60,7 @@ class ResultsController extends Controller
         $timeValues = $this->extractTimeValues($mismatches, $datatypes);
         $parsedTimeValues = $wikidata->parseValues($timeValues);
         // assert if calendar model is specified
-        if ( !empty( $mismatches->meta_wikidata_value ) ) {
+        if (!empty($mismatches->meta_wikidata_value)) {
             $parsedTimeValues[ 'calendarmodel' ] =
             'http://www.wikidata.org/entity/' . $mismatches->meta_wikidata_value;
         }

--- a/resources/js/Pages/Results.vue
+++ b/resources/js/Pages/Results.vue
@@ -274,8 +274,9 @@
                     };
                     if (mismatch.property_id in this.formatted_values) {
                         const formattedValues = this.formatted_values[mismatch.property_id];
-                        if (mismatch.wikidata_value in formattedValues) {
-                            labelled.value_label = formattedValues[mismatch.wikidata_value];
+                        const key = mismatch.meta_wikidata_value + '|' + mismatch.wikidata_value;
+                        if (key in formattedValues) {
+                            labelled.value_label = formattedValues[key];
                         }
                     }
                     return labelled;

--- a/tests/Feature/WebResultsRouteTest.php
+++ b/tests/Feature/WebResultsRouteTest.php
@@ -146,15 +146,10 @@ class WebResultsRouteTest extends TestCase
                 ->has("results.$itemMismatchQid.0", $isMismatch($itemMismatch))
                 ->has("results.$stringMismatchQid.0", $isMismatch($stringMismatch))
                 ->where("labels", $assertLabels)
-                ->where(
-                    "formatted_values.
-                    {$dateMismatch->property_id}.
-                    {$dateMismatch->meta_wikidata_value}|
-                    {$dateMismatch->wikidata_value}",
-                    $assertDate
-                );
+                // phpcs:disable Generic.Files.LineLength
+                ->where("formatted_values.{$dateMismatch->property_id}.{$dateMismatch->meta_wikidata_value}|{$dateMismatch->wikidata_value}", $assertDate);
         };
-
+                //phpcs:enable
         $response = $this->get(route('results', [
             'ids' => "$dateMismatchQid|$itemMismatchQid|$stringMismatchQid|$noMismatchQid"
         ]));

--- a/tests/Feature/WebResultsRouteTest.php
+++ b/tests/Feature/WebResultsRouteTest.php
@@ -146,8 +146,8 @@ class WebResultsRouteTest extends TestCase
                 ->has("results.$itemMismatchQid.0", $isMismatch($itemMismatch))
                 ->has("results.$stringMismatchQid.0", $isMismatch($stringMismatch))
                 ->where("labels", $assertLabels)
-                ->where("formatted_values.{$dateMismatch->property_id}.{$dateMismatch->wikidata_value}", $assertDate);
-        };
+                ->where("formatted_values.{$dateMismatch->property_id}.{$dateMismatch->meta_wikidata_value}|{$dateMismatch->wikidata_value}", $assertDate);
+            };
 
         $response = $this->get(route('results', [
             'ids' => "$dateMismatchQid|$itemMismatchQid|$stringMismatchQid|$noMismatchQid"

--- a/tests/Feature/WebResultsRouteTest.php
+++ b/tests/Feature/WebResultsRouteTest.php
@@ -146,8 +146,14 @@ class WebResultsRouteTest extends TestCase
                 ->has("results.$itemMismatchQid.0", $isMismatch($itemMismatch))
                 ->has("results.$stringMismatchQid.0", $isMismatch($stringMismatch))
                 ->where("labels", $assertLabels)
-                ->where("formatted_values.{$dateMismatch->property_id}.{$dateMismatch->meta_wikidata_value}|{$dateMismatch->wikidata_value}", $assertDate);
-            };
+                ->where(
+                    "formatted_values.
+                    {$dateMismatch->property_id}.
+                    {$dateMismatch->meta_wikidata_value}|
+                    {$dateMismatch->wikidata_value}",
+                    $assertDate
+                );
+        };
 
         $response = $this->get(route('results', [
             'ids' => "$dateMismatchQid|$itemMismatchQid|$stringMismatchQid|$noMismatchQid"

--- a/tests/Feature/WebResultsRouteTest.php
+++ b/tests/Feature/WebResultsRouteTest.php
@@ -146,10 +146,10 @@ class WebResultsRouteTest extends TestCase
                 ->has("results.$itemMismatchQid.0", $isMismatch($itemMismatch))
                 ->has("results.$stringMismatchQid.0", $isMismatch($stringMismatch))
                 ->where("labels", $assertLabels)
-                // phpcs:disable Generic.Files.LineLength
+                // phpcs:ignore
                 ->where("formatted_values.{$dateMismatch->property_id}.{$dateMismatch->meta_wikidata_value}|{$dateMismatch->wikidata_value}", $assertDate);
         };
-                //phpcs:enable
+
         $response = $this->get(route('results', [
             'ids' => "$dateMismatchQid|$itemMismatchQid|$stringMismatchQid|$noMismatchQid"
         ]));

--- a/tests/Vue/Pages/Results.spec.js
+++ b/tests/Vue/Pages/Results.spec.js
@@ -168,6 +168,7 @@ describe('Results.vue', () => {
                 item_id: 'Q321',
                 property_id: 'P123',
                 wikidata_value: '21. century',
+                meta_wikidata_value: '',
                 external_value: 'Another Value',
                 import_meta: {
                     user: {
@@ -180,7 +181,7 @@ describe('Results.vue', () => {
 
         const formatted_values = {
             'P123': {
-                '21. century': '21. Jahrhundert', // pretend uselang=de
+                '|21. century': '21. Jahrhundert', // pretend uselang=de
             },
         };
 

--- a/tests/Vue/Pages/Results.spec.js
+++ b/tests/Vue/Pages/Results.spec.js
@@ -190,7 +190,38 @@ describe('Results.vue', () => {
         });
 
         expect(wrapper.props().formatted_values).toBe(formatted_values);
+        expect(wrapper.text()).toContain('21. Jahrhundert');
+    });
 
+    it('renders formatted values when a calendar model item id is specified', () => {
+        const results = {
+            'Q321': [{
+                id: 123,
+                item_id: 'Q321',
+                property_id: 'P123',
+                wikidata_value: '21. century',
+                meta_wikidata_value: 'Q565787',
+                external_value: 'Another Value',
+                import_meta: {
+                    user: {
+                        username: 'some_user_name'
+                    },
+                    created_at: '2021-09-23'
+                },
+            }]
+        };
+        // meta_wikidata_value is prepended to the wikidata_value with a pipe separator
+        const formatted_values = {
+            'P123': {
+                'Q565787|21. century': '21. Jahrhundert', // pretend uselang=de
+            },
+        };
+
+        const wrapper = mountWithMocks({
+            props: { results, formatted_values }
+        });
+
+        expect(wrapper.props().formatted_values).toBe(formatted_values);
         expect(wrapper.text()).toContain('21. Jahrhundert');
     });
 


### PR DESCRIPTION
check if meta_wikidata_value exists and if so
append it to the base URL and assign that as
the calendar model of the parsed time values.

Bug: T321174