### PR TITLE
Don’t replace history entry when navigating back from Results

### DIFF
--- a/resources/js/Pages/Results.vue
+++ b/resources/js/Pages/Results.vue
@@ -2,7 +2,7 @@
     <div class="page-container results-page">
         <loading-overlay ref="overlay" />
         <inertia-head title="Mismatch Finder - Results" />
-        <wikit-button class="back-button" @click.native="() => $inertia.get('/', {} ,{ replace: true })">
+        <wikit-button class="back-button" @click.native="() => $inertia.get('/', {})">
             <template #prefix>
                 <icon type="arrowprevious" size="medium" color="inherit" :dir="pageDirection"/>
             </template>


### PR DESCRIPTION
The “replace” option means that the link target (the mismatch finder index / main page) will replace the current browser history entry instead of appending a new entry. I find this exceedingly confusing; also, as far as I can tell, it was never a product requirement, only brought up as a “neat little feature” [during code review][1]. I propose getting rid of it, and making this navigation a regular browser history entry; this also seems more in line with the change to the button text in T323682 / commit 75a2b01dd7 (from “refine item selection”, which arguably suggests a close relation to the current history entry, to “find more mismatches”, which sounds more like navigation).

[1]: https://github.com/wmde/wikidata-mismatch-finder/pull/191#discussion_r747272776