### PR TITLE
Reassign css to proper div to remove white space below footer

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,7 @@ module.exports = {
 		'vue/no-deprecated-slot-scope-attribute': 'off',
 		'vue/no-v-for-template-key-on-child': 'off',
 		'vue/no-deprecated-destroyed-lifecycle': 'off',
-		'vue/no-v-model-argument': 'off'
+		'vue/no-v-model-argument': 'off',
+		'vue/no-multiple-template-root': 'off' // TODO: remove this rule in T351644
 		},
 };

--- a/resources/js/Pages/Layout.vue
+++ b/resources/js/Pages/Layout.vue
@@ -1,67 +1,65 @@
 <template>
-    <div class="website">
-        <main class="content-wrap" ref="contentWrap">
-            <header ref="header">
-                <InertiaLink class="logo-link" href="/">
-                    <div class="mismatch-finder-logo" />
-                    <h1 class="visually-hidden">{{ $i18n('mismatch-finder-title') }}</h1>
-                </InertiaLink>
-                <div class="userSection" ref="userSection">
-                    <div v-detect-click-outside="onClickOutsideLanguageSelector" class="languageSelector">
-                        <LanguageSelectorButton :aria-label="$i18n('toggle-language-selector-button')"
-                            @click="onToggleLanguageSelector">
-                            <cdx-icon :icon="cdxIconLanguage" />
-                            {{ currentLanguageAutonym }}
-                        </LanguageSelectorButton>
-                        <LanguageSelector v-show="showLanguageSelector" ref="languageSelector"
-                            @close="onCloseLanguageSelector" @select="onChangeLanguage">
-                            <template #no-results>
-                                {{ $i18n('language-selector-no-results') }}
-                            </template>
-                        </LanguageSelector>
-                    </div>
-                    <auth-widget :user="user" />
+    <main class="content-wrap" ref="contentWrap">
+        <header ref="header">
+            <InertiaLink class="logo-link" href="/">
+                <div class="mismatch-finder-logo" />
+                <h1 class="visually-hidden">{{ $i18n('mismatch-finder-title') }}</h1>
+            </InertiaLink>
+            <div class="userSection" ref="userSection">
+                <div v-detect-click-outside="onClickOutsideLanguageSelector" class="languageSelector">
+                    <LanguageSelectorButton :aria-label="$i18n('toggle-language-selector-button')"
+                        @click="onToggleLanguageSelector">
+                        <cdx-icon :icon="cdxIconLanguage" />
+                        {{ currentLanguageAutonym }}
+                    </LanguageSelectorButton>
+                    <LanguageSelector v-show="showLanguageSelector" ref="languageSelector"
+                        @close="onCloseLanguageSelector" @select="onChangeLanguage">
+                        <template #no-results>
+                            {{ $i18n('language-selector-no-results') }}
+                        </template>
+                    </LanguageSelector>
                 </div>
-            </header>
-            <slot />
-        </main>
-        <wikidata-tool-footer
-            content-class="content-wrap"
-            :labels="{
-                tool: $i18n('mismatch-finder-title'),
-                license: $i18n('mismatch-finder-license'),
-            }"
-            :urls="{
-                license: 'https://github.com/wmde/wikidata-mismatch-finder/blob/license/bsd-3-clause/LICENSE',
-                source: 'https://github.com/wmde/wikidata-mismatch-finder',
-                issues: 'https://phabricator.wikimedia.org/project/board/5385/'
-            }"
-        >
-            <section>
-                <h2 class="h5">{{ $i18n('mismatch-finder-footer-more-tools') }}</h2>
-                <p>
-                    <a href="https://query.wikidata.org/querybuilder/">
-                        {{ $i18n('tool-query-builder') }}
-                    </a>
-                </p>
-                <p>
-                    <a href="https://item-quality-evaluator.toolforge.org/">
-                        {{ $i18n('tool-item-quality-evaluator') }}
-                    </a>
-                </p>
-                <p>
-                    <a href="https://wikidata-analytics.wmcloud.org/app/CuriousFacts">
-                        {{ $i18n('tool-curious-facts') }}
-                    </a>
-                </p>
-                <p>
-                    <a href="https://github.com/wmde/wikidata-constraints-violation-checker">
-                        {{ $i18n('tool-constraints-violation-checker') }}
-                    </a>
-                </p>
-            </section>
-        </wikidata-tool-footer>
-    </div>
+                <auth-widget :user="user" />
+            </div>
+        </header>
+        <slot />
+    </main>
+    <wikidata-tool-footer
+        content-class="content-wrap"
+        :labels="{
+            tool: $i18n('mismatch-finder-title'),
+            license: $i18n('mismatch-finder-license'),
+        }"
+        :urls="{
+            license: 'https://github.com/wmde/wikidata-mismatch-finder/blob/license/bsd-3-clause/LICENSE',
+            source: 'https://github.com/wmde/wikidata-mismatch-finder',
+            issues: 'https://phabricator.wikimedia.org/project/board/5385/'
+        }"
+    >
+        <section>
+            <h2 class="h5">{{ $i18n('mismatch-finder-footer-more-tools') }}</h2>
+            <p>
+                <a href="https://query.wikidata.org/querybuilder/">
+                    {{ $i18n('tool-query-builder') }}
+                </a>
+            </p>
+            <p>
+                <a href="https://item-quality-evaluator.toolforge.org/">
+                    {{ $i18n('tool-item-quality-evaluator') }}
+                </a>
+            </p>
+            <p>
+                <a href="https://wikidata-analytics.wmcloud.org/app/CuriousFacts">
+                    {{ $i18n('tool-curious-facts') }}
+                </a>
+            </p>
+            <p>
+                <a href="https://github.com/wmde/wikidata-constraints-violation-checker">
+                    {{ $i18n('tool-constraints-violation-checker') }}
+                </a>
+            </p>
+        </section>
+    </wikidata-tool-footer>
 </template>
 
 <script setup lang="ts">
@@ -170,7 +168,7 @@ onBeforeUnmount(() => {
 <style lang="scss">
 @import '~@wmde/wikit-tokens/dist/_variables.scss';
 
-.website {
+#app {
     box-sizing: border-box;
     min-height: 100%;
     display: flex;


### PR DESCRIPTION
This PR solves the issue of when the TextArea's height is reduced to the minimum, white space appears under the Mismatch app footer.

Note: currently the linting is failing due to the linting rules being set for Vue2. 

Two options here:
1. Wait until T351644 changing the ruleset is updated to Vue3 and this error will be gone. The error states that only one element can be inside a `<template>` tag, but this has changed in Vue3, and multiple elements can now be added inside a template. See: https://v3-migration.vuejs.org/new/fragments.html

2. Otherwise we can disable the rule that creates the error and remove it when we update the linting rules to Vue3.

I am choosing option 2. The rules will be updated later on in the `.eslintrc.js` file.

Bug: T347190