### PR TITLE
Update sail version in `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "facade/ignition": "^2.17.7",
         "fakerphp/faker": "^1.20.0",
         "laravel/dusk": "^6.25.1",
-        "laravel/sail": "^1.15.1",
+        "laravel/sail": "^1.19.0",
         "mockery/mockery": "^1.5.0",
         "nunomaduro/collision": "^5.11",
         "phpunit/phpunit": "^9.6.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "96456d7e2eec7d0f6ced34280780bfed",
+    "content-hash": "afb5b931d1cad1dca4b8f77aa2d4aee1",
     "packages": [
         {
             "name": "asm89/stack-cors",


### PR DESCRIPTION
Apparently this is the version we already use in `composer.lock` anyways. (Anything higher than 1.19 runs into PHP version issues.)

I think this is the last composer change for now – everything else in `composer outdated` is not a direct dependency and can’t be updated because of other packages’ requirements.

Bug: T338222