### PR TITLE
Adjust button copy to require less context

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -61,7 +61,7 @@
     "instructions-dialog-message-instruction-external": "Wrong data on external source: use this option if the error lies in the external source. When possible, please inform the data source's maintainers of the error or resolve the mismatch yourself.",
     "instructions-dialog-message-instruction-both": "Both are wrong: use this option if you find there are errors on both sides. When possible, please use the link to the Wikidata statement to resolve the mismatch and/or inform the data source’s maintainers of the error.",
     "instructions-dialog-message-instruction-none": "None of the above: use this option if none of the other options are applicable. This might for example be the case if the mismatch has already been resolved by someone else.",
-    "results-back-button": "Refine Item selection",
+    "results-back-button": "Find more mismatches",
     "faq-button": "More information",
     "faq-dialog-title": "More on the Mismatch Finder",
     "faq-dialog-question-finding-mismatches": "How are mismatches found?",


### PR DESCRIPTION
If one follows a deep-link to a results page (for example from the mismatch finder gadget), then the "Refine Item selection" copy is a bit confusing.

Bug: T323682