### PR TITLE
Show missing wikidata value as "None" and adjust validation

### DIFF
--- a/app/Http/Controllers/ResultsController.php
+++ b/app/Http/Controllers/ResultsController.php
@@ -66,7 +66,8 @@ class ResultsController extends Controller
                 'user' => $user,
                 'item_ids' => $requestedItemIds,
                 // Use wikidata to fetch labels for found entity ids
-                'labels' => $wikidata->getLabels($entityIds, $lang),
+                // array_filter removes empty values from an array if no callback argument is passed
+                'labels' => $wikidata->getLabels(array_filter($entityIds), $lang),
                 'formatted_values' => $formattedTimeValues,
             ],
             // only add 'results' prop if mismatches have been found

--- a/app/Http/Controllers/ResultsController.php
+++ b/app/Http/Controllers/ResultsController.php
@@ -94,10 +94,12 @@ class ResultsController extends Controller
         $idsAsKeys = [];
 
         foreach ($mismatches as $mismatch) {
-            $idsAsKeys[$mismatch->item_id] = null;
+            if ($mismatch->wikidata_value !== '' && $mismatch->statement_guid !== '') {
+                $idsAsKeys[$mismatch->item_id] = null;
 
-            if ($datatypes[$mismatch->property_id] === 'wikibase-item') {
-                $idsAsKeys[$mismatch->wikidata_value] = null;
+                if ($datatypes[$mismatch->property_id] === 'wikibase-item') {
+                    $idsAsKeys[$mismatch->wikidata_value] = null;
+                }
             }
         }
 

--- a/app/Http/Controllers/ResultsController.php
+++ b/app/Http/Controllers/ResultsController.php
@@ -94,9 +94,9 @@ class ResultsController extends Controller
         $idsAsKeys = [];
 
         foreach ($mismatches as $mismatch) {
-            if ($mismatch->wikidata_value !== '' && $mismatch->statement_guid !== '') {
-                $idsAsKeys[$mismatch->item_id] = null;
-
+            $idsAsKeys[$mismatch->item_id] = null;
+            
+            if ($mismatch->wikidata_value !== '') {
                 if ($datatypes[$mismatch->property_id] === 'wikibase-item') {
                     $idsAsKeys[$mismatch->wikidata_value] = null;
                 }

--- a/app/Http/Controllers/ResultsController.php
+++ b/app/Http/Controllers/ResultsController.php
@@ -66,7 +66,6 @@ class ResultsController extends Controller
                 'user' => $user,
                 'item_ids' => $requestedItemIds,
                 // Use wikidata to fetch labels for found entity ids
-                // array_filter removes empty values from an array if no callback argument is passed
                 'labels' => $wikidata->getLabels(array_filter($entityIds), $lang),
                 'formatted_values' => $formattedTimeValues,
             ],

--- a/app/Http/Controllers/ResultsController.php
+++ b/app/Http/Controllers/ResultsController.php
@@ -66,7 +66,7 @@ class ResultsController extends Controller
                 'user' => $user,
                 'item_ids' => $requestedItemIds,
                 // Use wikidata to fetch labels for found entity ids
-                'labels' => $wikidata->getLabels(array_filter($entityIds), $lang),
+                'labels' => $wikidata->getLabels($entityIds, $lang),
                 'formatted_values' => $formattedTimeValues,
             ],
             // only add 'results' prop if mismatches have been found

--- a/app/Jobs/ValidateCSV.php
+++ b/app/Jobs/ValidateCSV.php
@@ -111,7 +111,7 @@ class ValidateCSV implements ShouldQueue
                 'regex:' . $rules['item_id']['format']
             ],
             'statement_guid' => [
-                'required',
+                'required_with:wikidata_value',
                 'max:' . $rules['guid']['max_length'],
                 'regex:' . $rules['guid']['format']
             ],
@@ -121,7 +121,7 @@ class ValidateCSV implements ShouldQueue
                 'regex:' . $rules['pid']['format']
             ],
             'wikidata_value' => [
-                'required',
+                'required_with:statement_guid',
                 'max:' . $rules['wikidata_value']['max_length']
             ],
             'external_value' => [

--- a/app/Jobs/ValidateCSV.php
+++ b/app/Jobs/ValidateCSV.php
@@ -133,6 +133,7 @@ class ValidateCSV implements ShouldQueue
                 'max:' . $rules['external_url']['max_length']
             ],
             'meta_wikidata_value' => [
+                'prohibited_if:wikidata_value,',
                 'max:' . $rules['meta_wikidata_value']['max_length'],
                 'regex:' . $rules['meta_wikidata_value']['format']
             ]

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -29,6 +29,7 @@
     "column-external-source": "External source",
     "no-mismatches-found-message": "No mismatches have been found for:",
     "random-mismatches": "Random mismatches",
