### PR TITLE
Fix wrapping and alignment of header components

### DIFF
--- a/resources/js/Components/AuthWidget.vue
+++ b/resources/js/Components/AuthWidget.vue
@@ -26,16 +26,10 @@ export default Vue.extend({
 
 <style lang="scss">
 @import '~@wmde/wikit-tokens/dist/_variables.scss';
-$tinyViewportWidth: 38em;
 
 .auth-widget {
     display: flex;
     color: $color-base-50;
-
-    @media (max-width: $tinyViewportWidth) {
-        justify-content: space-between;
-        width: 100%
-    }
 
     .username {
         margin-inline-end: $dimension-spacing-xlarge;
@@ -44,6 +38,10 @@ $tinyViewportWidth: 38em;
     .icon-user {
         margin-inline-end: $dimension-spacing-small;
         vertical-align: middle;
+    }
+
+    .wikit-Link {
+        white-space: nowrap;
     }
 }
 

--- a/resources/js/Pages/Layout.vue
+++ b/resources/js/Pages/Layout.vue
@@ -2,7 +2,7 @@
     <div class="website">
         <main class="content-wrap">
             <header>
-                <InertiaLink href="/">
+                <InertiaLink class="logo-link" href="/">
                     <div class="mismatch-finder-logo" />
                     <h1 class="visually-hidden">{{ $i18n('mismatch-finder-title') }}</h1>
                 </InertiaLink>
@@ -22,9 +22,7 @@
                             </template>
                         </LanguageSelector>
                     </div>
-                    <div class="auth-widget">
-                        <auth-widget :user="user" />
-                    </div>
+                    <auth-widget :user="user" />
                 </div>
             </header>
             <slot />
@@ -166,7 +164,7 @@ $tinyViewportWidth: 38em;
     }
 
     .mismatch-finder-logo {
-        margin-block-end: $dimension-layout-small;
+        // margin-block-end: $dimension-layout-small;
         background-image: url('/images/mismatch-finder-logo_mobile.svg');
         width: 268px;
         height: 24px;
@@ -190,22 +188,25 @@ $tinyViewportWidth: 38em;
 
     main>header {
         flex-direction: column;
+        gap: 1.5rem;
+
+        .logo-link {
+            @media (min-width: $width-breakpoint-tablet) {
+                width: auto;
+            }
+        }
 
         .userSection {
             display: flex;
-            justify-content: space-between;
+            flex-wrap: wrap;
             gap: 1.5rem;
-
-            @media (max-width: $tinyViewportWidth) {
-                flex-direction: column;
-                justify-content: space-between;
-            }
         }
     }
 
     @media (min-width: $width-breakpoint-tablet) {
         main>header {
             flex-direction: row;
+            flex-wrap: wrap;
 
             .languageSelector {
                 >button {
@@ -216,10 +217,6 @@ $tinyViewportWidth: 38em;
                     position: relative;
                 }
             }
-        }
-
-        .mismatch-finder-logo {
-            margin-block-end: 0;
         }
     }
 }

--- a/resources/js/Pages/Layout.vue
+++ b/resources/js/Pages/Layout.vue
@@ -156,8 +156,6 @@ export default defineComponent({
 <style lang="scss">
 @import '~@wmde/wikit-tokens/dist/_variables.scss';
 
-$tinyViewportWidth: 38em;
-
 .website {
     .content-wrap {
         max-width: 1168px;
@@ -201,6 +199,10 @@ $tinyViewportWidth: 38em;
             flex-wrap: wrap;
             gap: 1.5rem;
         }
+
+        .languageSelector {
+            position: relative;
+        }
     }
 
     @media (min-width: $width-breakpoint-tablet) {
@@ -208,13 +210,10 @@ $tinyViewportWidth: 38em;
             flex-direction: row;
             flex-wrap: wrap;
 
+
             .languageSelector {
                 >button {
                     margin-bottom: 2px;
-                }
-
-                @media (min-width: $tinyViewportWidth) {
-                    position: relative;
                 }
             }
         }

--- a/resources/js/Pages/Layout.vue
+++ b/resources/js/Pages/Layout.vue
@@ -163,7 +163,6 @@ export default defineComponent({
     }
 
     .mismatch-finder-logo {
-        // margin-block-end: $dimension-layout-small;
         background-image: url('/images/mismatch-finder-logo_mobile.svg');
         width: 268px;
         height: 24px;

--- a/resources/js/Pages/Layout.vue
+++ b/resources/js/Pages/Layout.vue
@@ -140,6 +140,7 @@ export default defineComponent({
         onToggleLanguageSelector(): void {
             this.showLanguageSelector = !this.showLanguageSelector;
             if (this.showLanguageSelector === true) {
+                /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
                 const languageSelectorRefs = this.$refs.languageSelector as any;
                 this.$nextTick(() => {
                     languageSelectorRefs.focus();
@@ -209,7 +210,6 @@ export default defineComponent({
         main>header {
             flex-direction: row;
             flex-wrap: wrap;
-
 
             .languageSelector {
                 >button {


### PR DESCRIPTION
This change applies some changes to how the language selector and authorization widget wrap in smaller screens. During work on this another Bug was discovered where the language selector is not fully visible when wrapping to the next line, however I was not able to apply a small fix to correct that, thus I opened a bug ticket at T343563.

Bug: T328149