### PR TITLE
T356618: remove broken tool reference from layout

### DIFF
--- a/resources/js/Pages/Layout.vue
+++ b/resources/js/Pages/Layout.vue
@@ -71,11 +71,6 @@
         </a>
       </p>
       <p>
-        <a href="https://wikidata-analytics.wmcloud.org/app/CuriousFacts">
-          {{ $i18n('tool-curious-facts') }}
-        </a>
-      </p>
-      <p>
         <a href="https://github.com/wmde/wikidata-constraints-violation-checker">
           {{ $i18n('tool-constraints-violation-checker') }}
         </a>


### PR DESCRIPTION
Hi there :wave:

As a part of exploring WMDE tools that are currently broken in [T356618](https://phabricator.wikimedia.org/T356618), I found that there's a reference to one of them in the Mismatch Finder Layout. The broken link is the following:

https://wikidata-analytics.wmcloud.org/app/CuriousFacts

This commit removes the reference. Please let me know if there's anything else I should do!