### PR TITLE
Fix tablet breakpoint inconsistency

### DIFF
--- a/resources/js/Pages/Layout.vue
+++ b/resources/js/Pages/Layout.vue
@@ -85,12 +85,12 @@
 
     .mismatch-finder-logo {
         margin-block-end: $dimension-layout-small;
-        background-image: url('/images/mismatch-finder-logo.svg');
-        width: 384px;
+        background-image: url('/images/mismatch-finder-logo_mobile.svg');
+        width: 268px;
         height: 24px;
-        @media (max-width: $width-breakpoint-tablet) {
-            background-image: url('/images/mismatch-finder-logo_mobile.svg');
-            width: 268px;
+        @media (min-width: $width-breakpoint-tablet) {
+            background-image: url('/images/mismatch-finder-logo.svg');
+            width: 384px;
             height: 24px;
         }
     }


### PR DESCRIPTION
We were using the tablet breakpoint as max-width for the logo, but as min-width for the header flex-direction, resulting in a one-pixel discrepancy. Let’s use min-width consistently.

Bug: T324357