### PR TITLE
Don't show outline on logo

### DIFF
--- a/resources/js/Pages/Layout.vue
+++ b/resources/js/Pages/Layout.vue
@@ -231,6 +231,7 @@ onBeforeUnmount(() => {
         gap: 1.5rem;
 
         .logo-link {
+            outline: none;
             @media (min-width: $min-width-breakpoint-tablet) {
                 width: auto;
             }

--- a/resources/js/Pages/Layout.vue
+++ b/resources/js/Pages/Layout.vue
@@ -232,6 +232,7 @@ onBeforeUnmount(() => {
 
         .logo-link {
             outline: none;
+
             @media (min-width: $min-width-breakpoint-tablet) {
                 width: auto;
             }


### PR DESCRIPTION
This reinstates the outline style overwritten during the token chain merge

Bug: T347161