### PR TITLE
Update vertical spacing

### DIFF
--- a/resources/js/Pages/Home.vue
+++ b/resources/js/Pages/Home.vue
@@ -235,6 +235,11 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
+
+    h2 {
+        // the previous section already has enough margin-bottom
+        margin-top: 0;
+    }
 }
 
 #items-form {

--- a/resources/js/Pages/Results.vue
+++ b/resources/js/Pages/Results.vue
@@ -379,6 +379,11 @@
 <style lang="scss">
 @import '~@wmde/wikit-tokens/dist/_variables.scss';
 
+.back-button {
+    // to match the first heading on the home page
+    margin-top: $dimension-layout-xsmall;
+}
+
 h2 {
     .wikit-Link.wikit {
         font-weight: bold;

--- a/resources/js/Pages/Results.vue
+++ b/resources/js/Pages/Results.vue
@@ -382,6 +382,8 @@
 .back-button {
     // to match the first heading on the home page
     margin-top: $dimension-layout-xsmall;
+    // to avoid visual grouping with .description-section
+    margin-bottom: $dimension-layout-xsmall;
 }
 
 h2 {

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -20,15 +20,11 @@ main {
     & > header {
         display: flex;
         justify-content: space-between;
-        margin: $dimension-layout-xsmall 0;
+        margin: $dimension-layout-small 0;
     }
 
     @media(min-width: $width-breakpoint-tablet){
         padding: 0 $dimension-layout-small;
-
-        & > header {
-            margin: $dimension-layout-small 0;
-        }
     }
 }
 


### PR DESCRIPTION
Remove the breakpoint-dependent spacing of the header, and instead always make it $dimension-layout-small. I can’t find any reason for the margin depending on the background (it was added in aee8dc75cfe), nor a record of Design asking for this, and we don’t want it now.

Add a margin to the top of the “back” button on the results page; this makes its total spacing (including the header margin) match that of the first heading on the home page (as headings have a default top margin). Also add a margin to the bottom of the “back” button, so it’s not too close to the description section (which it’s not directly related to).

Remove the top margin of the “which items should be checked?” heading on the home page, so that the total space between it and the preceding section is just the section’s own margin, matching the space between sections on the results page.

Bug: T323678