+    "empty-value": "None",
     "no-mismatches-available-for-review": "There are currently no mismatches available for review.",
     "review-status-pending": "Awaiting review",
     "review-status-wikidata": "Wrong data on Wikidata",

--- a/public/i18n/qqq.json
+++ b/public/i18n/qqq.json
@@ -26,6 +26,7 @@
     "column-external-source": "External source column on mismatches table",
     "no-mismatches-found-message": "A message when no mismatches have been found for the provided Item Ids",
     "random-mismatches": "The call to action for retrieving random mismatches",
+    "empty-value": "Label for empty value in Mismatch Row column 'Value on Wikidata''",
     "no-mismatches-available-for-review": "A message when no unreviewed mismatches have been found. This message can be displayed when searching for random mismatches",
     "review-status-pending": "Label for pending review status. Default value for all un-reviewed mismatches",
     "review-status-wikidata": "Label that indicates that the mismatch is due to wrong data on Wikidata. Used as an option in the review decision dropdown",

--- a/public/i18n/qqq.json
+++ b/public/i18n/qqq.json
@@ -26,7 +26,7 @@
     "column-external-source": "External source column on mismatches table",
     "no-mismatches-found-message": "A message when no mismatches have been found for the provided Item Ids",
     "random-mismatches": "The call to action for retrieving random mismatches",
-    "empty-value": "Label for empty value in Mismatch Row column 'Value on Wikidata''",
+    "empty-value": "Label for empty value in Mismatch Row column 'Value on Wikidata'",
     "no-mismatches-available-for-review": "A message when no unreviewed mismatches have been found. This message can be displayed when searching for random mismatches",
     "review-status-pending": "Label for pending review status. Default value for all un-reviewed mismatches",
     "review-status-wikidata": "Label that indicates that the mismatch is due to wrong data on Wikidata. Used as an option in the review decision dropdown",

--- a/resources/js/Components/MismatchRow.vue
+++ b/resources/js/Components/MismatchRow.vue
@@ -9,7 +9,7 @@
             </wikit-link>
         </td>
         <td :data-header="$i18n('column-wikidata-value')">
-            <span class="empty-value" v-if="mismatch.value_label === null && !mismatch.wikidata_value === null">
+            <span class="empty-value" v-if="mismatch.wikidata_value === ''">
               {{ this.$i18n('empty-value') }}
             </span> 
             <wikit-link 

--- a/resources/js/Components/MismatchRow.vue
+++ b/resources/js/Components/MismatchRow.vue
@@ -9,7 +9,7 @@
             </wikit-link>
         </td>
         <td :data-header="$i18n('column-wikidata-value')">
-            <span class="empty-value" v-if="!mismatch.value_label && !mismatch.wikidata_value">
+            <span class="empty-value" v-if="mismatch.value_label === null && !mismatch.wikidata_value === null">
               {{ this.$i18n('empty-value') }}
             </span> 
             <wikit-link 

--- a/resources/js/Components/MismatchRow.vue
+++ b/resources/js/Components/MismatchRow.vue
@@ -9,7 +9,11 @@
             </wikit-link>
         </td>
         <td :data-header="$i18n('column-wikidata-value')">
-            <wikit-link class="break-line-link" :href="statementUrl" target="_blank">
+            <span class="empty-value" v-if="!mismatch.value_label && !mismatch.wikidata_value">
+              {{ this.$i18n('empty-value') }}
+            </span> 
+            <wikit-link 
+              v-else class="break-line-link" :href="statementUrl" target="_blank">
                 {{mismatch.value_label || mismatch.wikidata_value}}
             </wikit-link>
         </td>
