### PR TITLE
Remove redundant time traveling

### DIFF
--- a/tests/Feature/ImportReportTest.php
+++ b/tests/Feature/ImportReportTest.php
@@ -46,8 +46,6 @@ class ImportReportTest extends TestCase
         $total = $mismatches->count();
         $pending = $mismatches->where('review_status', 'pending')->count();
 
-        $this->travelTo(now()); // stop the clock
-
         $expected = $this->formatCsv([
             config('imports.report.headers'),
             [
@@ -80,8 +78,6 @@ class ImportReportTest extends TestCase
         $result = Storage::get($filename);
 
         $this->assertSame($expected, $result);
-
-        $this->travelBack(); // resumes the clock
     }
     /**
      * @return void


### PR DESCRIPTION
The test does not require any time manipulation anymore therefore these may be removed.