### PR TITLE
Make clickable area of Results Mismatch Table ItemId link restrained to item

### DIFF
--- a/resources/js/Pages/Results.vue
+++ b/resources/js/Pages/Results.vue
@@ -382,6 +382,7 @@
 h2 {
     .wikit-Link.wikit {
         font-weight: bold;
+        display: inline;
     }
 }
 


### PR DESCRIPTION
Bug: [T323823](https://phabricator.wikimedia.org/T323823)