### PR TITLE
Remove curious facts link from footer

### DIFF
--- a/resources/js/Pages/Layout.vue
+++ b/resources/js/Pages/Layout.vue
@@ -71,11 +71,6 @@
         </a>
       </p>
       <p>
-        <a href="https://wikidata-analytics.wmcloud.org/app/CuriousFacts">
-          {{ $i18n('tool-curious-facts') }}
-        </a>
-      </p>
-      <p>
         <a href="https://github.com/wmde/wikidata-constraints-violation-checker">
           {{ $i18n('tool-constraints-violation-checker') }}
         </a>


### PR DESCRIPTION
Quoting @andrewtavis-wmde from PR #876:
"Hi there 👋
As a part of exploring WMDE tools that are currently broken in [T356618](https://phabricator.wikimedia.org/T356618), I found that there's a reference to one of them in the Mismatch Finder Layout. The broken link is the following:

https://wikidata-analytics.wmcloud.org/app/CuriousFacts

This commit removes the reference. Please let me know if there's anything else I should do!"

The PR does not manage to run CI (presumably due to some git permission issue?) so I am uploading it myself instead. 

Bug: T356618