### PR TITLE
Fix Sail dependency version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "facade/ignition": "^2.17.7",
         "fakerphp/faker": "^1.20.0",
         "laravel/dusk": "^6.25.1",
-        "laravel/sail": "^1.51.1",
+        "laravel/sail": "^1.15.1",
         "mockery/mockery": "^1.5.0",
         "nunomaduro/collision": "^5.11",
         "phpunit/phpunit": "^9.6.8",


### PR DESCRIPTION
The dependency on v1.51.1 was added in commit 6c7b77f41e (#380), but that version doesn’t actually exist (the latest release is v1.22.0); since the latest version at the time was v1.15.1, I assume the two digits were just swapped accidentally (and apparently composer didn’t complain).