### PR TITLE
Add overwritten button text span items

### DIFF
--- a/resources/js/Pages/Home.vue
+++ b/resources/js/Pages/Home.vue
@@ -13,7 +13,7 @@
           @click="faqDialog = true"
         >
           <cdx-icon :icon="cdxIconInfo" />
-          {{ $i18n('faq-button') }}
+          <span class="text-with-icon-button">{{ $i18n('faq-button') }}</span>
         </cdx-button>
       </header>
       <cdx-dialog
@@ -94,7 +94,7 @@
           :disabled="loading"
         >
           <cdx-icon :icon="cdxIconDie" />
-          {{ $i18n('random-mismatches') }}
+          <span class="text-with-icon-button">{{ $i18n('random-mismatches') }}</span>
         </cdx-button>
       </div>
       <form

--- a/resources/js/Pages/Layout.vue
+++ b/resources/js/Pages/Layout.vue
@@ -26,7 +26,7 @@
             @click="onToggleLanguageSelector"
           >
             <cdx-icon :icon="cdxIconLanguage" />
-            {{ currentLanguageAutonym }}
+            <span class="text-with-icon-button">{{ currentLanguageAutonym }}</span>
           </LanguageSelectorButton>
           <LanguageSelector
             v-show="showLanguageSelector"

--- a/resources/js/Pages/Results.vue
+++ b/resources/js/Pages/Results.vue
@@ -7,7 +7,7 @@
       @click="() => $inertia.get('/', {})"
     >
       <cdx-icon :icon="cdxIconArrowPrevious" />
-      {{ $i18n('results-back-button') }}
+      <span class="text-with-icon-button">{{ $i18n('results-back-button') }}</span>
     </cdx-button>
     <section id="description-section">
       <header class="description-header">
@@ -21,7 +21,7 @@
           @click="instructionsDialog = true"
         >
           <cdx-icon :icon="cdxIconInfo" />
-          {{ $i18n('results-instructions-button') }}
+          <span class="text-with-icon-button">{{ $i18n('results-instructions-button') }}</span>
         </cdx-button>
       </header>
 

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -373,11 +373,11 @@ dl.import-meta .download-csv {
     .text-with-icon-button {
         vertical-align: text-top;
         padding-left: 5px;
+    }
 
     .cdx-icon {
         vertical-align: text-top;
     }
-  }
 }
 
 .svg {


### PR DESCRIPTION
This is a redo of PR #837 that got partially removed by PR #841 unintentionally.  
It extracts the text out of all icon buttons into a nesting <span> element. It also adds a missing brace in the styles.

Bug: [T352304](https://phabricator.wikimedia.org/T352304)