### PR TITLE
Schedule Release PR

### DIFF
--- a/.github/workflows/schedule-release.yml
+++ b/.github/workflows/schedule-release.yml
@@ -4,6 +4,7 @@ name: Release request from development to main
 on:
   schedule:
     - cron: '0 0 1,15 * *'
+  workflow_dispatch:
 
 jobs:
   release:

--- a/.github/workflows/schedule-release.yml
+++ b/.github/workflows/schedule-release.yml
@@ -4,7 +4,6 @@ name: Release request from development to main
 on:
   schedule:
     - cron: '0 0 1,15 * *'
-  pull_request:
 
 jobs:
   release:
@@ -19,7 +18,7 @@ jobs:
           body: |
             **_This PR was created automatically by a scheduled workflow._**
             Review and release the latest changes from staging to production.
-          branch: development
+          branch: release/production
           base: main
           draft: false
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/schedule-release.yml
+++ b/.github/workflows/schedule-release.yml
@@ -13,7 +13,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Create PR
-        run: gh pr create -B main -H development --title 'Merge branch_to_merge into base_branch' --body 'Created by Github action'
+        run: |
+          gh pr create -B main -H development \
+          --title "Release Mismatch Finder to Production" \
+          --body "Review and release the latest changes from staging to production."
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/schedule-release.yml
+++ b/.github/workflows/schedule-release.yml
@@ -1,0 +1,25 @@
+## Creates a PR from development to main every 2 weeks
+name: Release request from development to main
+
+on:
+  schedule:
+    - cron: '0 0 1,15 * *'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Create PR
+        uses: peter-evans/create-pull-request@v5
+        with:
+          title: Release request from development to main
+          body: |
+            **_This PR was created automatically by a scheduled workflow._**
+            Review and release the latest changes from staging to production.
+          branch: development
+          base: main
+          draft: false
+          token: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/schedule-release.yml
+++ b/.github/workflows/schedule-release.yml
@@ -12,11 +12,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: development
+      - name: Branch out Release
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "<>"
+          git branch release/$(date +'%Y-%m-%d')
+          git push -u origin release/$(date +'%Y-%m-%d')
       - name: Create PR
         run: |
-          gh pr create -B main -H development \
+          gh pr create -B main -H release/$(date +'%Y-%m-%d') \
           --title "Release Mismatch Finder to Production" \
-          --body "Review and release the latest changes from staging to production."
+          --body "Review and release the latest changes."
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/schedule-release.yml
+++ b/.github/workflows/schedule-release.yml
@@ -13,14 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Create PR
-        uses: peter-evans/create-pull-request@v5
-        with:
-          title: Release request from development to main
-          body: |
-            **_This PR was created automatically by a scheduled workflow._**
-            Review and release the latest changes from staging to production.
-          branch: release/production
-          base: main
-          draft: false
-          token: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr create -B main -H development --title 'Merge branch_to_merge into base_branch' --body 'Created by Github action'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/schedule-release.yml
+++ b/.github/workflows/schedule-release.yml
@@ -4,6 +4,7 @@ name: Release request from development to main
 on:
   schedule:
     - cron: '0 0 1,15 * *'
+  pull_request:
 
 jobs:
   release:


### PR DESCRIPTION
This change adds a workflow to create a PR to make a production release of Mismatch Finder every two weeks approximately (on the 1st and 15th of every month) or on manual dispatch when required.

This PR can then be reviewed by the engineers, UX and Product, and either accepted and merged or rejected and closed.

Please see #712 for an example of such PR.