### PR TITLE
Use the latest version of chrome-driver instead of detecting OS' version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,7 +81,7 @@ jobs:
         run: |
           php artisan key:generate
       - name: Upgrade Chrome Driver
-        run: php artisan dusk:chrome-driver --detect
+        run: php artisan dusk:chrome-driver
 
       - name: Start Chrome Driver
         run: ./vendor/laravel/dusk/bin/chromedriver-linux > /dev/null 2>&1 &


### PR DESCRIPTION
According to latest changes on coverage of chromium.org (hence dusk:chrome-driver uses it for downloads and queries), they no longer support chrome versions newer than v114 (https://chromedriver.chromium.org/downloads), to avoid any inconvenience until dusk:chrome-driver is updated, we should use the latest version.