### PR TITLE
Find a way around icon - text misalignment issue in codex buttons

### DIFF
--- a/resources/js/Pages/Home.vue
+++ b/resources/js/Pages/Home.vue
@@ -11,7 +11,7 @@
                     @click="faqDialog = true"
                 >
                     <cdx-icon :icon="cdxIconInfo" />
-                    {{ $i18n('faq-button') }}
+                    <span class="text-with-icon-button">{{ $i18n('faq-button') }}</span>
                 </cdx-button>
             </header>
             <cdx-dialog id="faq-dialog"
@@ -74,7 +74,7 @@
                     :disabled="loading"
                 >
                     <cdx-icon :icon="cdxIconDie" />
-                    {{ $i18n('random-mismatches') }}
+                    <span class="text-with-icon-button">{{ $i18n('random-mismatches') }}</span>
                 </cdx-button>
             </div>
             <form id="items-form" @submit.prevent="send">

--- a/resources/js/Pages/Layout.vue
+++ b/resources/js/Pages/Layout.vue
@@ -10,7 +10,7 @@
                     <LanguageSelectorButton :aria-label="$i18n('toggle-language-selector-button')"
                         @click="onToggleLanguageSelector">
                         <cdx-icon :icon="cdxIconLanguage" />
-                        {{ currentLanguageAutonym }}
+                        <span class="text-with-icon-button">{{ currentLanguageAutonym }}</span>
                     </LanguageSelectorButton>
                     <LanguageSelector v-show="showLanguageSelector" ref="languageSelector"
                         @close="onCloseLanguageSelector" @select="onChangeLanguage">

--- a/resources/js/Pages/Results.vue
+++ b/resources/js/Pages/Results.vue
@@ -4,7 +4,7 @@
         <inertia-head title="Mismatch Finder - Results" />
         <cdx-button class="back-button" @click="() => $inertia.get('/', {})">
             <cdx-icon :icon="cdxIconArrowPrevious" />
-            {{ $i18n('results-back-button') }}
+            <span class="text-with-icon-button">{{ $i18n('results-back-button') }}</span>
         </cdx-button>
         <section id="description-section">
             <header class="description-header">
@@ -16,7 +16,7 @@
                     @click="instructionsDialog = true"
                 >
                     <cdx-icon :icon="cdxIconInfo" />
-                    {{$i18n('results-instructions-button')}}
+                    <span class="text-with-icon-button">{{$i18n('results-instructions-button')}}</span>
                 </cdx-button>
             </header>
 

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -348,6 +348,13 @@ dl.import-meta .download-csv {
 // is marked as resolved.
 .cdx-button {
     @include ui-text-M($font-weight-bold);
+
+    padding-top: 4px;
+
+    .text-with-icon-button {
+        vertical-align: text-top;
+        padding-left: 5px;
+    }
 }
 
 .svg {

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -352,7 +352,10 @@ dl.import-meta .download-csv {
     .text-with-icon-button {
         vertical-align: text-top;
         padding-left: 5px;
+    .cdx-icon {
+        vertical-align: text-top;
     }
+  }
 }
 
 .svg {

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -349,8 +349,6 @@ dl.import-meta .download-csv {
 .cdx-button {
     @include ui-text-M($font-weight-bold);
 
-    padding-top: 4px;
-
     .text-with-icon-button {
         vertical-align: text-top;
         padding-left: 5px;


### PR DESCRIPTION
There is[ a known issue](https://phabricator.wikimedia.org/T326900) with codex buttons that contain an icon and text. In the past we managed to fix that with the `vertical-align: text-top` workaround suggested in the comments, but that has stopped working once we replaced the body tokens. 
What seems to make the difference in the alignment is the font-family, but codex inherits that from the system, so we're not sure what actually causes the misalignment. 
This is worse on Firefox than on Chrome. 

This PR extracts the text out of all icon buttons into a nesting `<span>` element and styles that. 

Bug: T352304