### PR TITLE
Add name to package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "wikidata-mismatch-finder",
             "dependencies": {
                 "@inertiajs/inertia": "^0.11.0",
                 "@inertiajs/inertia-vue": "^0.8.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
     "private": true,
+    "name": "wikidata-mismatch-finder",
     "scripts": {
         "lint": "eslint --ext .js,.vue resources/js",
         "lint:fix": "eslint --fix --ext .js,.vue resources/js",


### PR DESCRIPTION
Previously, it was only added to package-lock.json, where it’s prone to being removed again by other package operations.