### PR TITLE
Refactor Error.vue Page in Vue3 syntax

### DIFF
--- a/resources/js/Pages/Error.vue
+++ b/resources/js/Pages/Error.vue
@@ -5,13 +5,6 @@
   </div>
 </template>
 
-<script>
-import { defineComponent } from 'vue';
-
-export default defineComponent({
-  props: {
-    title: String,
-    description: String
-  }
-});
+<script setup lang="ts">
+defineProps<{title: string, description: string}>();
 </script>


### PR DESCRIPTION
To manually test this, add this line `throw new Error('error!');` right before line 23, `createInertiaApp({`

As discussed with @itamargiv the option of creating an automated test atm is too much overhead for the current task and will be addressed in the future as tech debt.

Bug: [T353719](https://phabricator.wikimedia.org/T353719)