@@ -184,6 +188,8 @@ export default Vue.extend({
 </script>
 
 <style lang="scss">
+@import '~@wmde/wikit-tokens/dist/_variables.scss';
+
     .wikit-Link.break-line-link {
       width: 100%;
     }
@@ -193,5 +199,8 @@ export default Vue.extend({
     .wikit-Button.full-description-button {
       padding: 0px 2px;
       font-weight: 400;
+    }
+    .empty-value {
+      color: $font-color-disabled;
     }
 </style>

--- a/tests/Browser/ResultsTest.php
+++ b/tests/Browser/ResultsTest.php
@@ -128,6 +128,57 @@ class ResultsTest extends DuskTestCase
         });
     }
 
+    public function test_shows_None_in_Value_in_Wikidata_column_when_statement_guid_and_wikidata_value_empty()
+    {
+        $import = ImportMeta::factory()
+        ->for(User::factory()->uploader())
+        ->create();
+
+        Mismatch::factory(2)
+            ->for($import)
+            ->state(new Sequence(
+                [
+                    'item_id' => 'Q2',
+                    'statement_guid' => 'Q2$a2b48f1f-426d-91b3-1e0e-1d3c7b236bd0',
+                    'property_id' => 'P610',
+                    'wikidata_value' => 'Q513',
+                    'meta_wikidata_value' => ''
+                ],
+                [
+                    'item_id' => 'Q111',
+                    'statement_guid' => '',
+                    'property_id' => 'P571',
+                    'wikidata_value' => '',
+                    'meta_wikidata_value' => ''
+                ]
+            ))
+            ->create();
+
+        $expected = [
+            [
+                'item_label' => 'Earth (Q2)',
+                'property_label' => 'highest point',
+                'wikidata_value' => 'Mount Everest'
+            ],
+            [
+                'item_label' => 'Mars (Q111)',
+                'property_label' => 'inception',
+                'wikidata_value' => 'None'
+            ]
+        ];
+
+        $mismatches = Mismatch::all();
+
+        $this->browse(function (Browser $browser) use ($mismatches, $expected) {
+            $idsQuery = $mismatches->implode('item_id', '|');
+            $browser->visit(new ResultsPage($idsQuery));
+
+            foreach ($mismatches as $i => $mismatch) {
+                $browser->assertSee($expected[$i]['wikidata_value']);
+            }
+        });
+    }
+
     public function test_shows_disabled_decision_forms_for_guests()
     {
         $import = ImportMeta::factory()

--- a/tests/Browser/ResultsTest.php
+++ b/tests/Browser/ResultsTest.php
@@ -146,9 +146,9 @@ class ResultsTest extends DuskTestCase
                 ],
                 [
                     'item_id' => 'Q111',
-                    'statement_guid' => null,
+                    'statement_guid' => '',
                     'property_id' => 'P571',
-                    'wikidata_value' => null,
+                    'wikidata_value' => '',
                     'meta_wikidata_value' => ''
                 ]
             ))

--- a/tests/Browser/ResultsTest.php
+++ b/tests/Browser/ResultsTest.php
@@ -146,9 +146,9 @@ class ResultsTest extends DuskTestCase
                 ],
                 [
                     'item_id' => 'Q111',
-                    'statement_guid' => '',
+                    'statement_guid' => null,
                     'property_id' => 'P571',
-                    'wikidata_value' => '',
+                    'wikidata_value' => null,
                     'meta_wikidata_value' => ''
                 ]
             ))

--- a/tests/Feature/ValidateCSVTest.php
+++ b/tests/Feature/ValidateCSVTest.php
@@ -167,8 +167,8 @@ class ValidateCSVTest extends TestCase
         yield 'missing wikidata value when statement guid is present' => [
             function (array $config): array {
                 return [
-                    'Q184746,Q184746$97120cf9-ff1b-37c9-8af6-89d0b44a1cf2,'
-                    . 'P569,,,1934-04-03,http://www.example.com', // Emulate missing wikidata value
+                    'Q184746,Q184746$7814880A-A6EF-40EC-885E-F46DD58C8DC5,P569'
+                    . ',,,1934-04-03,http://www.example.com', // Emulate missing wikidata value
                     __('validation.required_with', [
                         'values' => 'statement guid',
                         'attribute' => 'wikidata value'

--- a/tests/Feature/ValidateCSVTest.php
+++ b/tests/Feature/ValidateCSVTest.php
@@ -164,16 +164,6 @@ class ValidateCSVTest extends TestCase
             }
         ];
 
-        yield 'invalid meta wikidata value' => [
-            function (array $config): array {
-                return [
-                    'Q1462,Q1462$97120cf9-ff1b-37c9-8af6-89d0b44a1cf2,P5,' // Ensure correct columns
-                    . '634463875,Q123,516380568,http://www.example.com', // Emulate invalid meta wikidata value
-                    __('validation.meta_wikidata_value')
-                ];
-            }
-        ];
-
         yield 'missing wikidata value when statement guid is present' => [
             function (array $config): array {
                 return [
@@ -183,6 +173,16 @@ class ValidateCSVTest extends TestCase
                         'values' => 'statement guid',
                         'attribute' => 'wikidata value'
                     ])
+                ];
+            }
+        ];
+
+        yield 'invalid meta wikidata value' => [
+            function (array $config): array {
+                return [
+                    'Q1462,Q1462$97120cf9-ff1b-37c9-8af6-89d0b44a1cf2,P5,' // Ensure correct columns
+                    . '634463875,Q123,516380568,http://www.example.com', // Emulate invalid meta wikidata value
+                    __('validation.meta_wikidata_value')
                 ];
             }
         ];

--- a/tests/Feature/ValidateCSVTest.php
+++ b/tests/Feature/ValidateCSVTest.php
@@ -71,6 +71,19 @@ class ValidateCSVTest extends TestCase
             }
         ];
 
