### PR TITLE
Fix focus border outline for the store download button

### DIFF
--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -254,6 +254,7 @@ dl.import-meta .download-csv {
         background-color: $background-color-interactive-subtle;
         border-color: $border-color-progressive--focus;
         box-shadow: $box-shadow-inset-small $box-shadow-color-progressive--focus;
+        outline: $outline-base--focus;
     }
 
     &:hover {


### PR DESCRIPTION
Don't outline button on focus

Bug: T352304