### PR TITLE
Add deploy to production option in github workflow

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -4,6 +4,7 @@ on:
   push:
    branches:
     - main
+    - deploy-prod/**
 
 concurrency:
   group: '${{ github.workflow }}'


### PR DESCRIPTION
Add an option to allow for manual deploys to production to not need to unprotect the main branch in case we need to make a manual deploy at some point.

Bug: T361552