### PR TITLE
Add new route for import result csv

### DIFF
--- a/app/Http/Controllers/ImportsResultsController.php
+++ b/app/Http/Controllers/ImportsResultsController.php
@@ -2,20 +2,23 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\ImportMeta;
 use App\Services\ImportResults;
 
 class ImportsResultsController extends Controller
 {
     public function showResultsCsv(int $import_id, ImportResults $results)
     {
+        $import = ImportMeta::findOrFail($import_id);
+
         $filename = strtr(config('imports.results.filename_template'), [
             ':datetime' => now()->format('Y-m-dTH:i:s')
         ]);
 
         $headers = [ 'Content-Type' => 'text/csv; charset=utf-8' ];
 
-        return response()->streamDownload(function () use ($import_id, $results) {
-            $results->generateCSV('php://output', $import_id);
+        return response()->streamDownload(function () use ($import, $results) {
+            $results->generateCSV('php://output', $import);
         }, $filename, $headers);
     }
 }

--- a/app/Http/Controllers/ImportsResultsController.php
+++ b/app/Http/Controllers/ImportsResultsController.php
@@ -12,7 +12,7 @@ class ImportsResultsController extends Controller
         $import = ImportMeta::findOrFail($import_id);
 
         $filename = strtr(config('imports.results.filename_template'), [
-            ':id' => $import_id
+            ':id' => $import_id,
             ':datetime' => now()->format('Y-m-dTH:i:s')
         ]);
 

--- a/app/Http/Controllers/ImportsResultsController.php
+++ b/app/Http/Controllers/ImportsResultsController.php
@@ -15,7 +15,6 @@ class ImportsResultsController extends Controller
         $headers = [ 'Content-Type' => 'text/csv; charset=utf-8' ];
 
         return response()->streamDownload(function () use ($import_id) {
-            // make the file happen somehow
             ImportResults::class->generateCSV('php://output', $import_id);
         }, $filename, $headers);
     }

--- a/app/Http/Controllers/ImportsResultsController.php
+++ b/app/Http/Controllers/ImportsResultsController.php
@@ -9,7 +9,7 @@ class ImportsResultsController extends Controller
     public function showResultsCsv(int $import_id, ImportResults $results)
     {
         $filename = strtr(config('imports.results.filename_template'), [
-            ':datetime' => now()->format('Y-m-d_H-i-s')
+            ':datetime' => now()->format('Y-m-dTH:i:s')
         ]);
 
         $headers = [ 'Content-Type' => 'text/csv; charset=utf-8' ];

--- a/app/Http/Controllers/ImportsResultsController.php
+++ b/app/Http/Controllers/ImportsResultsController.php
@@ -13,7 +13,7 @@ class ImportsResultsController extends Controller
         $headers = [ 'Content-Type' => 'text/csv; charset=utf-8' ];
 
         return response()->streamDownload(function () use ($import_id) {
-            $report->generateCSV('php://output');
+            // make the file happen somehow
         }, $filename, $headers);
     }
 }

