### PR TITLE
Rewrite MismatchRow in Vue3 script setup syntax

### DIFF
--- a/resources/js/Components/MismatchRow.vue
+++ b/resources/js/Components/MismatchRow.vue
@@ -108,8 +108,6 @@
 
 <script setup lang="ts">
 import { formatISO } from 'date-fns';
-
-import type { PropType } from 'vue';
 import { computed, ref } from 'vue';
 import { CdxButton, CdxDialog, CdxSelect } from "@wikimedia/codex";
 import { MenuItem } from '@wmde/wikit-vue-components/dist/components/MenuItem';
@@ -167,7 +165,6 @@ const uploadInfoDescription = computed<string>(() => {
   return shouldTruncate.value ? text.substring(0, truncateLength) + '...' : text;
 });
 
-const decision = statusOptions[props.mismatch.review_status];
 const reviewStatus = String(props.mismatch.review_status);
 const fullDescriptionDialog = ref(false);
 

--- a/resources/js/Components/MismatchRow.vue
+++ b/resources/js/Components/MismatchRow.vue
@@ -12,12 +12,12 @@
               {{mismatch.type}}
             </span>
             <span v-else>
-              {{ this.$i18n('statement') }}
+              {{ $i18n('statement') }}
             </span>
         </td>
         <td :data-header="$i18n('column-wikidata-value')">
             <span class="empty-value" v-if="mismatch.wikidata_value === ''">
-              {{ this.$i18n('empty-value') }}
+              {{ $i18n('empty-value') }}
             </span> 
             <a
               v-else class="break-line-link" :href="statementUrl" target="_blank">
@@ -99,7 +99,7 @@
             </a>
             <span class="upload-date">{{uploadDate}}</span>
             <div class="description">
-              {{this.mismatch.import_meta.description}}
+              {{mismatch.import_meta.description}}
             </div>
           </cdx-dialog>
         </td>

--- a/resources/js/Components/MismatchRow.vue
+++ b/resources/js/Components/MismatchRow.vue
@@ -165,7 +165,7 @@ const uploadInfoDescription = computed<string>(() => {
   return shouldTruncate.value ? text.substring(0, truncateLength) + '...' : text;
 });
 
