### PR TITLE
Override list item styling for select menu items

### DIFF
--- a/resources/js/Components/MismatchRow.vue
+++ b/resources/js/Components/MismatchRow.vue
@@ -201,6 +201,7 @@ function showDialog(e: Event) {
 
   .cdx-menu-item {
     margin-inline-start: 0; // overwrite <li> styles from app.scss
+    margin-block-start: 0; // overwrite <li>+<li> styles from app.scss
   }
 
  .full-description-button {

--- a/resources/js/Components/MismatchRow.vue
+++ b/resources/js/Components/MismatchRow.vue
@@ -199,6 +199,10 @@ function showDialog(e: Event) {
     }
   }
 
+  .cdx-menu-item {
+    margin-inline-start: 0; // overwrite <li> styles from app.scss
+  }
+
  .full-description-button {
       padding: 0 2px;
       font-weight: 400;


### PR DESCRIPTION
The menu items on the results view ended up showing a margin inherited from `app.scss` 's style definition for `<li>` elements (meant for lists like the FAQ and instructions).
This PR overrides the inherited style definitions.

Bug: T348271 

