### PR TITLE
Improve links

### DIFF
--- a/resources/js/Components/AuthWidget.vue
+++ b/resources/js/Components/AuthWidget.vue
@@ -6,7 +6,7 @@
             </a>
             <a  href="/auth/logout">{{ $i18n('log-out') }}</a>
         </div>
-        <a class="auth-widget" v-else href="/auth/login">{{ $i18n('log-in') }}</a>
+        <a v-else href="/auth/login">{{ $i18n('log-in') }}</a>
     </div>
 
 </template>

--- a/resources/js/Components/AuthWidget.vue
+++ b/resources/js/Components/AuthWidget.vue
@@ -1,10 +1,10 @@
 <template>
     <div class="auth-widget_wrapper"> 
         <div class="auth-widget" v-if="user">
-        <a :href="`https://www.wikidata.org/wiki/User:${user.name}`">
-            <img src="images/user.svg" class="icon-user" /><span class="username">{{ user.name }}</span>
-        </a>
-        <a  href="/auth/logout">{{ $i18n('log-out') }}</a>
+            <a :href="`https://www.wikidata.org/wiki/User:${user.name}`">
+                <img src="images/user.svg" class="icon-user" /><span class="username">{{ user.name }}</span>
+            </a>
+            <a  href="/auth/logout">{{ $i18n('log-out') }}</a>
         </div>
         <a class="auth-widget" v-else href="/auth/login">{{ $i18n('log-in') }}</a>
     </div>

--- a/resources/js/Components/AuthWidget.vue
+++ b/resources/js/Components/AuthWidget.vue
@@ -1,11 +1,13 @@
 <template>
-    <div class="auth-widget" v-if="user">
+    <div class="auth-widget"> 
+        <div class="auth-widget" v-if="user">
         <a :href="`https://www.wikidata.org/wiki/User:${user.name}`">
             <img src="images/user.svg" class="icon-user" /><span class="username">{{ user.name }}</span>
         </a>
         <a  href="/auth/logout">{{ $i18n('log-out') }}</a>
+        </div>
+        <a class="auth-widget" v-else href="/auth/login">{{ $i18n('log-in') }}</a>
     </div>
-    <a class="auth-widget" v-else href="/auth/login">{{ $i18n('log-in') }}</a>
 
 </template>
 
@@ -24,6 +26,7 @@ export default defineComponent({
 
 <style lang="scss">
 @import '~@wmde/wikit-tokens/dist/_variables.scss';
+@import '~@wikimedia/codex-design-tokens/theme-wikimedia-ui.scss';
 
 .auth-widget {
     display: flex;
@@ -39,6 +42,9 @@ export default defineComponent({
 
     a {
         white-space: nowrap;
+        &:visited {
+            color: $color-progressive;
+        }
     }
 }
 

--- a/resources/js/Components/AuthWidget.vue
+++ b/resources/js/Components/AuthWidget.vue
@@ -40,10 +40,12 @@ export default defineComponent({
         vertical-align: middle;
     }
 
-    a {
-        white-space: nowrap;
-        &:visited {
-            color: $color-progressive;
+&_wrapper {
+        a {
+            white-space: nowrap;
+            &:visited {
+                color: $color-progressive;
+            }
         }
     }
 }

--- a/resources/js/Components/AuthWidget.vue
+++ b/resources/js/Components/AuthWidget.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="auth-widget"> 
+    <div class="auth-widget_wrapper"> 
         <div class="auth-widget" v-if="user">
         <a :href="`https://www.wikidata.org/wiki/User:${user.name}`">
             <img src="images/user.svg" class="icon-user" /><span class="username">{{ user.name }}</span>

--- a/resources/js/Pages/Layout.vue
+++ b/resources/js/Pages/Layout.vue
@@ -225,6 +225,7 @@ export default defineComponent({
         gap: 1.5rem;
 
         .logo-link {
+            outline: none;
             @media (min-width: $width-breakpoint-tablet) {
                 width: auto;
             }


### PR DESCRIPTION
Issues this PR addresses:
1. `:visited` and `:hover` styles removed from auth widget links
2. visible outline removed from logo

The issue of auth widget link base color is already part of PR #792 and is therefore not part of this PR.

Bug: T347161