### PR TITLE
Add type null to User type to remove warnings

### DIFF
--- a/resources/js/Components/AuthWidget.vue
+++ b/resources/js/Components/AuthWidget.vue
@@ -15,7 +15,7 @@
 
 import User from '../types/User';
 
-defineProps<{ user: User }>();
+defineProps<{ user: User | null}>();
 
 </script>
 

--- a/resources/js/Pages/Layout.vue
+++ b/resources/js/Pages/Layout.vue
@@ -86,7 +86,7 @@ const header: Ref<HTMLElement> = ref(null);
 const userSection: Ref<HTMLElement> = ref(null);
 const contentWrap: Ref<Element> = ref(null);
 
-defineProps<{user: User}>();
+defineProps<{user: User | null}>();
 
 const currentLanguageAutonym = computed<string>(() => {
     return languagedata.getAutonym(document.documentElement.lang);

--- a/resources/js/Pages/Results.vue
+++ b/resources/js/Pages/Results.vue
@@ -192,7 +192,7 @@ const confirmationDialog = ref(false);
 const overlayRef = ref(null);
 
 const props = withDefaults(defineProps<{
-    user: User
+    user: User | null
     item_ids: Array<string>
     results: Result
     labels: LabelMap


### PR DESCRIPTION
When the user is not logged in the passed prop=null, this case should also be included in the User type.