### PR TITLE
Fix :visited:hover color for auth widget links

### DIFF
--- a/resources/js/Components/AuthWidget.vue
+++ b/resources/js/Components/AuthWidget.vue
@@ -39,6 +39,9 @@ defineProps<{ user: User | null}>();
             white-space: nowrap;
             &:visited {
                 color: $color-progressive;
+                &:hover {
+                    color: $color-progressive--hover;
+                }
             }
         }
     }


### PR DESCRIPTION
The Codex link mixin default of the :visited:hover style is `$color-progressive`, which is redundant for the auth widget links, since we removed :visited styles for those. 
This PR fixes the hover color specifically for the username and log in/log out buttons. 

Bug: T347161