### PR TITLE
Expand ImportReportTest

### DIFF
--- a/tests/Feature/ImportReportTest.php
+++ b/tests/Feature/ImportReportTest.php
@@ -24,6 +24,10 @@ class ImportReportTest extends TestCase
         $import = ImportMeta::factory()->for($user)->create(
             ['status' => 'completed']
         );
+        $expiredImportWithoutMismatches = ImportMeta::factory()
+            ->for($user)
+            ->expired()
+            ->create();
 
         $mismatches = Mismatch::factory(3)
             ->for($import)
@@ -58,7 +62,15 @@ class ImportReportTest extends TestCase
                 $pending, // Pending count
                 100 - ($pending / $total * 100), // % completed
                 $import->expires, // Expiry date
-                $import->expires < now() ? 'y' : 'n' // Expired
+                'n' // Expired
+            ],
+            [
+                $expiredImportWithoutMismatches->id,
+                $expiredImportWithoutMismatches->status,
+                0, 0, 0, 0, 0, 0, 0, // no mismatches, all counts are zero
+                0, // % completed
+                $expiredImportWithoutMismatches->expires, // Expiry date
+                'y' // Expired
             ]
         ]);
 


### PR DESCRIPTION
Add a second test case for an import without any mismatches (in an earlier version of #510, where I looped over `$res` instead of `$imports`, such imports would have been completely dropped from the result, which I only noticed with manual testing); and use this opportunity to also test the output for an expired import. Also, hard-code the expired state ('y' or 'n') – by default, ImportMetaFactory always generates imports that haven’t expired yet.