-const reviewStatus = String(props.mismatch.review_status);
+const reviewStatus = ref(String(props.mismatch.review_status));
 const fullDescriptionDialog = ref(false);
 
 function showDialog(e: Event) {

--- a/resources/js/Components/MismatchesTable.vue
+++ b/resources/js/Components/MismatchesTable.vue
@@ -22,27 +22,18 @@
     </wikit-table>
 </template>
 
-<script lang="ts">
-import type { PropType } from 'vue';
-import { defineComponent } from 'vue';
+<script setup lang="ts">
 import { Table as WikitTable } from '@wmde/wikit-vue-components';
 
 import MismatchRow from './MismatchRow.vue';
 
-import { LabelledMismatch } from '../types/Mismatch';
+import type { LabelledMismatch } from '../types/Mismatch';
 
-export default defineComponent({
-    components: {
-        MismatchRow,
-        WikitTable,
-    },
-    props: {
-        mismatches: Array as PropType<LabelledMismatch[]>,
-        disabled: {
-            type: Boolean,
-            default: false
-        }
-    }
+withDefaults(defineProps<{
+	mismatches: LabelledMismatch[],
+    disabled: boolean
+}>(), {
+	disabled: false
 });
 </script>
 

--- a/tests/Vue/Components/MismatchRow.spec.js
+++ b/tests/Vue/Components/MismatchRow.spec.js
@@ -5,6 +5,13 @@ import {CdxSelect} from "@wikimedia/codex";
 import {ReviewDecision} from '@/types/Mismatch.ts';
 
 import MismatchRow from '@/Components/MismatchRow.vue';
+import { createI18n } from 'vue-banana-i18n';
+
+const i18n = createI18n({
+    messages: {},
+    locale: 'en',
+    wikilinks: true
+});
 
 describe('MismatchesRow.vue', () => {
     it('accepts a disabled property', () => {
@@ -25,10 +32,7 @@ describe('MismatchesRow.vue', () => {
         const wrapper = mount(MismatchRow, {
             props: {mismatch, disabled},
             global: {
-                mocks: {
-                    // Mock the banana-i18n plugin dependency
-                    $i18n: key => key
-                }
+                plugins: [i18n],
             }
         });
 
@@ -57,10 +61,7 @@ describe('MismatchesRow.vue', () => {
         const wrapper = mount(MismatchRow, {
             props: {mismatch},
             global: {
-                mocks: {
-                    // Mock the banana-i18n plugin dependency
-                    $i18n: key => key
-                }
+                plugins: [i18n],
             }
         });
         const rowText = wrapper.find('tr').text();
@@ -97,10 +98,7 @@ describe('MismatchesRow.vue', () => {
         const wrapper = mount(MismatchRow, {
             props: {mismatch},
             global: {
-                mocks: {
-                    // Mock the banana-i18n plugin dependency
-                    $i18n: key => key
-                }
+                plugins: [i18n],
             }
         });
 
@@ -129,10 +127,7 @@ describe('MismatchesRow.vue', () => {
         const wrapper = mount(MismatchRow, {
             props: {mismatch},
             global: {
-                mocks: {
-                    // Mock the banana-i18n plugin dependency
-                    $i18n: key => key
-                }
+                plugins: [i18n],
             }
         });
 
@@ -161,10 +156,7 @@ describe('MismatchesRow.vue', () => {
         const wrapper = mount(MismatchRow, {
             props: {mismatch},
             global: {
-                mocks: {
-                    // Mock the banana-i18n plugin dependency
-                    $i18n: key => key
-                }
+                plugins: [i18n],
             }
         });
 
@@ -198,10 +190,7 @@ describe('MismatchesRow.vue', () => {
         const wrapper = mount(MismatchRow, {
             props: {mismatch},
             global: {
-                mocks: {
-                    // Mock the banana-i18n plugin dependency
-                    $i18n: key => key
-                }
+                plugins: [i18n],
             }
         });
 
@@ -241,10 +230,7 @@ describe('MismatchesRow.vue', () => {
         const wrapper = mount(MismatchRow, {
             props: {mismatch},
             global: {
-                mocks: {
-                    // Mock the banana-i18n plugin dependency
-                    $i18n: key => key
-                }
+                plugins: [i18n],
             }
         });
 
@@ -279,10 +265,7 @@ describe('MismatchesRow.vue', () => {
         const wrapper = mount(MismatchRow, {
             props: {mismatch},
             global: {
-                mocks: {
-                    // Mock the banana-i18n plugin dependency
-                    $i18n: key => key
-                },
+                plugins: [i18n],
                 stubs: {
                     teleport: true,
                     transition: true
@@ -312,10 +295,7 @@ describe('MismatchesRow.vue', () => {
         const wrapper = mount(MismatchRow, {
             props: {mismatch},
             global: {
-                mocks: {
-                    // Mock the banana-i18n plugin dependency
-                    $i18n: key => key
-                }
+                plugins: [i18n],
             }
         });
 
@@ -339,10 +319,7 @@ describe('MismatchesRow.vue', () => {
         const wrapper = mount(MismatchRow, {
             props: {mismatch},
             global: {
-                mocks: {
-                    // Mock the banana-i18n plugin dependency
-                    $i18n: key => key
-                }
+                plugins: [i18n],
             }
         });
 
@@ -371,10 +348,7 @@ describe('MismatchesRow.vue', () => {
         const wrapper = mount(MismatchRow, {
             props: {mismatch},
             global: {
-                mocks: {
-                    // Mock the banana-i18n plugin dependency
-                    $i18n: key => `${key}`
-                }
+                plugins: [i18n],
             }
         });
 
@@ -404,9 +378,8 @@ describe('MismatchesRow.vue', () => {
         const wrapper = mount(MismatchRow, {
             props: {mismatch},
             global: {
+                plugins: [i18n],
                 mocks: {
-                    // Mock the banana-i18n plugin dependency
-                    $i18n: key => `${key}`,
                     $bubble: bubbleStub
                 }
             }

--- a/tests/Vue/Components/MismatchesTable.spec.js
+++ b/tests/Vue/Components/MismatchesTable.spec.js
@@ -1,6 +1,13 @@
 import { mount } from '@vue/test-utils';
 import MismatchesTable from '@/Components/MismatchesTable.vue';
 import MismatchRow from '@/Components/MismatchRow.vue';
+import { createI18n } from 'vue-banana-i18n';
+
+const i18n = createI18n({
+    messages: {},
+    locale: 'en',
+    wikilinks: true
+});
 
 describe('MismatchesTable.vue', () => {
     it('accepts a mismatches property', () => {
@@ -22,10 +29,7 @@ describe('MismatchesTable.vue', () => {
         const wrapper = mount(MismatchesTable, {
             props: { mismatches },
             global: {
-                mocks: {
-                    // Mock the banana-i18n plugin dependency
-                    $i18n: key => key
-                }
+                plugins: [i18n]
             }
         });
 
@@ -59,10 +63,7 @@ describe('MismatchesTable.vue', () => {
         const wrapper = mount(MismatchesTable, {
             props: { disabled, mismatches },
             global: {
-                mocks: {
-                    // Mock the banana-i18n plugin dependency
-                    $i18n: key => key
-                }
+                plugins: [i18n]
             }
         });
 


### PR DESCRIPTION
The commits from MismatchesTable #828 are included here, otherwise the tests don't pass. 

#828 is to be merged before this one. Otherwise both components will be merged under one commit if this one is merged first.

Bug: T354346