--- a/app/Http/Controllers/ImportsResultsController.php
+++ b/app/Http/Controllers/ImportsResultsController.php
@@ -6,7 +6,7 @@ use App\Services\ImportResults;
 
 class ImportsResultsController extends Controller
 {
-    public function showResultsCsv(int $import_id)
+    public function showResultsCsv(int $import_id, ImportResults $results)
     {
         $filename = strtr(config('imports.results.filename_template'), [
             ':datetime' => now()->format('Y-m-d_H-i-s')
@@ -14,8 +14,8 @@ class ImportsResultsController extends Controller
 
         $headers = [ 'Content-Type' => 'text/csv; charset=utf-8' ];
 
-        return response()->streamDownload(function () use ($import_id) {
-            ImportResults::class->generateCSV('php://output', $import_id);
+        return response()->streamDownload(function () use ($import_id, $results) {
+            $results->generateCSV('php://output', $import_id);
         }, $filename, $headers);
     }
 }

--- a/app/Http/Controllers/ImportsResultsController.php
+++ b/app/Http/Controllers/ImportsResultsController.php
@@ -2,8 +2,6 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
-
 class ImportsResultsController extends Controller
 {
     public function showResultsCsv(string $import_id)

--- a/app/Http/Controllers/ImportsResultsController.php
+++ b/app/Http/Controllers/ImportsResultsController.php
@@ -12,6 +12,7 @@ class ImportsResultsController extends Controller
         $import = ImportMeta::findOrFail($import_id);
 
         $filename = strtr(config('imports.results.filename_template'), [
+            ':id' => $import_id
             ':datetime' => now()->format('Y-m-dTH:i:s')
         ]);
 

--- a/app/Http/Controllers/ImportsResultsController.php
+++ b/app/Http/Controllers/ImportsResultsController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class ImportsResultsController extends Controller
+{
+    public function showResultsCsv(string $import_id)
+    {
+        $filename = strtr(config('imports.results.filename_template'), [
+            ':datetime' => now()->format('Y-m-d_H-i-s')
+        ]);
+
+        $headers = [ 'Content-Type' => 'text/csv; charset=utf-8' ];
+
+        return response()->streamDownload(function () use ($import_id) {
+            $report->generateCSV('php://output');
+        }, $filename, $headers);
+    }
+}

--- a/app/Http/Controllers/ImportsResultsController.php
+++ b/app/Http/Controllers/ImportsResultsController.php
@@ -13,7 +13,7 @@ class ImportsResultsController extends Controller
 
         $filename = strtr(config('imports.results.filename_template'), [
             ':id' => $import_id,
-            ':datetime' => now()->format('Y-m-dTH:i:s')
+            ':datetime' => now()->format('Y-m-dTH-i-s')
         ]);
 
         $headers = [ 'Content-Type' => 'text/csv; charset=utf-8' ];

--- a/app/Http/Controllers/ImportsResultsController.php
+++ b/app/Http/Controllers/ImportsResultsController.php
@@ -2,9 +2,11 @@
 
 namespace App\Http\Controllers;
 
+use App\Services\ImportResults;
+
 class ImportsResultsController extends Controller
 {
-    public function showResultsCsv(string $import_id)
+    public function showResultsCsv(int $import_id)
     {
         $filename = strtr(config('imports.results.filename_template'), [
             ':datetime' => now()->format('Y-m-d_H-i-s')
@@ -12,8 +14,10 @@ class ImportsResultsController extends Controller
 
         $headers = [ 'Content-Type' => 'text/csv; charset=utf-8' ];
 
-        return response()->streamDownload(function () use ($import_id) {
+        $results = ImportResults::class;
+        return response()->streamDownload(function () use ($results, $import_id) {
             // make the file happen somehow
+            $results->generateCSV('php://output', $import_id);
         }, $filename, $headers);
     }
 }

--- a/app/Http/Controllers/ImportsResultsController.php
+++ b/app/Http/Controllers/ImportsResultsController.php
@@ -14,10 +14,9 @@ class ImportsResultsController extends Controller
 
         $headers = [ 'Content-Type' => 'text/csv; charset=utf-8' ];
 
-        $results = ImportResults::class;
-        return response()->streamDownload(function () use ($results, $import_id) {
+        return response()->streamDownload(function () use ($import_id) {
             // make the file happen somehow
-            $results->generateCSV('php://output', $import_id);
+            ImportResults::class->generateCSV('php://output', $import_id);
         }, $filename, $headers);
     }
 }

--- a/app/Services/ImportResults.php
+++ b/app/Services/ImportResults.php
@@ -15,7 +15,8 @@ class ImportResults
         $handle = fopen($path, 'w');
 
         $import = ImportMeta::find($import_id);
-        $mismatches = Mismatch::whereBelongsTo($import)->get();
+        // Get the mismatches as a LazyCollection
+        $mismatches = Mismatch::whereBelongsTo($import)->cursor();
 
         // write column headers
         fputcsv($handle, config('imports.results.column_keys'));

--- a/app/Services/ImportResults.php
+++ b/app/Services/ImportResults.php
@@ -31,8 +31,8 @@ class ImportResults
         }, $mismatches->toArray());
 
         // Add column keys as CSV headers
-        $mismatchesWithKeys = [config('imports.results.column_keys')
-        ]+$mismatchValues;
+        $mismatchesWithKeys = array_merge([config('imports.results.column_keys')
+        ], $mismatchValues);
 
         foreach ($mismatchesWithKeys as $mismatch) {
             fputcsv($handle, $mismatch);

--- a/app/Services/ImportResults.php
+++ b/app/Services/ImportResults.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\ImportMeta;
+use App\Models\Mismatch;
+
+class ImportResults
+{
+    public function generateCSV(string $path, int $import_id): void
+    {
+        $mismatches = Mismatch::get();
+
+        // Creating the output stream
+        $handle = fopen($path, 'w');
+
+        $importMeta = ImportMeta::find($import_id);
+        $mismatches = $importMeta->mismatches();
+
+        foreach ($mismatches as $mismatch) {
+            fputcsv($handle, [
+            $mismatch->id,
+            $mismatch->status
+            ]);
+        }
+    }
+}

--- a/app/Services/ImportResults.php
+++ b/app/Services/ImportResults.php
@@ -14,7 +14,8 @@ class ImportResults
         // Creating the output stream
         $handle = fopen($path, 'w');
 
-        $import = ImportMeta::find($import_id);
+        $import = ImportMeta::findOrFail($import_id);
+
         // Get the mismatches as a LazyCollection
         $mismatches = Mismatch::whereBelongsTo($import)->cursor();
 

--- a/app/Services/ImportResults.php
+++ b/app/Services/ImportResults.php
@@ -20,8 +20,8 @@ class ImportResults
         // write column headers
         fputcsv($handle, config('imports.results.column_keys'));
 
-        foreach ($mismatches->toArray() as $mismatch) {
-            $mismatch = [
+        $mismatches->map(function ($mismatch) {
+            return [
                 $mismatch['item_id'],
                 $mismatch['statement_guid'],
                 $mismatch['property_id'],
@@ -31,8 +31,9 @@ class ImportResults
                 $mismatch['external_url'],
                 $mismatch['review_status']
             ];
-            fputcsv($handle, $mismatch);
-        }
+        })->each(function ($row) use ($handle) {
+            fputcsv($handle, $row);
+        });
 
         fclose($handle);
     }

--- a/app/Services/ImportResults.php
+++ b/app/Services/ImportResults.php
@@ -18,19 +18,14 @@ class ImportResults
         $mismatches = Mismatch::whereBelongsTo($import)->cursor();
 
         // write column headers
-        fputcsv($handle, config('imports.results.column_keys'));
+        $keys = config('imports.results.column_keys');
+        fputcsv($handle, $keys);
 
-        $mismatches->map(function ($mismatch) {
-            return [
-                $mismatch['item_id'],
-                $mismatch['statement_guid'],
-                $mismatch['property_id'],
-                $mismatch['wikidata_value'],
-                $mismatch['meta_wikidata_value'],
-                $mismatch['external_value'],
-                $mismatch['external_url'],
-                $mismatch['review_status']
-            ];
+        // map mismatch values to correspond to column keys
+        $mismatches->map(function ($mismatch) use ($keys) {
+            return array_map(function ($key) use ($mismatch) {
+                return $mismatch[$key];
+            }, $keys);
         })->each(function ($row) use ($handle) {
             fputcsv($handle, $row);
         });

--- a/app/Services/ImportResults.php
+++ b/app/Services/ImportResults.php
@@ -17,8 +17,11 @@ class ImportResults
         $import = ImportMeta::find($import_id);
         $mismatches = Mismatch::whereBelongsTo($import)->get();
 
-        $mismatchValues = array_map(function ($mismatch) {
-            return [
+        // write column headers
+        fputcsv($handle, config('imports.results.column_keys'));
+
+        foreach ($mismatches->toArray() as $mismatch) {
+            $mismatch = [
                 $mismatch['item_id'],
                 $mismatch['statement_guid'],
                 $mismatch['property_id'],
@@ -28,13 +31,6 @@ class ImportResults
                 $mismatch['external_url'],
                 $mismatch['review_status']
             ];
-        }, $mismatches->toArray());
-
-        // Add column keys as CSV headers
-        $mismatchesWithKeys = array_merge([config('imports.results.column_keys')
-        ], $mismatchValues);
-
-        foreach ($mismatchesWithKeys as $mismatch) {
             fputcsv($handle, $mismatch);
         }
 

--- a/app/Services/ImportResults.php
+++ b/app/Services/ImportResults.php
@@ -14,8 +14,8 @@ class ImportResults
         // Creating the output stream
         $handle = fopen($path, 'w');
 
-        $importMeta = ImportMeta::find($import_id);
-        $mismatches = $importMeta->mismatches();
+        $import = ImportMeta::find($import_id);
+        $mismatches = Mismatch::whereBelongsTo($import)->get();
 
         foreach ($mismatches as $mismatch) {
             fputcsv($handle, [

--- a/app/Services/ImportResults.php
+++ b/app/Services/ImportResults.php
@@ -7,14 +7,12 @@ use App\Models\Mismatch;
 
 class ImportResults
 {
-    public function generateCSV(string $path, int $import_id): void
+    public function generateCSV(string $path, ImportMeta $import): void
     {
         $mismatches = Mismatch::get();
 
         // Creating the output stream
         $handle = fopen($path, 'w');
-
-        $import = ImportMeta::findOrFail($import_id);
 
         // Get the mismatches as a LazyCollection
         $mismatches = Mismatch::whereBelongsTo($import)->cursor();

--- a/app/Services/ImportResults.php
+++ b/app/Services/ImportResults.php
@@ -17,10 +17,25 @@ class ImportResults
         $import = ImportMeta::find($import_id);
         $mismatches = Mismatch::whereBelongsTo($import)->get();
 
-        foreach ($mismatches as $mismatch) {
-            fputcsv($handle, [
-            $mismatch
-            ]);
+        $mismatchValues = array_map(function ($mismatch) {
+            return [
+                $mismatch['item_id'],
+                $mismatch['statement_guid'],
+                $mismatch['property_id'],
+                $mismatch['wikidata_value'],
+                $mismatch['meta_wikidata_value'],
+                $mismatch['external_value'],
+                $mismatch['external_url'],
+                $mismatch['review_status']
+            ];
+        }, $mismatches->toArray());
+
+        // Add column keys as CSV headers
+        $mismatchesWithKeys = [config('imports.results.column_keys')
+        ]+$mismatchValues;
+
+        foreach ($mismatchesWithKeys as $mismatch) {
+            fputcsv($handle, $mismatch);
         }
 
         fclose($handle);

--- a/app/Services/ImportResults.php
+++ b/app/Services/ImportResults.php
@@ -22,5 +22,7 @@ class ImportResults
             $mismatch
             ]);
         }
+
+        fclose($handle);
     }
 }

--- a/app/Services/ImportResults.php
+++ b/app/Services/ImportResults.php
@@ -19,8 +19,7 @@ class ImportResults
 
         foreach ($mismatches as $mismatch) {
             fputcsv($handle, [
-            $mismatch->id,
-            $mismatch->status
+            $mismatch
             ]);
         }
     }

--- a/config/imports.php
+++ b/config/imports.php
@@ -51,9 +51,19 @@ return [
             "expiry date",
             "expired?"
         ]
-        ],
+    ],
 
     'results' => [
-        'filename_template' => 'import-results-:datetime.csv'
+        'filename_template' => 'import-results-:datetime.csv',
+        'column_keys' => [
+            'item_id',
+            'statement_guid',
+            'property_id',
+            'wikidata_value',
+            'meta_wikidata_value',
+            'external_value',
+            'external_url',
+            'review_status'
+        ]
     ]
 ];

--- a/config/imports.php
+++ b/config/imports.php
@@ -54,7 +54,7 @@ return [
     ],
 
     'results' => [
-        'filename_template' => 'import-results-:datetime.csv',
+        'filename_template' => 'results-:id-:datetime.csv',
         'column_keys' => [
             'item_id',
             'statement_guid',

--- a/config/imports.php
+++ b/config/imports.php
@@ -51,5 +51,9 @@ return [
             "expiry date",
             "expired?"
         ]
+        ],
+
+    'results' => [
+        'filename_template' => 'import-results-:datetime.csv'
     ]
 ];

--- a/routes/web.php
+++ b/routes/web.php
@@ -59,7 +59,7 @@ Route::prefix('store')->name('store.')->group(function () {
         ]);
     })->name('import-status');
 
-    Route::get('/imports/{import_id}/', [
+    Route::get('/imports/{import_id}', [
         ImportsResultsController::class, 'showResultsCsv'
     ])->name('import-status/import_id');
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -61,7 +61,7 @@ Route::prefix('store')->name('store.')->group(function () {
 
     Route::get('/imports/{import_id}', [
         ImportsResultsController::class, 'showResultsCsv'
-    ])->name('import-status/import_id');
+    ])->name('import-results');
 
     Route::get('/imports-overview', [
         ImportsOverviewController::class, 'downloadCsv'

--- a/routes/web.php
+++ b/routes/web.php
@@ -58,7 +58,7 @@ Route::prefix('store')->name('store.')->group(function () {
         ]);
     })->name('import-status');
 
-    Route::get('/imports/{import_id}/results.csv', [
+    Route::get('/imports/{import_id}/', [
         ImportsResultsController::class, 'showResultsCsv'
     ])->name('import-status/import_id');
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -58,6 +58,10 @@ Route::prefix('store')->name('store.')->group(function () {
         ]);
     })->name('import-status');
 
+    Route::get('/imports/{import_id}/results.csv', [
+        ImportsResultsController::class, 'showResultsCsv'
+    ])->name('import-status/import_id');
+
     Route::get('/imports-overview', [
         ImportsOverviewController::class, 'downloadCsv'
     ])->name('imports-overview');

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Auth;
 use App\Http\Controllers\RandomizeController;
 use App\Http\Controllers\ResultsController;
 use App\Http\Controllers\ImportsOverviewController;
+use App\Http\Controllers\ImportsResultsController;
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/Feature/ImportReportTest.php
+++ b/tests/Feature/ImportReportTest.php
@@ -21,7 +21,9 @@ class ImportReportTest extends TestCase
     public function test_generate_csv_writes_to_path(): void
     {
         $user = User::factory()->uploader()->create();
-        $import = ImportMeta::factory()->for($user)->create();
+        $import = ImportMeta::factory()->for($user)->create(
+            ['status' => 'completed']
+        );
         $expiredImportWithoutMismatches = ImportMeta::factory()
             ->for($user)
             ->expired()

--- a/tests/Feature/ImportReportTest.php
+++ b/tests/Feature/ImportReportTest.php
@@ -21,9 +21,7 @@ class ImportReportTest extends TestCase
     public function test_generate_csv_writes_to_path(): void
     {
         $user = User::factory()->uploader()->create();
-        $import = ImportMeta::factory()->for($user)->create(
-
-        );
+        $import = ImportMeta::factory()->for($user)->create();
         $expiredImportWithoutMismatches = ImportMeta::factory()
             ->for($user)
             ->expired()

--- a/tests/Feature/ImportReportTest.php
+++ b/tests/Feature/ImportReportTest.php
@@ -22,7 +22,7 @@ class ImportReportTest extends TestCase
     {
         $user = User::factory()->uploader()->create();
         $import = ImportMeta::factory()->for($user)->create(
-            ['status' => 'completed']
+
         );
         $expiredImportWithoutMismatches = ImportMeta::factory()
             ->for($user)

--- a/tests/Feature/ImportResultsTest.php
+++ b/tests/Feature/ImportResultsTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Models\Mismatch;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Tests\TestCase;
 use App\Services\ImportResults;
 use Illuminate\Support\Facades\Storage;
@@ -77,5 +78,16 @@ class ImportResultsTest extends TestCase
         rewind($csv);
 
         return stream_get_contents($csv);
+    }
+
+    /**
+     * ׂׂ
+     * @return void
+     */
+    public function test_non_existant_import_throws_exception(): void
+    {
+        $this->expectException(ModelNotFoundException::class);
+        $results = new ImportResults();
+        $results->generateCSV('php://output', 1234111223356);
     }
 }

--- a/tests/Feature/ImportResultsTest.php
+++ b/tests/Feature/ImportResultsTest.php
@@ -46,9 +46,13 @@ class ImportResultsTest extends TestCase
                 $mismatch['review_status']
             ];
         }, $mismatches->toArray());
-        $expected = $this->formatCsv([
-            config('imports.results.column_keys')
-        ]+$mismatchValues);
+
+        // Add CSV headers
+        $mismatchesWithKeys = array_merge(
+            [config('imports.results.column_keys')],
+            $mismatchValues
+        );
+        $expected = $this->formatCsv($mismatchesWithKeys);
 
         $results = new ImportResults();
         $results->generateCSV($path, $import->id);

--- a/tests/Feature/ImportResultsTest.php
+++ b/tests/Feature/ImportResultsTest.php
@@ -34,7 +34,21 @@ class ImportResultsTest extends TestCase
 
         $this->travelTo(now()); // stop the clock
 
-        $expected = $this->formatCsv($mismatches);
+        $mismatchValues = array_map(function ($mismatch) {
+            return [
+                $mismatch['item_id'],
+                $mismatch['statement_guid'],
+                $mismatch['property_id'],
+                $mismatch['wikidata_value'],
+                $mismatch['meta_wikidata_value'],
+                $mismatch['external_value'],
+                $mismatch['external_url'],
+                $mismatch['review_status']
+            ];
+        }, $mismatches->toArray());
+        $expected = $this->formatCsv([
+            config('imports.results.column_keys')
+        ]+$mismatchValues);
 
         $results = new ImportResults();
         $results->generateCSV($path, $import->id);
@@ -48,12 +62,12 @@ class ImportResultsTest extends TestCase
     /**
      * @return void
      */
-    private function formatCsv($mismatches): string
+    private function formatCsv(array $mismatches): string
     {
         $csv = fopen('php://memory', 'r+');
 
         foreach ($mismatches as $row) {
-            fputcsv($csv, [$row]);
+            fputcsv($csv, $row);
         }
 
         rewind($csv);

--- a/tests/Feature/ImportResultsTest.php
+++ b/tests/Feature/ImportResultsTest.php
@@ -5,7 +5,6 @@ namespace Tests\Feature;
 use App\Models\Mismatch;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Tests\TestCase;
 use App\Services\ImportResults;
 use Illuminate\Support\Facades\Storage;

--- a/tests/Feature/ImportResultsTest.php
+++ b/tests/Feature/ImportResultsTest.php
@@ -33,8 +33,6 @@ class ImportResultsTest extends TestCase
         Storage::put($filename, '');
         $path = Storage::path($filename);
 
-        $this->travelTo(now()); // stop the clock
-
         $mismatchValues = array_map(function ($mismatch) {
             return [
                 $mismatch['item_id'],
@@ -61,8 +59,6 @@ class ImportResultsTest extends TestCase
         $actualCSV = Storage::get($filename);
 
         $this->assertSame($expected, $actualCSV);
-
-        $this->travelBack(); // resumes the clock
     }
     /**
      * @return void

--- a/tests/Feature/ImportResultsTest.php
+++ b/tests/Feature/ImportResultsTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+use App\Services\ImportResults;
+use Illuminate\Support\Facades\Storage;
+use App\Models\User;
+use App\Models\ImportMeta;
+
+class ImportResultsTest extends TestCase
+{
+    use RefreshDatabase, WithFaker;
+    /**
+     * @return void
+     */
+    public function test_generate_csv_writes_to_path(): void
+    {
+        $this->markTestIncomplete(
+            'This test has not been implemented yet.'
+        );
+
+        $user = User::factory()->uploader()->create();
+        $import = ImportMeta::factory()->for($user)->create(
+            ['status' => 'completed']
+        );
+        $expiredImportWithoutMismatches = ImportMeta::factory()
+            ->for($user)
+            ->expired()
+            ->create();
+
+        $importMeta = ImportMeta::find($import->id);
+        $mismatches = $importMeta->mismatches();
+
+        Storage::fake('local');
+        $filename = 'temp_test.csv';
+
+        Storage::put($filename, '');
+        $path = Storage::path($filename);
+
+        $this->travelTo(now()); // stop the clock
+
+        $expected = $this->formatCsv($mismatches);
+
+        $results = new ImportResults();
+        $results->generateCSV($path, $import->id);
+
+        $actualCSV = Storage::get($filename);
+
+        $this->assertSame($expected, $actualCSV);
+
+        $this->travelBack(); // resumes the clock
+    }
+    /**
+     * @return void
+     */
+    private function formatCsv($mismatches): string
+    {
+        $csv = fopen('php://memory', 'r+');
+
+        foreach ($mismatches as $row) {
+            fputcsv($csv, $row);
+        }
+
+        rewind($csv);
+
+        return stream_get_contents($csv);
+    }
+}

--- a/tests/Feature/ImportResultsTest.php
+++ b/tests/Feature/ImportResultsTest.php
@@ -54,7 +54,7 @@ class ImportResultsTest extends TestCase
         $expected = $this->formatCsv($mismatchesWithKeys);
 
         $results = new ImportResults();
-        $results->generateCSV($path, $import->id);
+        $results->generateCSV($path, $import);
 
         $actualCSV = Storage::get($filename);
 
@@ -74,16 +74,5 @@ class ImportResultsTest extends TestCase
         rewind($csv);
 
         return stream_get_contents($csv);
-    }
-
-    /**
-     * ׂׂ
-     * @return void
-     */
-    public function test_non_existant_import_throws_exception(): void
-    {
-        $this->expectException(ModelNotFoundException::class);
-        $results = new ImportResults();
-        $results->generateCSV('php://output', 1234111223356);
     }
 }

--- a/tests/Feature/ImportResultsTest.php
+++ b/tests/Feature/ImportResultsTest.php
@@ -34,7 +34,7 @@ class ImportResultsTest extends TestCase
 
         $this->travelTo(now()); // stop the clock
 
-        $expected = $this->formatCsv([[$mismatches]]);
+        $expected = $this->formatCsv($mismatches);
 
         $results = new ImportResults();
         $results->generateCSV($path, $import->id);
@@ -48,12 +48,12 @@ class ImportResultsTest extends TestCase
     /**
      * @return void
      */
-    private function formatCsv(array $mismatches): string
+    private function formatCsv($mismatches): string
     {
         $csv = fopen('php://memory', 'r+');
 
         foreach ($mismatches as $row) {
-            fputcsv($csv, $row);
+            fputcsv($csv, [$row]);
         }
 
         rewind($csv);

--- a/tests/Feature/ImportResultsTest.php
+++ b/tests/Feature/ImportResultsTest.php
@@ -32,24 +32,23 @@ class ImportResultsTest extends TestCase
         Storage::put($filename, '');
         $path = Storage::path($filename);
 
-        $mismatchValues = array_map(function ($mismatch) {
-            return [
-                $mismatch['item_id'],
-                $mismatch['statement_guid'],
-                $mismatch['property_id'],
-                $mismatch['wikidata_value'],
-                $mismatch['meta_wikidata_value'],
-                $mismatch['external_value'],
-                $mismatch['external_url'],
-                $mismatch['review_status']
-            ];
+        $keys = config('imports.results.column_keys');
+
+        $mismatchValues = array_map(function ($mismatch) use ($keys) {
+            return array_map(
+                function ($key) use ($mismatch) {
+                    return $mismatch[$key];
+                },
+                $keys
+            );
         }, $mismatches->toArray());
 
         // Add CSV headers
         $mismatchesWithKeys = array_merge(
-            [config('imports.results.column_keys')],
+            [$keys],
             $mismatchValues
         );
+
         $expected = $this->formatCsv($mismatchesWithKeys);
 
         $results = new ImportResults();

--- a/tests/Feature/ImportResultsTest.php
+++ b/tests/Feature/ImportResultsTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Feature;
 
 use App\Models\Mismatch;
-use Illuminate\Database\Eloquent\Factories\Sequence;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
@@ -35,7 +34,7 @@ class ImportResultsTest extends TestCase
 
         $this->travelTo(now()); // stop the clock
 
-        $expected = $this->formatCsv([$mismatches]);
+        $expected = $this->formatCsv([[$mismatches]]);
 
         $results = new ImportResults();
         $results->generateCSV($path, $import->id);

--- a/tests/Feature/WebStoreRouteTest.php
+++ b/tests/Feature/WebStoreRouteTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Feature;
 
+use App\Models\ImportMeta;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -59,6 +61,30 @@ class WebStoreRouteTest extends TestCase
         ]);
 
         $response = $this->get(route('store.imports-overview'));
+
+        $response->assertSuccessful();
+        $response->assertHeader('Content-Type', 'text/csv; charset=utf-8');
+        $response->assertDownload($filename);
+    }
+
+    public function test_store_import_results_route_import_id_does_not_exist()
+    {
+        $response = $this->call('GET', '/store/imports/1231112123');
+
+        // $response->assertStatus(404);
+    }
+
+    public function test_store_import_results_route()
+    {
+        $filename = strtr(config('imports.results.filename_template'), [
+            ':datetime' => now()->format('Y-m-dTH:i:s')
+        ]);
+
+        $import = ImportMeta::factory()
+            ->for(User::factory()->uploader())
+            ->create();
+
+        $response = $this->call('GET', '/store/imports/' . $import->id . '/');
 
         $response->assertSuccessful();
         $response->assertHeader('Content-Type', 'text/csv; charset=utf-8');

--- a/tests/Feature/WebStoreRouteTest.php
+++ b/tests/Feature/WebStoreRouteTest.php
@@ -69,9 +69,8 @@ class WebStoreRouteTest extends TestCase
 
     public function test_store_import_results_route_import_id_does_not_exist()
     {
-        $response = $this->call('GET', '/store/imports/1231112123');
-
-        // $response->assertStatus(404);
+        $response = $this->get(route('store.import-results', ['123123123']));
+        $response->assertStatus(404);
     }
 
     public function test_store_import_results_route()

--- a/tests/Feature/WebStoreRouteTest.php
+++ b/tests/Feature/WebStoreRouteTest.php
@@ -75,14 +75,15 @@ class WebStoreRouteTest extends TestCase
 
     public function test_store_import_results_route()
     {
-        $filename = strtr(config('imports.results.filename_template'), [
-            ':id' => $import->id
-            ':datetime' => now()->format('Y-m-dTH:i:s')
-        ]);
 
         $import = ImportMeta::factory()
             ->for(User::factory()->uploader())
             ->create();
+
+        $filename = strtr(config('imports.results.filename_template'), [
+            ':id' => $import->id,
+            ':datetime' => now()->format('Y-m-dTH:i:s')
+        ]);
 
         $response = $this->call('GET', '/store/imports/' . $import->id . '/');
 

--- a/tests/Feature/WebStoreRouteTest.php
+++ b/tests/Feature/WebStoreRouteTest.php
@@ -76,6 +76,7 @@ class WebStoreRouteTest extends TestCase
     public function test_store_import_results_route()
     {
         $filename = strtr(config('imports.results.filename_template'), [
+            ':id' => $import->id
             ':datetime' => now()->format('Y-m-dTH:i:s')
         ]);
 

--- a/tests/Feature/WebStoreRouteTest.php
+++ b/tests/Feature/WebStoreRouteTest.php
@@ -82,7 +82,7 @@ class WebStoreRouteTest extends TestCase
 
         $filename = strtr(config('imports.results.filename_template'), [
             ':id' => $import->id,
-            ':datetime' => now()->format('Y-m-dTH:i:s')
+            ':datetime' => now()->format('Y-m-dTH-i-s')
         ]);
 
         $response = $this->call('GET', '/store/imports/' . $import->id . '/');


### PR DESCRIPTION
This pr adds the route and introduces the
`ImportsResultsController`, which uses the new `ImportResults` service to generate the CSV dynamically. 
This also adds a new config section with the file name template and the headers.

Bug: T325158