+        yield 'missing statement guid when wikidata value present' => [
+            function (array $config): array {
+                return [
+                    'Q184746,,' // Emulate missing guid
+                    . 'P569,3 April 1934,,1934-04-03,http://www.example.com',
+                    __('validation.required_with', [
+                        'values' => 'wikidata value',
+                        'attribute' => 'statement guid'
+                    ])
+                ];
+            }
+        ];
+
         yield 'long statement guid' => [
             function (array $config, Generator $faker): array {
                 $longQID= $faker->numerify('Q' . str_repeat('#', $config['guid']['max_length']));
@@ -157,6 +170,19 @@ class ValidateCSVTest extends TestCase
                     'Q1462,Q1462$97120cf9-ff1b-37c9-8af6-89d0b44a1cf2,P5,' // Ensure correct columns
                     . '634463875,Q123,516380568,http://www.example.com', // Emulate invalid meta wikidata value
                     __('validation.meta_wikidata_value')
+                ];
+            }
+        ];
+
+        yield 'missing wikidata value when statement guid is present' => [
+            function (array $config): array {
+                return [
+                    'Q184746,Q184746$97120cf9-ff1b-37c9-8af6-89d0b44a1cf2,'
+                    . 'P569,,,1934-04-03,http://www.example.com', // Emulate missing wikidata value
+                    __('validation.required_with', [
+                        'values' => 'statement guid',
+                        'attribute' => 'wikidata value'
+                    ])
                 ];
             }
         ];

--- a/tests/Feature/ValidateCSVTest.php
+++ b/tests/Feature/ValidateCSVTest.php
@@ -71,18 +71,6 @@ class ValidateCSVTest extends TestCase
             }
         ];
 
-        yield 'missing statement guid' => [
-            function (array $config): array {
-                return [
-                    'Q184746,,' // Emulate missing guid
-                    . 'P569,3 April 1934,,1934-04-03,http://www.example.com',
-                    __('validation.required', [
-                        'attribute' => 'statement guid'
-                    ])
-                ];
-            }
-        ];
-
         yield 'long statement guid' => [
             function (array $config, Generator $faker): array {
                 $longQID= $faker->numerify('Q' . str_repeat('#', $config['guid']['max_length']));
@@ -158,18 +146,6 @@ class ValidateCSVTest extends TestCase
                     . '3 April 1934,,1934-04-03,http://www.example.com', // Ensure correct columns
                     __('validation.regex', [
                         'attribute' => 'property id'
-                    ])
-                ];
-            }
-        ];
-
-        yield 'missing wikidata value' => [
-            function (array $config): array {
-                return [
-                    'Q184746,Q184746$7814880A-A6EF-40EC-885E-F46DD58C8DC5,P569' // Ensure correct columns
-                    . ',,,1934-04-03,http://www.example.com', // Emulate missing wikidata value
-                    __('validation.required', [
-                        'attribute' => 'wikidata value'
                     ])
                 ];
             }

--- a/tests/Feature/ValidateCSVTest.php
+++ b/tests/Feature/ValidateCSVTest.php
@@ -187,6 +187,20 @@ class ValidateCSVTest extends TestCase
             }
         ];
 
+        yield 'meta wikidata value present even though wikidata value is missing' => [
+            function (array $config): array {
+                return [
+                    'Q1462,,P3150,'
+                    . ',Q12138,1879-03-14,http://www.example.com', // Emulate invalid meta wikidata value
+                    __('validation.prohibited_if', [
+                        'attribute' => 'meta wikidata value',
+                        'other' => 'wikidata value',
+                        'value' => ''
+                    ])
+                ];
+            }
+        ];
+
         yield 'long wikidata value' => [
             function (array $config): array {
                 $longValue = str_repeat('a', $config['wikidata_value']['max_length'] + 10);

--- a/tests/Feature/WebResultsRouteTest.php
+++ b/tests/Feature/WebResultsRouteTest.php
@@ -118,6 +118,8 @@ class WebResultsRouteTest extends TestCase
                 $itemMismatch->property_id,
                 $stringMismatchQid,
                 $stringMismatch->property_id,
+                // as well as item id of an item mismatch value
+                $itemMismatch->wikidata_value,
             ]);
         };
 

--- a/tests/Feature/WebResultsRouteTest.php
+++ b/tests/Feature/WebResultsRouteTest.php
@@ -118,8 +118,6 @@ class WebResultsRouteTest extends TestCase
                 $itemMismatch->property_id,
                 $stringMismatchQid,
                 $stringMismatch->property_id,
-                // as well as item id of an item mismatch value
-                $itemMismatch->wikidata_value,
             ]);
         };
 


### PR DESCRIPTION
Bug: T323206

Todo - tests: 
 - [x] check that the 'None' value is correctly added when statement-guid and wikidata value are missing. 
 - [x] check that statement-guid cannot be present without wikidata-value and viceversa (2 tests)
