### PR TITLE
update chore docs after Vue3 upgrade

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -397,16 +397,8 @@ If, after following the steps in the [Working with OAuth section](#working-with-
 ### Npm dependencies
 
 You can see which dependencies have new releases by first making sure your local dependencies are up-to-date by executing `npm ci` and then running `npm outdated`.
-The query builder uses the latest full release of Wikit which works on Vue 2.6. For this reason we do not update any of the following packages till further notice:
-- vue
-- vuex
-- vue-banana-i18n
-- vite
-- @vue/test-utils
-- @vitejs/plugin-vue
-- vue-template-compiler
 
-All other dependencies should generally be updated to the latest version. If you discover that a dependency should not be updated for some reason, please add it to the above list. If a dependency can only be updated with substantial manual work, you can create a new task for it and skip it in the context of the current chore.
+Dependencies should generally be updated to the latest version. If you discover that a dependency should not be updated for some reason, please change this section of the documentation to reflect that (even if it's temporary). If a dependency can only be updated with substantial manual work, you can create a new task for it and skip it in the context of the current chore.
 
 The recommended way to update dependencies is to collect related dependency updates into grouped commits; this keeps the number of commits to review manageable (compared to having one commit for every update), while keeping the scope of each commit limited and increasing reviewability and debuggability (compared to combining all updates in a single commit). For example, this can be one commit for each of:
 - all ESLint-related dependency updates


### PR DESCRIPTION
Now that upgraded the mismatch finder to use Vue 3 and are gradually deprecating Wikit, Vue packages should be upgraded normally. 

Bug:  T350667