### PR TITLE
Add max-width for store unintentionally removed

### DIFF
--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -23,6 +23,7 @@ body {
 main {
     padding: 0 var(--dimension-layout-xsmall);
     margin: 0 auto;
+    max-width: 1090px; // width for the store page
 
     & > header {
         display: flex;


### PR DESCRIPTION
This style was removed as part of the grid changes (#849), but it is required for the store page. Added a hint to avoid further misunderstanding